### PR TITLE
Implemented all CEF3 BrowserSettings

### DIFF
--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -158,7 +158,7 @@ namespace CefSharp
             void set(String^ value) { StringUtils::AssignNativeFromClr(_browserSettings->default_encoding, value); }
         }
 
-        property Nullable<bool>^ JavaScriptDisabled
+        property Nullable<bool>^ JavascriptDisabled
         {
             Nullable<bool>^ get() { return CefStateToDisabledSetting(_browserSettings->javascript); }
             void set(Nullable<bool>^ value) { _browserSettings->javascript = CefStateFromDisabledSetting(value); }


### PR DESCRIPTION
Implement all CEF3 settings which are defined in cef_browser_settings_t struct.
Changed the Nullable<bool> to an enumeration _BrowserSettingsState like in CEf3. I think this is easier to read instead of the multiple mixture of xxxDisable/xxxEnabled settings and the assigned bool.
