### PR TITLE
Don't break when calling aliased methods of CLR object

### DIFF
--- a/CefSharp/Internals/JavascriptBinding/BindingHandler.cpp
+++ b/CefSharp/Internals/JavascriptBinding/BindingHandler.cpp
@@ -33,6 +33,12 @@ namespace CefSharp
             bool BindingHandler::Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8ValueList& arguments, CefRefPtr<CefV8Value>& retval, CefString& exception)
             {
                 auto unmanagedWrapper = static_cast<UnmanagedWrapper*>(object->GetUserData().get());
+                if (unmanagedWrapper == nullptr)
+                {
+                    exception = "Illegal invocation";
+                    return true;
+                }
+
                 Object^ self = unmanagedWrapper->Get();
 
                 if (self == nullptr)


### PR DESCRIPTION
If a CLR object `foo` has a method `bar` and you do `var f = foo.bar; f();` or `foo.bar.call()` the code breaks with a null pointer exception. If you instead alias some other native method (eg: console.log) it will instead give a `Type Error: Illegal invocation`. Here I attempt to mimic that behavior to some extent.
