### PR TITLE
Wpf Cleanup and Add License

### DIFF
--- a/CefSharp.Wpf.Example/App.xaml.cs
+++ b/CefSharp.Wpf.Example/App.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Windows;
 using CefSharp.Example;
 
 namespace CefSharp.Wpf.Example

--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Windows.Data;
-using System.Windows.Input;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Windows.Data;
 using CefSharp.Wpf.Example.Views.Main;
 using System.Windows;
 using System.Windows.Controls;

--- a/CefSharp.Wpf.Example/Mvvm/DelegateCommand.cs
+++ b/CefSharp.Wpf.Example/Mvvm/DelegateCommand.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
 using System.Windows.Input;
 
 namespace CefSharp.Wpf.Example.Mvvm

--- a/CefSharp.Wpf.Example/Mvvm/DelegateCommandT.cs
+++ b/CefSharp.Wpf.Example/Mvvm/DelegateCommandT.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
 using System.Windows.Input;
 
 namespace CefSharp.Wpf.Example.Mvvm

--- a/CefSharp.Wpf.Example/Mvvm/ViewModelBase.cs
+++ b/CefSharp.Wpf.Example/Mvvm/ViewModelBase.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;
@@ -18,7 +22,7 @@ namespace CefSharp.Wpf.Example.Mvvm
         }
 
         /// <summary>
-        /// Is called when a property is changed and raises a  <see cref="PropertyChangedEvent"/>
+        /// Is called when a property is changed and raises a <see cref="PropertyChanged"/> event
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="oldvalue">The old value.</param>

--- a/CefSharp.Wpf.Example/Views/Main/MainView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/Main/MainView.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Controls;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace CefSharp.Wpf.Example.Views.Main

--- a/CefSharp.Wpf.Example/Views/Main/MainViewModel.cs
+++ b/CefSharp.Wpf.Example/Views/Main/MainViewModel.cs
@@ -1,4 +1,8 @@
-﻿using CefSharp.Example;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using CefSharp.Example;
 using CefSharp.Wpf.Example.Mvvm;
 using System;
 using System.ComponentModel;

--- a/CefSharp.Wpf/DelegateCommand.cs
+++ b/CefSharp.Wpf/DelegateCommand.cs
@@ -1,7 +1,10 @@
-﻿using System;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Threading;
 
 namespace CefSharp.Wpf
 {

--- a/CefSharp.Wpf/IWpfWebBrowser.cs
+++ b/CefSharp.Wpf/IWpfWebBrowser.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Input;
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Windows.Input;
 
 namespace CefSharp.Wpf
 {


### PR DESCRIPTION
Add license disclaimer to source c# source files
Remove an unused reference in MainWindow.xaml.cs
Fix comment for OnPropertyChanged event
