### PR TITLE
Exposing flushcookie api.

### DIFF
--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -10,6 +10,7 @@
 
 #include "Internals/CefSharpApp.h"
 #include "Internals/CookieVisitor.h"
+#include "Internals/CompletionHandler.h"
 #include "Internals/StringUtils.h"
 #include "ManagedCefBrowserAdapter.h"
 #include "CefSettings.h"
@@ -316,6 +317,24 @@ namespace CefSharp
             }
         }
 
+        /// <summary> Flush the backing store (if any) to disk and execute the specified |handler| on the IO thread when done. Returns </summary>
+        /// <param name="visitor">A user-provided Cookie Visitor implementation.</param>
+        /// <return>Returns false if cookies cannot be accessed.</return>
+        static bool FlushStore(IComplete^ handler)
+        {
+            CefRefPtr<CompletionHandler> wrapper = new CompletionHandler(handler);
+            CefRefPtr<CefCookieManager> manager = CefCookieManager::GetGlobalManager();
+
+            if (manager != nullptr)
+            {
+                manager->FlushStore(static_cast<CefRefPtr<CefCompletionHandler>>(wrapper));
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
         /// <summary>Shuts down CefSharp and the underlying CEF infrastructure. This method is safe to call multiple times; it will only
         /// shut down CEF on the first call (all subsequent calls will be ignored).
         /// </summary>

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -217,8 +217,9 @@
     <ClCompile Include="AssemblyInfo.cpp" />
     <ClCompile Include="CefAppWrapper.cpp" />
     <ClCompile Include="Internals\ClientAdapter.cpp" />
-    <ClCompile Include="Internals\CookieVisitor.cpp" />
     <ClCompile Include="Internals\CefRequestWrapper.cpp" />
+    <ClCompile Include="Internals\CompletionHandler.cpp" />
+    <ClCompile Include="Internals\CookieVisitor.cpp" />
     <ClCompile Include="Internals\RequestResponse.cpp" />
     <ClCompile Include="SchemeHandlerResponse.cpp" />
     <ClCompile Include="SchemeHandlerWrapper.cpp" />
@@ -235,6 +236,7 @@
   <ItemGroup>
     <ClInclude Include="BrowserSettings.h" />
     <ClInclude Include="Cef.h" />
+    <ClInclude Include="Internals\CompletionHandler.h" />
     <ClInclude Include="Wrappers\CefAppWrapper.h" />
     <ClInclude Include="Internals\DownloadAdapter.h" />
     <ClInclude Include="Internals\ClientAdapter.h" />

--- a/CefSharp.Core/CefSharp.Core.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.vcxproj.filters
@@ -23,9 +23,6 @@
     <ClCompile Include="Internals\CefRequestWrapper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Internals\CookieVisitor.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Internals\ClientAdapter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -45,6 +42,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CefAppWrapper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Internals\CompletionHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Internals\CookieVisitor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -113,6 +116,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CefSettings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Internals\CompletionHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CefSharp.Core/Internals/CompletionHandler.cpp
+++ b/CefSharp.Core/Internals/CompletionHandler.cpp
@@ -1,0 +1,18 @@
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+#include "CompletionHandler.h"
+
+using namespace System::Net;
+
+namespace CefSharp
+{
+    void CompletionHandler::OnComplete()
+    {
+        _handler->OnComplete();
+    }
+}

--- a/CefSharp.Core/Internals/CompletionHandler.h
+++ b/CefSharp.Core/Internals/CompletionHandler.h
@@ -1,0 +1,27 @@
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+#include "include/cef_cookie.h"
+
+namespace CefSharp
+{
+    private class CompletionHandler : public CefCompletionHandler
+    {
+    private:
+        gcroot<IComplete^> _handler;
+
+    public:
+        CompletionHandler(IComplete^ handler)
+        {
+            _handler = handler;
+        }
+
+        virtual void OnComplete() OVERRIDE;
+
+        IMPLEMENT_REFCOUNTING(CompletionHandler);
+    };
+}

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -86,6 +86,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IComplete.cs" />
     <Compile Include="Internals\BitmapInfo.cs" />
     <Compile Include="Internals\ManagedCefApp.cs" />
     <Compile Include="CefCustomScheme.cs" />

--- a/CefSharp/IComplete.cs
+++ b/CefSharp/IComplete.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace CefSharp
+{
+    public interface IComplete
+    {
+        void OnComplete();
+    }
+}


### PR DESCRIPTION
Been spending lots of time with the cookie API and notice we don't have this API exposed . 

Put together `b5319b0` for it.

I modeled this after the VisitAllCookies API design.

More more more cookies :cookie: :cookie: :cookie: 

Also noticed we are not setting the creation time of the cookies in the visit API , pulling that information out of the struct and adding to the .net cookies in `63f13a4`.

Cookie time :cookie: 
