### PR TITLE
Fixed process not exiting in Windows XP

### DIFF
--- a/CefSharp/Cef.h
+++ b/CefSharp/Cef.h
@@ -51,6 +51,14 @@ namespace CefSharp
             SetEvent(_event);
         }
 
+        static void ParentProcessExitHandler(Object^ sender, EventArgs^ e)
+        {
+            if (Cef::IsInitialized)
+            {
+                Cef::Shutdown();
+            }
+        }
+
     internal:
         static IDictionary<String^, Object^>^ GetBoundObjects()
         {
@@ -130,6 +138,11 @@ namespace CefSharp
                 success = CefInitialize(main_args, *(cefSettings->_cefSettings), app.get());
                 app->CompleteSchemeRegistrations();
                 _initialized = success;
+
+                if (_initialized)
+                {
+                    AppDomain::CurrentDomain->ProcessExit += gcnew EventHandler(ParentProcessExitHandler);
+                }
             }
 
             return success;


### PR DESCRIPTION
Added a handler assignment on the first call to CefSharp::Initialize
which will ensure CEF is shutdown properly should the calling program
not manually call the shutdown method before the process exits.

This bug only seems to affect Windows XP, however I have tested on both
Windows XP and Windows 7 and with this change neither have any ghost
processes left over after the program calling CefSharp exits.

This commit fixes #80
