### PR TITLE
Adding a name check to avoid unwanted cookie exceptions.

### DIFF
--- a/CefSharp.Core/Internals/CookieVisitor.cpp
+++ b/CefSharp.Core/Internals/CookieVisitor.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 


### PR DESCRIPTION
I am seeing a few cases where the name is empty in the cefcookie struct. 

Even though we are not expecting cookies to not have a key, I am adding a name check to avoid .NET cookieexception when a name is empty and return an empty cookie.
