### PR TITLE
Fix text rendering in WPF

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -66,7 +66,8 @@ namespace CefSharp
             HWND hwnd = HWND();
             CefWindowInfo window;
             window.SetAsOffScreen(hwnd);
-            window.SetTransparentPainting(true);
+            // Commented out as it causes fonts to be rendered without ClearType, making them blurry
+            //window.SetTransparentPainting(true);
             CefString addressNative = StringUtils::ToNative("about:blank");
 
             if (!CefBrowserHost::CreateBrowser(window, _renderClientAdapter.get(), addressNative,


### PR DESCRIPTION
Text rendered in the WPF version seems blurry. If `SetTransparentPainting` in `ManagedCefBrowserAdapter` is commented out the rendered text looks the same as in the WinForms version (and exactly the same as rendered in Chrome).

This is the standard CefSharp welcome page enlarged a bit:
![previous_zoom](https://cloud.githubusercontent.com/assets/7759875/3676464/dcacf0aa-1288-11e4-94f4-7e3e12f747bc.PNG)

The same part of the welcome page after the change:
![cleartype_zoom](https://cloud.githubusercontent.com/assets/7759875/3676465/dcafae44-1288-11e4-9eb6-62e27377d0bc.PNG)
