### PR TITLE
provide access to settings boolean ignore_certificate_errors

### DIFF
--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -89,6 +89,12 @@ namespace CefSharp
             void set(String^ value) override { StringUtils::AssignNativeFromClr(_cefSettings->cache_path, value); }
         }
 
+        virtual property bool IgnoreCertificateErrors
+        {
+            bool get() { return _cefSettings->ignore_certificate_errors; }
+            void set(bool value) { _cefSettings->ignore_certificate_errors = value; }
+        }
+
         virtual property String^ Locale
         {
             String^ get() override { return StringUtils::ToClr(_cefSettings->locale); }


### PR DESCRIPTION
ignore_certificate_errors  setting was added upstream over a year ago,  it would be nice to have access to it.
https://code.google.com/p/chromiumembedded/issues/detail?id=345&can=1&q=certificate
