### PR TITLE
Implemented OnStatusMessage and event for WPF and WinForms for CefSharp1

### DIFF
--- a/CefSharp.WinForms/WebView.cpp
+++ b/CefSharp.WinForms/WebView.cpp
@@ -332,6 +332,11 @@ namespace WinForms
         ConsoleMessage(this, gcnew ConsoleMessageEventArgs(message, source, line));
     }
 
+    void WebView::OnStatusMessage(String^ value, StatusType type)
+    {
+        StatusMessage(this, gcnew StatusMessageEventArgs(value, type));
+    }
+
     void WebView::OnFrameLoadStart(String^ url)
     {
         _browserCore->OnFrameLoadStart();

--- a/CefSharp.WinForms/WebView.h
+++ b/CefSharp.WinForms/WebView.h
@@ -44,6 +44,7 @@ namespace WinForms
         }
 
         virtual event ConsoleMessageEventHandler^ ConsoleMessage;
+        virtual event StatusMessageEventHandler^ StatusMessage;
         virtual event KeyEventHandler^ BrowserKey;
         virtual event LoadCompletedEventHandler^ LoadCompleted;
 
@@ -185,6 +186,7 @@ namespace WinForms
         virtual void OnFrameLoadEnd(String^ url);
         virtual void OnTakeFocus(bool next);
         virtual void OnConsoleMessage(String^ message, String^ source, int line);
+        virtual void OnStatusMessage(String^ value, StatusType type);
 
         virtual void RegisterJsObject(String^ name, Object^ objectToBind);
         virtual IDictionary<String^, Object^>^ GetBoundObjects();

--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -613,6 +613,11 @@ namespace CefSharp
             ConsoleMessage(this, gcnew ConsoleMessageEventArgs(message, source, line));
         }
 
+        void WebView::OnStatusMessage(String^ value, StatusType type)
+        {
+            StatusMessage(this, gcnew StatusMessageEventArgs(value, type));
+        }
+
         void WebView::RegisterJsObject(String^ name, Object^ objectToBind)
         {
             _browserCore->RegisterJsObject(name, objectToBind);

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -126,6 +126,7 @@ namespace CefSharp
             }
 
             virtual event ConsoleMessageEventHandler^ ConsoleMessage;
+            virtual event StatusMessageEventHandler^ StatusMessage;
             virtual event KeyEventHandler^ BrowserKey;
             virtual event LoadCompletedEventHandler^ LoadCompleted;
 
@@ -295,6 +296,7 @@ namespace CefSharp
             virtual void OnFrameLoadEnd(String^ url);
             virtual void OnTakeFocus(bool next);
             virtual void OnConsoleMessage(String^ message, String^ source, int line);
+            virtual void OnStatusMessage(String^ value, StatusType type);
 
             virtual void RegisterJsObject(String^ name, Object^ objectToBind);
             virtual IDictionary<String^, Object^>^ GetBoundObjects();

--- a/CefSharp/CefSharp.vcxproj
+++ b/CefSharp/CefSharp.vcxproj
@@ -176,6 +176,8 @@
     <ClInclude Include="ScriptCore.h" />
     <ClInclude Include="ScriptException.h" />
     <ClInclude Include="Settings.h" />
+    <ClInclude Include="StatusMessageEventArgs.h" />
+    <ClInclude Include="StatusType.h" />
     <ClInclude Include="Stdafx.h" />
     <ClInclude Include="StreamAdapter.h" />
     <ClInclude Include="StringUtil.h" />

--- a/CefSharp/CefSharp.vcxproj.filters
+++ b/CefSharp/CefSharp.vcxproj.filters
@@ -190,5 +190,11 @@
     <ClInclude Include="ISchemeHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="StatusMessageEventArgs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="StatusType.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -12,6 +12,7 @@
 #include "IMenuHandler.h"
 #include "IKeyboardHandler.h"
 #include "IJsDialogHandler.h"
+#include "StatusType.h"
 
 using namespace std;
 using namespace CefSharp::Internals::JavascriptBinding;
@@ -97,6 +98,12 @@ namespace CefSharp
         _browserControl->OnConsoleMessage(messageStr, sourceStr, line);
 
         return true;
+    }
+
+    void ClientAdapter::OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefString& value, CefDisplayHandler::StatusType type)
+    {
+        String^ valueStr = toClr(value);
+        _browserControl->OnStatusMessage(valueStr, (CefSharp::StatusType)type);
     }
 
     bool ClientAdapter::OnKeyEvent(CefRefPtr<CefBrowser> browser, KeyEventType type, int code, int modifiers, bool isSystemKey, bool isAfterJavaScript)

--- a/CefSharp/ClientAdapter.h
+++ b/CefSharp/ClientAdapter.h
@@ -69,6 +69,7 @@ namespace CefSharp
         virtual DECL void OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) OVERRIDE;
         virtual DECL bool OnTooltip(CefRefPtr<CefBrowser> browser, CefString& text) OVERRIDE;
         virtual DECL bool OnConsoleMessage(CefRefPtr<CefBrowser> browser, const CefString& message, const CefString& source, int line) OVERRIDE;
+        virtual DECL void OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefString& value, CefDisplayHandler::StatusType type) OVERRIDE;
 
         // CefV8ContextHandler
         virtual DECL void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context) OVERRIDE;

--- a/CefSharp/IWebBrowser.h
+++ b/CefSharp/IWebBrowser.h
@@ -4,6 +4,8 @@
 #include "BrowserCore.h"
 #include "ConsoleMessageEventArgs.h"
 #include "LoadCompletedEventArgs.h"
+#include "StatusMessageEventArgs.h"
+#include "StatusType.h"
 
 using namespace System;
 using namespace System::ComponentModel;
@@ -69,6 +71,7 @@ namespace CefSharp
         void OnFrameLoadEnd(String^ url);
         void OnTakeFocus(bool next);
         void OnConsoleMessage(String^ message, String^ source, int line);
+        void OnStatusMessage(String^ value, StatusType type);
 
         void RegisterJsObject(String^ name, Object^ objectToBind);
         IDictionary<String^, Object^>^ GetBoundObjects();

--- a/CefSharp/StatusMessageEventArgs.h
+++ b/CefSharp/StatusMessageEventArgs.h
@@ -1,0 +1,24 @@
+#include "Stdafx.h"
+#pragma once
+
+#include "StatusType.h"
+
+using namespace System;
+
+namespace CefSharp
+{
+    public ref class StatusMessageEventArgs : EventArgs
+    {
+        String^ _value;
+        StatusType _type;
+
+    public:
+        StatusMessageEventArgs(String^ value, StatusType type)
+            : _value(value), _type(type) {}
+
+        property String^ Value { String^ get() { return _value; } }
+        property StatusType Type { StatusType get() { return _type; } }
+    };
+
+    public delegate void StatusMessageEventHandler(Object^ sender, StatusMessageEventArgs^ e);
+}

--- a/CefSharp/StatusType.h
+++ b/CefSharp/StatusType.h
@@ -1,0 +1,12 @@
+#include "Stdafx.h"
+#pragma once
+
+namespace CefSharp
+{
+    public enum class StatusType
+    {
+        Text = STATUSTYPE_TEXT,
+        MouseoverUrl = STATUSTYPE_MOUSEOVER_URL,
+        KeyboardFocusUrl = STATUSTYPE_KEYBOARD_FOCUS_URL,
+    };
+}


### PR DESCRIPTION
We're using CefSharp1 because CefSharp3 is quite unstable for us. I've implemented `OnStatusMessage` and a `StatusMessage` event for both the WPF and WinForms `WebView` controls.

A couple of things I wasn't sure about:
1. The naming/placement of the `StatusType` enum. I've been consistent with .NET conventions and kept it in its own file. Other declared enums went with their handler, but this patch doesn't have an associated handler class.
2. Are we OK with just using the event handler (similar to how `OnConsoleMessage` is done)?
3. Should `StatusType` have `MouseOverUrl` instead of `MouseoverUrl`. I was going along with the casing conventions from the CEF enum.

I've ported this PR to CefSharp3 too (#443).
