### PR TITLE
WinForms: don't report size changed when Size is 0x0.

### DIFF
--- a/CefSharp.WinForms/CefSharp.WinForms.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -140,7 +140,9 @@ namespace CefSharp.WinForms
         protected override void OnSizeChanged(EventArgs e)
         {
             base.OnSizeChanged(e);
-            if (managedCefBrowserAdapter != null)
+
+            // Size is 0x0 when we are on a modeless Form which is minimized.
+            if (!Size.IsEmpty && managedCefBrowserAdapter != null)
                 managedCefBrowserAdapter.OnSizeChanged(Handle);
         }
 


### PR DESCRIPTION
This occurs when the control is on a modeless Form and it is minimized.  Similar guard as in my PR is in cefclient.

To reproduce the problem, replace BrowserFormLoad() in CefSharp.WinForms.Example\BrowserForm.cs with the following...

```
    private void BrowserFormLoad(object sender, EventArgs e)
    {
        ToggleBottomToolStrip();

        Form f = new Form();
        f.Controls.Add(new ChromiumWebBrowser(CefExample.DefaultUrl) {
            Dock = DockStyle.Fill,
        });
        f.Show();
    }
```

Then,
1. start the example app,
2. minimize the new modeless dialog,
3. then restore it.
4. Observe that Chrome has not been repainted, and the form's grey background is showing.
