### PR TITLE
#165: Add bindings for SetZoomLevel in WPF

### DIFF
--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -111,6 +111,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -134,6 +135,17 @@
                             Maximum="1"
                             TickFrequency="0.01"
                             Value="0.85" />
+                    <Label Grid.Row="2"
+                           Grid.Column="0"
+                           Content="Zoom level:" />
+                    <Slider Grid.Row="2"
+                            Grid.Column="1"
+                            Name="zoomSlider"
+                            Minimum="0"
+                            Maximum="1"
+                            TickFrequency="0.1"
+                            Value="0.0" 
+                            ValueChanged="SetZoomLevel"/>
                 </Grid>
             </GroupBox>
             <Label Name="outputLabel"

--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -122,6 +122,11 @@ namespace CefSharp.Wpf.Example
             outputLabel.Content = output;
         }
 
+        public void SetZoomLevel(object sender, RoutedPropertyChangedEventArgs<double> zoomLevelArgs)
+        {
+            web_view.ZoomLevel = zoomLevelArgs.NewValue;
+        }
+
         private void control_Activated(object sender, RoutedEventArgs e)
         {
             EventHandler handler;

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -235,6 +235,25 @@ namespace CefSharp
                 void set(IJsDialogHandler^ handler) { _browserCore->JsDialogHandler = handler; }
             }
 
+            virtual property double ZoomLevel
+            {
+                double get() { 
+                  CefRefPtr<CefBrowser> browser;
+                  if(!TryGetCefBrowser(browser)) {
+                    return 0;
+                  }
+                  return browser->GetZoomLevel();
+                }
+                void set(double zoomLevel)
+                {
+                  CefRefPtr<CefBrowser> browser;
+                  if(!TryGetCefBrowser(browser)) {
+                    return;
+                  }
+                  browser->SetZoomLevel(zoomLevel);
+                }
+            }
+
             virtual void OnInitialized();
 
             virtual void Load(String^ url);


### PR DESCRIPTION
> The C++ CEF API exposes the method SetZoomLevel in the CEFBrowser class. Most other methods listed there > already have bindings, but for my project, SetZoomLevel would be very useful.
> http://magpcss.org/ceforum/apidocs/projects/(default)/CefBrowser.html#SetZoomLevel(double)
