### PR TITLE
Add support for transparent HTML backgrounds

### DIFF
--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -153,9 +153,9 @@ namespace CefSharp
                 _image->Source = nullptr;
                 GC::Collect(1);
 
-                int stride = _width * PixelFormats::Bgr32.BitsPerPixel / 8;
+                int stride = _width * PixelFormats::Bgra32.BitsPerPixel / 8;
                 bitmap = (InteropBitmap^)Interop::Imaging::CreateBitmapSourceFromMemorySection(
-                    (IntPtr)_fileMappingHandle, _width, _height, PixelFormats::Bgr32, stride, 0);
+                    (IntPtr)_fileMappingHandle, _width, _height, PixelFormats::Bgra32, stride, 0);
                 _image->Source = bitmap;
                 _ibitmap = bitmap;
             }
@@ -172,9 +172,9 @@ namespace CefSharp
                 _popupImage->Source = nullptr;
                 GC::Collect(1);
 
-                int stride = _popupImageWidth * PixelFormats::Bgr32.BitsPerPixel / 8;
+                int stride = _popupImageWidth * PixelFormats::Bgra32.BitsPerPixel / 8;
                 bitmap = (InteropBitmap^)Interop::Imaging::CreateBitmapSourceFromMemorySection(
-                    (IntPtr)_popupFileMappingHandle, _popupImageWidth, _popupImageHeight, PixelFormats::Bgr32, stride, 0);
+                    (IntPtr)_popupFileMappingHandle, _popupImageWidth, _popupImageHeight, PixelFormats::Bgra32, stride, 0);
                 _popupImage->Source = bitmap;
                 _popupIbitmap = bitmap;
             }
@@ -638,6 +638,7 @@ namespace CefSharp
             HWND hwnd = static_cast<HWND>(_source->Handle.ToPointer());
             CefWindowInfo window;
             window.SetAsOffScreen(hwnd);
+            window.SetTransparentPainting(TRUE);
             CefString url = toNative(_browserCore->Address);
 
             CefBrowser::CreateBrowser(window, _clientAdapter.get(),


### PR DESCRIPTION
Currently, CefSharp does not support transparent backgrounds in the rendered document. My application has a requirement that I be able to render several instances of CefSharp WPF WebView controls over a shared background. Each instance has a small snippet of HTML content to render. The WPF background may contain color gradients and/or background images, which are not easily mimicked in the background of the HTML documents.

In my research, I found the following discussion for doing this generically in CEF, which led me to the "CefWindowInfo.SetTransparentPainting()" method:

http://www.magpcss.org/ceforum/viewtopic.php?f=6&t=10504

In addition, in the below CefSharp Google Group discussion, the OP suggested that it might be enough to switch from Bgr32 to Bgra32 rendering of the image in order to preserve transparency:

https://groups.google.com/forum/#!topic/cefsharp/dpJW_8YFFuA

Neither of these is enough on its own, but together, success! In my build of CefSharp with these changes, I can now set a style like this, and the WPF background shines through with rendered HTML content over it:

```
html, body {
    background: transparent;
}
```

Please consider making this a main-line feature for the WPF control. My thought is that this is unlikely to be a breaking change for most people, since HTML documents (at least in Chrome) have a white background by default, and this kind of CSS makes no sense in a traditional web browsing scenario.
