### PR TITLE
Exposed ClientHandler::OnBeforeClose

### DIFF
--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -40,6 +40,12 @@ namespace CefSharp
     {
         if (_browserHwnd == browser->GetWindowHandle())
         {
+			ILifeSpanHandler^ handler = _browserControl->LifeSpanHandler;
+			if (handler != nullptr)
+			{
+				handler->OnBeforeClose(_browserControl);
+			}
+
             _cefBrowser = nullptr;
         }
     }

--- a/CefSharp/ILifeSpanHandler.h
+++ b/CefSharp/ILifeSpanHandler.h
@@ -9,5 +9,6 @@ namespace CefSharp
     {
     public:
         bool OnBeforePopup(IWebBrowser^ browser, String^ url, int% x, int% y, int% width, int% height);
+		void OnBeforeClose(IWebBrowser^ browser);
     };
 }


### PR DESCRIPTION
Exposed OnBeforeClose to handle the destroying of browsers. 

Access to this method is of particular use when a browser is forcibly being closed via JavaScript, such as on this page: http://www.quackit.com/javascript/popup_windows.cfm which calls `javascript:window.close()` if the user clicks the close link in the pop up window.
