### PR TITLE
Bump `cef.sdk` package to 3.2062.1876-pre1 with VS2013 specific libs too

### DIFF
--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.3.2062.1876-pre0\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.3.2062.1876-pre0\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.3.2062.1876-pre1\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.3.2062.1876-pre1\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -66,7 +66,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>11.0.51106.1</_ProjectFileVersion>
-    <NuGetPackageImportStamp>692f35e4</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>9aa99f24</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>bin\$(Configuration)\</OutDir>
@@ -285,6 +285,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\cef.sdk.3.2062.1876-pre0\build\cef.sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.sdk.3.2062.1876-pre0\build\cef.sdk.props'))" />
+    <Error Condition="!Exists('..\packages\cef.sdk.3.2062.1876-pre1\build\cef.sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.sdk.3.2062.1876-pre1\build\cef.sdk.props'))" />
   </Target>
 </Project>

--- a/CefSharp.Core/packages.config
+++ b/CefSharp.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="3.2062.1876-pre0" targetFramework="Native" />
+  <package id="cef.sdk" version="3.2062.1876-pre1" targetFramework="Native" />
 </packages>

--- a/build.ps1
+++ b/build.ps1
@@ -5,7 +5,7 @@ param(
     [Parameter(Position = 1)]
     [string] $Version = "37.0.0",
     [Parameter(Position = 2)]
-    [string] $RedistVersion = "3.2062.1856"
+    [string] $RedistVersion = "3.2062.1876"
 )
 
 $WorkingDir = split-path -parent $MyInvocation.MyCommand.Definition


### PR DESCRIPTION
BTW I guess we have to exercise "the split" on x86/x64 a bit on this branch with how it affects NuGet users (and prepare some communication?). We can use `CefSharp.MinimalExample` + start from scratch scenarios like the one painfully documented  in #520 for that.

Maybe we can even move `CefSharp.*` packages a bit more towards a more normal NuGet structure with `lib` folders and such? We just need to find a way to make sure we can still install both `x86` and `x64` in parallel - or should we go for a `AnyCPU` package? 

Hmm - forgive me for thinking out loud above - I hope _some_ of it brings us forward though ;)
