### PR TITLE
WinForms Bug - OnSizeChanged

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -469,7 +469,7 @@ namespace CefSharp
                 *(CefBrowserSettings*) browserSettings->_internalBrowserSettings, NULL);
         }
 
-        void OnSizeChanged(IntPtr^ sourceHandle)
+        void OnPaint(IntPtr^ sourceHandle)
         {
             HWND hWnd = static_cast<HWND>(sourceHandle->ToPointer());
             RECT rect;

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -59,13 +59,6 @@ namespace CefSharp.WinForms
             Paint += OnPaint;
         }
 
-        private void OnPaint(object sender, PaintEventArgs e)
-        {
-            // Size is 0x0 when we are on a modeless Form which is minimized.
-            if (!Size.IsEmpty && managedCefBrowserAdapter != null)
-                managedCefBrowserAdapter.OnSizeChanged(Handle);
-        }
-
         protected override void Dispose(bool disposing)
         {
             Paint -= OnPaint;
@@ -351,6 +344,15 @@ namespace CefSharp.WinForms
             var taskStringVisitor = new TaskStringVisitor();
             managedCefBrowserAdapter.GetText(taskStringVisitor);
             return taskStringVisitor.Task;
+        }
+
+        private void OnPaint(object sender, PaintEventArgs e)
+        {
+            // Size is 0x0 when we are on a modeless Form which is minimized.
+            if (!Size.IsEmpty && managedCefBrowserAdapter != null)
+            {
+                managedCefBrowserAdapter.OnPaint(Handle);
+            }
         }
     }
 }


### PR DESCRIPTION
Creates a unique PR that fixes a bug in the `WinForms` control when running in a tabbed environment.

With running the browser in tabs, sometimes the dimensions go askew when updating the size on `OnSizeChanged`, so doing it `OnPaint` (which is actually called fewer times and is potentially more efficient).
