### PR TITLE
Additional SchemeHandlerResponse options

### DIFF
--- a/CefSharp/SchemeHandlerResponse.h
+++ b/CefSharp/SchemeHandlerResponse.h
@@ -44,6 +44,12 @@ namespace CefSharp
         /// </summary>
         property String^ RedirectUrl;
 
+        /// <summary>
+        /// Set to true to close the response stream once it has been read. The default value
+        /// is false in order to preserve the old CefSharp behavior of not closing the stream.
+        /// </summary>
+        property bool CloseStream;
+
         SchemeHandlerResponse(SchemeHandlerWrapper* schemeHandlerWrapper)
         {
             ContentLength = -1;

--- a/CefSharp/SchemeHandlerWrapper.cpp
+++ b/CefSharp/SchemeHandlerWrapper.cpp
@@ -55,6 +55,7 @@ namespace CefSharp
         _statusCode = response->StatusCode;
         _redirectUrl = toNative(response->RedirectUrl);
         _contentLength = response->ContentLength;
+        _closeStream = response->CloseStream;
 
         _headers = ToHeaderMap(response->ResponseHeaders);
 
@@ -100,6 +101,10 @@ namespace CefSharp
             bytes_read = ret;
             // must return false when the response is complete
             has_data = ret > 0;
+            if (!has_data && _closeStream)
+            {
+                _stream->Close();
+            }
         }
 
         return has_data;
@@ -107,6 +112,10 @@ namespace CefSharp
 
     void SchemeHandlerWrapper::Cancel()
     {
+        if (!!_stream && _closeStream)
+        {
+            _stream->Close();
+        }
         _stream = nullptr;
     }
 

--- a/CefSharp/SchemeHandlerWrapper.h
+++ b/CefSharp/SchemeHandlerWrapper.h
@@ -27,6 +27,7 @@ namespace CefSharp
         int _statusCode;
         CefString _redirectUrl;
         int _contentLength;
+        bool _closeStream;
 
         int SizeFromStream();
 


### PR DESCRIPTION
This PR adds a number of properties/options to SchemeHandlerResponse:
- StatusCode, to return something else than status 200 to CEF.
- RedirectUrl, to have CEF do redirects.
- ContentLength, to provide a content length to CEF regardless of whether the response stream is seekable or not, for optimal response reading.
- CloseStream, so that SchemeHandlerWrapper can close the response stream once it has read all data.

It also fixes a bug in SchemeHandlerWrapper, which didn't return false upon response completion in ReadResponse.

The ultimate goal of all changes were to be able to write a SchemeHandler implementation for proxying HTTP requests, which now is possible.

I'm sorry to say that I couldn't write any unit tests. I don't know how to instantiate SchemeHandlerWrapper from the CefSharp.Test project. Any suggestions?
