### PR TITLE
Added support for overriding file browse dialogs by implementing the cef...

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -408,5 +408,31 @@ namespace CefSharp
             // Unknown dialog type, so we return "not handled".
             return false;
         }
+
+		bool ClientAdapter::OnFileDialog(CefRefPtr<CefBrowser> browser,
+			FileDialogMode mode,
+			const CefString& title,
+			const CefString& default_file_name,
+			const std::vector<CefString>& accept_types,
+			CefRefPtr<CefFileDialogCallback> callback)
+		{
+			IDialogHandler^ handler = _browserControl->DialogHandler;
+
+			if (handler == nullptr)
+			{
+				return false;
+			}
+
+			bool result;
+			bool handled;
+
+			List<System::String ^>^ resultString = nullptr;
+
+			result = handler->OnOpenFile(_browserControl, StringUtils::ToClr(title), StringUtils::ToClr(default_file_name), StringUtils::ToClr(accept_types), resultString);
+			callback->Continue(StringUtils::ToNative(resultString));
+
+			// Unknown dialog type, so we return "not handled".
+			return false;
+		}
     }
 }

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -26,7 +26,8 @@ namespace CefSharp
             public CefContextMenuHandler,
             public CefFocusHandler,
             public CefKeyboardHandler,
-            public CefJSDialogHandler
+            public CefJSDialogHandler,
+			public CefDialogHandler
         {
         private:
             gcroot<IWebBrowserInternal^> _browserControl;
@@ -62,6 +63,7 @@ namespace CefSharp
             virtual CefRefPtr<CefFocusHandler> GetFocusHandler() OVERRIDE{ return this; }
             virtual CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() OVERRIDE{ return this; }
             virtual CefRefPtr<CefJSDialogHandler> GetJSDialogHandler() OVERRIDE{ return this; }
+			virtual CefRefPtr<CefDialogHandler> GetDialogHandler() OVERRIDE{ return this; }
 
             // CefLifeSpanHandler
             virtual DECL bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
@@ -104,6 +106,14 @@ namespace CefSharp
             virtual bool OnJSDialog(CefRefPtr<CefBrowser> browser, const CefString& origin_url, const CefString& accept_lang,
                 JSDialogType dialog_type, const CefString& message_text, const CefString& default_prompt_text,
                 CefRefPtr<CefJSDialogCallback> callback, bool& suppress_message) OVERRIDE;
+
+			// CefDialogHandler
+			virtual bool OnFileDialog(CefRefPtr<CefBrowser> browser,
+				FileDialogMode mode,
+				const CefString& title,
+				const CefString& default_file_name,
+				const std::vector<CefString>& accept_types,
+				CefRefPtr<CefFileDialogCallback> callback) OVERRIDE;
 
             IMPLEMENT_LOCKING(ClientAdapter);
             IMPLEMENT_REFCOUNTING(ClientAdapter);

--- a/CefSharp.Core/Internals/StringUtils.cpp
+++ b/CefSharp.Core/Internals/StringUtils.cpp
@@ -5,6 +5,7 @@
 #include "Stdafx.h"
 
 using namespace System::Diagnostics;
+using namespace System::Collections::Generic;
 
 namespace CefSharp
 {
@@ -22,6 +23,13 @@ namespace CefSharp
             return gcnew String(cefStr.c_str());
         }
 
+		[DebuggerStepThrough]
+		List<String^>^ StringUtils::ToClr(const std::vector<CefString>& cefStr)
+		{
+			//cefStr.c_str()
+			return gcnew List<String^>();
+		}
+
         [DebuggerStepThrough]
         CefString StringUtils::ToNative(String^ str)
         {
@@ -34,6 +42,26 @@ namespace CefSharp
             CefString cefStr(pStr);
             return cefStr;
         }
+
+		[DebuggerStepThrough]
+		std::vector<CefString> StringUtils::ToNative(List<String^>^ str)
+		{
+			if (str == nullptr)
+			{
+				return std::vector<CefString>();
+			}
+
+			std::vector<CefString> result = std::vector<CefString>();
+
+			for each (String^ s in str)
+			{
+				pin_ptr<const wchar_t> pStr = PtrToStringChars(s);
+				CefString cefStr(pStr);
+				result.push_back(cefStr);
+			}
+
+			return result;
+		}
 
         [DebuggerStepThrough]
         void StringUtils::AssignNativeFromClr(cef_string_t& cefStr, String^ str)

--- a/CefSharp.Core/Internals/StringUtils.h
+++ b/CefSharp.Core/Internals/StringUtils.h
@@ -6,6 +6,7 @@
 #pragma once
 
 using namespace System;
+using namespace System::Collections::Generic;
 
 namespace CefSharp
 {
@@ -28,6 +29,13 @@ namespace CefSharp
             /// <returns>A .NET string.</returns>
             static String^ ToClr(const CefString& cefStr);
 
+			/// <summary>
+			/// Converts an unmanaged vector of strings to a (managed) .NET List of strings.
+			/// </summary>
+			/// <param name="cefStr">The vector of strings that should be converted.</param>
+			/// <returns>A .NET string.</returns>
+			static List<String^>^ ToClr(const std::vector<CefString>& cefStr);
+
             /// <summary>
             /// Converts a .NET string to native (unmanaged) format. Note that this method does not allocate a new copy of the
             // string, but rather returns a pointer to the memory in the existing managed String object.
@@ -35,6 +43,13 @@ namespace CefSharp
             /// <param name="str">The string that should be converted.</param>
             /// <returns>An unmanaged representation of the provided string, or an empty string if the input string is a nullptr.</returns>
             static CefString ToNative(String^ str);
+
+			/// <summary>
+			/// Converts a .NET List of strings to native (unmanaged) format.
+			/// </summary>
+			/// <param name="str">The List of strings that should be converted.</param>
+			/// <returns>An unmanaged representation of the provided List of strings, or an empty List if the input is a nullptr.</returns>
+			static std::vector<CefString> ToNative(List<String^>^ str);
 
             /// <summary>
             /// Assigns the provided cef_string_t object from the given .NET string.

--- a/CefSharp.WinForms/WebView.cs
+++ b/CefSharp.WinForms/WebView.cs
@@ -16,7 +16,8 @@ namespace CefSharp.WinForms
         public bool IsLoading { get; set; }
         public string TooltipText { get; set; }
         public string Address { get; set; }
-                
+
+        public IDialogHandler DialogHandler { get; set; }
         public IJsDialogHandler JsDialogHandler { get; set; }
         public IKeyboardHandler KeyboardHandler { get; set; }
         public IRequestHandler RequestHandler { get; set; }

--- a/CefSharp.Wpf/WebView.cs
+++ b/CefSharp.Wpf/WebView.cs
@@ -42,6 +42,7 @@ namespace CefSharp.Wpf
 
         public BrowserSettings BrowserSettings { get; set; }
         public bool IsBrowserInitialized { get; private set; }
+        public IDialogHandler DialogHandler { get; set; }
         public IJsDialogHandler JsDialogHandler { get; set; }
         public IKeyboardHandler KeyboardHandler { get; set; }
         public IRequestHandler RequestHandler { get; set; }

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -86,6 +86,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IDialogHandler.cs" />
     <Compile Include="Internals\BitmapInfo.cs" />
     <Compile Include="Internals\ManagedCefApp.cs" />
     <Compile Include="CefCustomScheme.cs" />

--- a/CefSharp/IDialogHandler.cs
+++ b/CefSharp/IDialogHandler.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+namespace CefSharp
+{
+    public interface IDialogHandler
+    {
+        bool OnOpenFile(IWebBrowser browser, string title, string default_file_name, List<string> accept_types, out List<string> result);
+    }
+}

--- a/CefSharp/Internals/IWebBrowserInternal.cs
+++ b/CefSharp/Internals/IWebBrowserInternal.cs
@@ -9,6 +9,7 @@ namespace CefSharp.Internals
         ILifeSpanHandler LifeSpanHandler { get; set; }
         IKeyboardHandler KeyboardHandler { get; set; }
         IJsDialogHandler JsDialogHandler { get; set; }
+        IDialogHandler DialogHandler { get; set; }
 
         void OnInitialized();
 

--- a/CefSharp3.sln
+++ b/CefSharp3.sln
@@ -47,6 +47,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CefSharp.Core", "CefSharp.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CefSharp", "CefSharp\CefSharp.csproj", "{A55848CC-10E7-40CB-ADDB-04740B16DD43}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A3BF0056-FB83-4682-9130-6EDAB93CB5B9}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32


### PR DESCRIPTION
Example usage...

```
public class SilentDialogHandler : IDialogHandler
{
    public static string FilePath;
    public bool OnOpenFile(IWebBrowser browser, string title, string default_file_name, List<string> accept_types, out List<string> result)
    {
        result = new List<string>() { FilePath };
        return true;
    }
}
```

Then make sure you set it on your view

```
webView.DialogHandler = new SilentDialogHandler();
```

then before you click a browse button, make sure you set the static FilePath field on the SilentDialogHandler class.
