### PR TITLE
Added Tab Opening and Closing Shortcuts.

### DIFF
--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -11,9 +11,21 @@ namespace CefSharp.Wpf.Example
         public FrameworkElement Tab1Content { get; set; }
         public FrameworkElement Tab2Content { get; set; }
 
+        private RoutedCommand newTab;
+        private RoutedCommand closeTab;
+
         public MainWindow()
         {
             InitializeComponent();
+
+            newTab = new RoutedCommand();
+            newTab.InputGestures.Add(new KeyGesture(Key.T, ModifierKeys.Control));
+            CommandBindings.Add(new CommandBinding(newTab, tabShortcut));
+
+            closeTab = new RoutedCommand();
+            closeTab.InputGestures.Add(new KeyGesture(Key.W, ModifierKeys.Control));
+            CommandBindings.Add(new CommandBinding(closeTab, closeTabShortcut));
+
             DataContext = this;
 
             Tab1Content = new MainView
@@ -52,6 +64,18 @@ namespace CefSharp.Wpf.Example
                 RelativeSource = RelativeSource.Self
             });
             return tabItem;
+        }
+
+        private void tabShortcut(object sender, ExecutedRoutedEventArgs e)
+        {
+            var tabItem = CreateTabItem();
+            TabControl.Items.Insert(TabControl.Items.Count - 1, tabItem);
+        }
+
+        private void closeTabShortcut(object sender, ExecutedRoutedEventArgs e)
+        {
+            MessageBox.Show("Tab closing is not enabled at this time :(");
+            //TabControl.Items.RemoveAt(TabControl.SelectedIndex);
         }
 
         private static MainView CreateNewTab()


### PR DESCRIPTION
I added in tab opening and closing shortcuts in the WPF CefSharp example. I had problems with my tab closing shortcut, as it seems like my code does work but something, I suspect the `OnTabControlSelectionChanged` function, creates a new tab whenever I close one.
