### PR TITLE
removed Website Reload when switching Tabs

### DIFF
--- a/CefSharp/ManagedCefBrowserAdapter.h
+++ b/CefSharp/ManagedCefBrowserAdapter.h
@@ -54,13 +54,13 @@ namespace CefSharp
             _renderClientAdapter = nullptr;
         }
 
-        void CreateOffscreenBrowser(BrowserSettings^ browserSettings, IntPtr^ sourceHandle, String^ address)
+        void CreateOffscreenBrowser(BrowserSettings^ browserSettings)
         {
-            HWND hwnd = static_cast<HWND>(sourceHandle->ToPointer());
+            HWND hwnd = HWND();
             CefWindowInfo window;
             window.SetAsOffScreen(hwnd);
             window.SetTransparentPainting(true);
-            CefString addressNative = StringUtils::ToNative(address);
+            CefString addressNative = StringUtils::ToNative("about:blank");
 
             CefBrowserHost::CreateBrowser(window, _renderClientAdapter, addressNative,
                 *(CefBrowserSettings*) browserSettings->_internalBrowserSettings);


### PR DESCRIPTION
it was a bit more complicated as i thought.

i thought that i only have to remove the ContentControl because the ContentTemplate causes the lazy load but the TabControl uses ContentPresenter internally so this did not help.

I Removed the whole lazy create approach and pass an emty handle / adress to the offscreenbrowser. i had to tune the OnResize code a bit because on my first attempt i got empty tab2

you should carefully look at the changes you did to the example. it loads horribly slow on my machine and throws tonns of binding errors which it did not get without the changes u made.
