### PR TITLE
GetPostData implementation

### DIFF
--- a/CefSharp/IRequest.h
+++ b/CefSharp/IRequest.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "PostData.h"
+
 using namespace System;
 using namespace System::Collections::Generic;
 
@@ -12,5 +14,6 @@ namespace CefSharp
         property String^ Body { String^ get(); }
         IDictionary<String^, String^>^ GetHeaders();
         void SetHeaders(IDictionary<String^, String^>^ headers);
+        CefPostDataWrapper^ GetPostData();
     };
 }

--- a/CefSharp/PostData.cpp
+++ b/CefSharp/PostData.cpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Stdafx.h"
+#include "PostData.h"
+
+namespace CefSharp
+{
+    Int32^ CefPostDataWrapper::ElementCount::get()
+    {
+        return gcnew Int32(_wrappedData->GetElementCount());
+    }
+
+    IList<CefPostDataElementWrapper^>^ CefPostDataWrapper::GetElements()
+    {
+        CefPostData::ElementVector ev;
+
+        _wrappedData->GetElements(ev);
+
+        IList<CefPostDataElementWrapper^>^ elementList = gcnew List<CefPostDataElementWrapper^>();
+
+        for (CefPostData::ElementVector::iterator it = ev.begin(); it != ev.end(); ++it)
+        {
+            CefPostDataElement* elem = it->get();
+
+            elementList->Add(gcnew CefPostDataElementWrapper(elem));
+        }
+
+        return elementList;
+    }
+}

--- a/CefSharp/PostData.h
+++ b/CefSharp/PostData.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Stdafx.h"
+#include "PostDataElement.h"
+
+using namespace System;
+using namespace System::Collections::Generic;
+
+namespace CefSharp
+{
+    public ref class CefPostDataWrapper
+    {
+        MCefRefPtr<CefPostData> _wrappedData;
+
+    internal:
+        CefPostDataWrapper(CefRefPtr<CefPostData> cefPostData) : _wrappedData(cefPostData) {}
+
+    public:
+        property Int32^ ElementCount { Int32^ get(); }
+
+        IList<CefPostDataElementWrapper^>^ GetElements();
+    };
+}

--- a/CefSharp/PostDataElement.cpp
+++ b/CefSharp/PostDataElement.cpp
@@ -1,0 +1,45 @@
+#include "Stdafx.h"
+
+#include "PostDataElement.h"
+
+namespace CefSharp
+{
+    ElementType^ CefPostDataElementWrapper::Type::get()
+    {
+        CefPostDataElement::Type type = _wrappedPostDataElement->GetType();
+        
+        switch (type)
+        {
+        case PDE_TYPE_EMPTY:
+            return ElementType::Empty;
+        case PDE_TYPE_BYTES:
+            return ElementType::Bytes;
+        case PDE_TYPE_FILE:
+            return ElementType::File;
+        }
+    }
+
+    String^ CefPostDataElementWrapper::File::get()
+    {
+        return toClr(_wrappedPostDataElement->GetFile());
+    }
+
+    array<Byte>^ CefPostDataElementWrapper::Bytes::get()
+    {
+        size_t byteCount = _wrappedPostDataElement->GetBytesCount();
+        unsigned char* byteBuffer = new unsigned char[byteCount];
+
+        _wrappedPostDataElement->GetBytes(byteCount, byteBuffer);
+
+        array<Byte>^ clrByteArray = gcnew array<Byte>(byteCount);
+        System::Runtime::InteropServices::Marshal::Copy(IntPtr(byteBuffer), clrByteArray, 0, byteCount);
+        delete[] byteBuffer;
+
+        return clrByteArray;
+    }
+
+    Int32^ CefPostDataElementWrapper::BytesCount::get()
+    {
+        return gcnew Int32(_wrappedPostDataElement->GetBytesCount());
+    }
+}

--- a/CefSharp/PostDataElement.h
+++ b/CefSharp/PostDataElement.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Stdafx.h"
+
+using namespace System;
+using namespace System::Collections::Generic;
+
+namespace CefSharp
+{
+    public enum class ElementType
+    {
+        Empty = PDE_TYPE_EMPTY,
+        Bytes = PDE_TYPE_BYTES,
+        File = PDE_TYPE_FILE
+    };
+
+    public ref class CefPostDataElementWrapper
+    {
+        MCefRefPtr<CefPostDataElement> _wrappedPostDataElement;
+
+    internal:
+        CefPostDataElementWrapper(CefRefPtr<CefPostDataElement> cefPostDataElement) : _wrappedPostDataElement(cefPostDataElement) {}
+
+    public:
+        property ElementType^ Type { ElementType^ get(); }
+        property String^ File { String^ get(); }
+        property array<Byte>^ Bytes { array<Byte>^ get(); }
+        property Int32^ BytesCount { Int32^ get(); }
+    };
+}

--- a/CefSharp/Request.cpp
+++ b/CefSharp/Request.cpp
@@ -88,4 +88,9 @@ namespace CefSharp
 
         _wrappedRequest->SetHeaderMap(hm);
     }
+
+    CefPostDataWrapper^ CefRequestWrapper::GetPostData()
+    {
+        return gcnew CefPostDataWrapper(_wrappedRequest->GetPostData());
+    }
 }

--- a/CefSharp/Request.h
+++ b/CefSharp/Request.h
@@ -3,6 +3,7 @@
 #include "Stdafx.h"
 #include "IRequest.h"
 #include "SchemeHandlerResponse.h"
+#include "PostData.h"
 
 using namespace System;
 using namespace System::Collections::Generic;
@@ -24,5 +25,6 @@ namespace CefSharp
         virtual property String^ Body { String^ get(); }
         virtual IDictionary<String^, String^>^ GetHeaders();
         virtual void SetHeaders(IDictionary<String^, String^>^ headers);
+        virtual CefPostDataWrapper^ GetPostData();
     };
 }


### PR DESCRIPTION
- Added a wrapper around CefPostDataElement
- Added an enum for passing cef_postdataelement_type_t values
- Added a wrapper around CefPostData
- Added implementation of GetPostData to Request

I haven't checked thoroughly, but I don't believe anything has changed in the CEF3 API for GetPostData, so this change may work in the CefSharp3 branch as well.
