### PR TITLE
Add Javascript callback support

### DIFF
--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace CefSharp.Example
 {
@@ -162,5 +163,35 @@ namespace CefSharp.Example
         {
             return arg0;
         }
+
+        #region JS Callback test methods
+        public void DoNoArgumentCallback_Sync(CefCallbackWrapper callback)
+        {
+            callback.Call();
+        }
+        public void DoStringArgumentCallback_Sync(string message, CefCallbackWrapper callback)
+        {
+            callback.Call(message);
+        }
+        public void DoNoArgumentCallback_Async(CefCallbackWrapper callback)
+        {
+            ThreadPool.QueueUserWorkItem(doNoArgumentCallbackWorkItem, callback);
+        }
+        public void DoStringArgumentCallback_Async(string message, CefCallbackWrapper callback)
+        {
+            ThreadPool.QueueUserWorkItem(doCallbackWorkItem, new object[]{ callback, message});
+        }
+        #region threadpool workers
+        void doNoArgumentCallbackWorkItem(object state)
+        {
+            (state as CefCallbackWrapper).Call();
+        }
+        void doCallbackWorkItem(object state)
+        {
+            object[] o = (object[])state;
+            (o[0] as CefCallbackWrapper).Call(o[1]);
+        }
+        #endregion
+        #endregion
     }
 }

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -5,6 +5,31 @@
 	</head>
 	<body>
 	    <p>
+        Javascript Callback Methods:<br />
+        <ul>
+            <li>Synchronous, no arguments    :<span id="callbackBindingTargetSyncNoArgs">FAIL</span></li>
+            <li>Synchronous, String argument :<span id="callbackBindingTargetSyncStringArg">FAIL</span></li>
+            <li>Asynchronous, no arguments   :<span id="callbackBindingTargetAsyncNoArgs">FAIL</span></li>
+            <li>Asynchronous, String argument:<span id="callbackBindingTargetAsyncStringArg">FAIL</span></li>
+            <script type="text/javascript">
+                bound.DoNoArgumentCallback_Sync(function() {
+                    document.getElementById('callbackBindingTargetSyncNoArgs').innerText = " SUCCESS";
+                });
+                bound.DoStringArgumentCallback_Sync(" SUCCESS", function(s) {
+                    document.getElementById('callbackBindingTargetSyncStringArg').innerText = s;
+                });
+                bound.DoNoArgumentCallback_Async(function() {
+                    document.getElementById('callbackBindingTargetAsyncNoArgs').innerText = " SUCCESS";
+                });
+                bound.DoStringArgumentCallback_Async(" SUCCESS", function(s) {
+                    document.getElementById('callbackBindingTargetAsyncStringArg').innerText = s;
+                });
+            </script>
+        </ul>
+        </p>
+        
+	    <p>
+
 	    Result of calling bound.Repeat("hi ", 5) =
 	    <script type="text/javascript">
 	        var result = bound.Repeat("hi ", 5);
@@ -28,5 +53,6 @@
                 }
             </script>
         </ul>
+        
 	</body>
 </html>

--- a/CefSharp/BindingHandler.cpp
+++ b/CefSharp/BindingHandler.cpp
@@ -128,6 +128,7 @@ namespace CefSharp
     {
         CefRefPtr<BindingData> bindingData = static_cast<BindingData*>(object->GetUserData().get());
         Object^ self = bindingData->Get();
+		
         if(self == nullptr) 
         {
             exception = "Binding's CLR object is null.";

--- a/CefSharp/CefCallbackWrapper.cpp
+++ b/CefSharp/CefCallbackWrapper.cpp
@@ -1,0 +1,47 @@
+#include "StdAfx.h"
+#include "CefCallbackWrapper.h"
+#include "include/cef_runnable.h"
+
+using namespace System;
+
+namespace CefSharp
+{
+	static void _call(CefV8Value* callback, CefV8Context* context, gcroot<array<Object^>^> args)
+	{
+		context->Enter();
+
+		CefV8ValueList arguments = CefV8ValueList(args->Length);
+		for(int i = 0; i < args->Length; i++)
+		{
+			arguments[i] = convertToCef(args[i], args[i]->GetType());
+		}
+		
+		callback->ExecuteFunction(CefV8Value::CreateUndefined() , arguments);
+		callback->Release();
+
+		context->Exit();
+		context->Release();
+	}
+
+	CefCallbackWrapper::CefCallbackWrapper(CefRefPtr<CefV8Value> callback)
+	{
+		this->cbInfo = new CEF_CALLBACK_INFO();
+		this->cbInfo->callback = callback.get();
+		this->cbInfo->callback->AddRef();
+
+		CefRefPtr<CefV8Context> pC = CefV8Context::GetEnteredContext();
+		this->cbInfo->context = pC.get();
+		this->cbInfo->context->AddRef();
+	}
+
+	void CefCallbackWrapper::Call(...array<Object^> ^args)
+	{
+		if(CefCurrentlyOn(TID_UI)){
+			_call(this->cbInfo->callback, this->cbInfo->context, (gcroot<array<Object^>^>) args);
+		}
+		else
+		{
+			CefPostTask(TID_UI, NewCefRunnableFunction(&_call, this->cbInfo->callback, this->cbInfo->context, (gcroot<array<Object^>^>) args));
+		}
+	}
+}

--- a/CefSharp/CefCallbackWrapper.h
+++ b/CefSharp/CefCallbackWrapper.h
@@ -1,0 +1,22 @@
+#pragma once
+
+using namespace System;
+namespace CefSharp
+{
+	struct CEF_CALLBACK_INFO {
+		CefV8Value *callback;
+		CefV8Context *context;
+	};
+
+	public ref class CefCallbackWrapper
+	{
+	public:
+		CefCallbackWrapper(CefRefPtr<CefV8Value> callback);
+		~CefCallbackWrapper(){
+			delete cbInfo;
+		}
+		void Call(...array<Object^> ^args);
+	private:
+		CEF_CALLBACK_INFO *cbInfo;
+	};
+}

--- a/CefSharp/CefSharp.vcproj
+++ b/CefSharp/CefSharp.vcproj
@@ -72,7 +72,7 @@
 				GenerateDebugInformation="true"
 				AssemblyDebug="1"
 				TargetMachine="1"
-				KeyFile="$(SolutionDir)\CefSharp.snk"
+				KeyFile=""
 			/>
 			<Tool
 				Name="VCALinkTool"
@@ -201,6 +201,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\CefCallbackWrapper.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\ClientAdapter.cpp"
 				>
 			</File>
@@ -280,6 +284,10 @@
 			</File>
 			<File
 				RelativePath=".\BrowserSettings.h"
+				>
+			</File>
+			<File
+				RelativePath=".\CefCallbackWrapper.h"
 				>
 			</File>
 			<File

--- a/CefSharp/TypeUtil.cpp
+++ b/CefSharp/TypeUtil.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "CefCallbackWrapper.h"
 
 using namespace System::Collections::Generic;
 
@@ -187,6 +188,11 @@ namespace CefSharp
 			}
 
 			return nullptr;
+		}
+
+		if (obj->IsFunction())
+		{
+			return gcnew CefCallbackWrapper(obj);
 		}
 
 		if (obj->IsObject())

--- a/CefSharp/TypeUtil.h
+++ b/CefSharp/TypeUtil.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "include/cef_v8.h"
-
 namespace CefSharp
 {
     CefRefPtr<CefV8Value> convertToCef(Object^ obj, Type^ type);


### PR DESCRIPTION
Adds native JavaScript callback support.  Tests are in CefSharp.Example\Resources\BindingTest.html

Created new class: CefCallbackWrapper, with two purposes:
1. wraps the callback function (CefV8Value) and callback context (CefV8Context) for the round-trip to managed-code
2. provides Call() method that invokes the JS callback with supplied arguments on the CEF UI thread.
