### PR TITLE
Key Modifier not being sent to Browser

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -112,7 +112,7 @@ namespace CefSharp
             }
         }
 
-        bool SendKeyEvent(int message, int wParam)
+        bool SendKeyEvent(int message, int wParam, CefEventFlags modifiers)
         {
             auto cefHost = _renderClientAdapter->TryGetCefHost();
 
@@ -135,6 +135,8 @@ namespace CefSharp
                     message == WM_SYSKEYDOWN ||
                     message == WM_SYSKEYUP ||
                     message == WM_SYSCHAR;
+
+                keyEvent.modifiers = (uint32)modifiers;
 
                 cefHost->SendKeyEvent(keyEvent);
                 return true;


### PR DESCRIPTION
Add modifiers parameter to ManagedCefBrowserAdapter SendKeyEvent function
Sent through key modifier so things like Shift-LeftArrow work as expected
Also include Home and End keys in list that gets sent to the browser directly (now Shift->Home and Shift->End work correctly when selecting items in input fields)
