### PR TITLE
Add OnRenderProcessTerminated - Resolves issue #207

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -225,6 +225,15 @@ namespace CefSharp
             }			
         }
 
+        void ClientAdapter::OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status)
+        {
+            IRequestHandler^ handler = _browserControl->RequestHandler;
+            if (handler != nullptr)
+            {
+                handler->OnRenderProcessTerminated(_browserControl, (CefTerminationStatus)status);
+            }			
+        }
+
         bool ClientAdapter::OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request)
         {
             // TOOD: Try to support with CEF3; seems quite difficult because the method signature has changed greatly with many parts

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -87,6 +87,7 @@ namespace CefSharp
             virtual DECL bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool isRedirect) OVERRIDE;
             virtual DECL bool OnBeforePluginLoad( CefRefPtr< CefBrowser > browser, const CefString& url, const CefString& policy_url, CefRefPtr< CefWebPluginInfo > info ) OVERRIDE;
             virtual DECL void OnPluginCrashed(CefRefPtr<CefBrowser> browser, const CefString& plugin_path) OVERRIDE;
+            virtual DECL void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status) OVERRIDE;
 
             // CefDisplayHandler
             virtual DECL void OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bool isLoading, bool canGoBack, bool canGoForward) OVERRIDE;

--- a/CefSharp.Example/RequestHandler.cs
+++ b/CefSharp.Example/RequestHandler.cs
@@ -48,5 +48,10 @@ namespace CefSharp.Example
             //blockPluginLoad = info.Name.ToLower().Contains("flash");
             return blockPluginLoad;
         }
+
+        void IRequestHandler.OnRenderProcessTerminated(IWebBrowser browser, CefTerminationStatus status)
+        {
+            // TODO: Add your own code here for handling scenarios where the Render Process terminated for one reason or another.
+        }
     }
 }

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -87,6 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CefFileDialogMode.cs" />
+    <Compile Include="CefTerminationStatus.cs" />
     <Compile Include="IDialogHandler.cs" />
     <Compile Include="AddressChangedEventArgs.cs" />
     <Compile Include="DownloadItem.cs" />

--- a/CefSharp/CefTerminationStatus.cs
+++ b/CefSharp/CefTerminationStatus.cs
@@ -1,0 +1,20 @@
+﻿namespace CefSharp
+{
+    public enum CefTerminationStatus
+    {
+        ///
+        // Non-zero exit status.
+        ///
+        AbnormalTermination = 0,
+
+        ///
+        // SIGKILL or task manager kill.
+        ///
+        ProcessWasKilled,
+
+        ///
+        // Segmentation fault.
+        ///
+        ProcessCrashed
+    }
+}

--- a/CefSharp/IRequestHandler.cs
+++ b/CefSharp/IRequestHandler.cs
@@ -55,5 +55,12 @@
         /// <param name="info">plugin information</param>
         /// <returns>Return true to block loading of the plugin.</returns>
         bool OnBeforePluginLoad(IWebBrowser browser, string url, string policyUrl, IWebPluginInfo info);
+
+        /// <summary>
+        /// Called when the render process terminates unexpectedly.
+        /// </summary>
+        /// <param name="browser">the browser object</param>
+        /// <param name="status">indicates how the process terminated.</param>
+        void OnRenderProcessTerminated(IWebBrowser browser, CefTerminationStatus status);
     }
 }


### PR DESCRIPTION
Basic implementation of `OnRenderProcessTerminated`
Kill `CefSharp.BrowserSubprocess` in task manager to trigger `OnRenderProcessTerminated`. Can test in the WPF Example
