### PR TITLE
Fix crash when responding to cancelled request, take 2

### DIFF
--- a/CefSharp.Core/SchemeHandlerWrapper.cpp
+++ b/CefSharp.Core/SchemeHandlerWrapper.cpp
@@ -61,7 +61,11 @@ namespace CefSharp
 
         _headers = ToHeaderMap(response->ResponseHeaders);
 
-        _callback->Continue();
+        // If CEF has cancelled the initial request, throw away a response that comes afterwards.
+        if (_callback != nullptr)
+        {
+            _callback->Continue();
+        }
 
         // Must be done AFTER CEF has been allowed to consume the headers etc. After this call is made, the SchemeHandlerWrapper
         // instance has likely been deallocated.


### PR DESCRIPTION
I use an ISchemeHandler that accepts a long-polling AJAX request, and responds some time later. If CEF cancels the SchemeHandlerWrapper (e.g. due to navigating to another URL), and my response later attempts to call the response completed callback, a NullReferenceException occurs.

I debated whether to add an IsCancelled flag and make the ISchemeHandler implementer check this flag before responding, but just throwing away the response seems less error-prone.
