### PR TITLE
Fix: js bindings must be kept by browser, not by process

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -16,40 +16,35 @@ using namespace System::Collections::Generic;
 
 namespace CefSharp
 {
-	private class CefAppUnmanagedWrapper : CefApp, CefRenderProcessHandler
-	{
-	private:
-		gcroot<Action<CefBrowserWrapper^>^> _onBrowserCreated;
-		gcroot<Action<CefBrowserWrapper^>^> _onBrowserDestroyed;
-		gcroot<JavascriptRootObject^> _javascriptRootObject;
-		gcroot<Func<IBrowserProcess^>^> _createBrowserProxyDelegate;
-		gcroot<Dictionary<int, CefBrowserWrapper^>^> _browserWrappers;
-	public:
-		
-		CefAppUnmanagedWrapper(Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestoryed)
-		{
-			_onBrowserCreated = onBrowserCreated;
-			_onBrowserDestroyed = onBrowserDestoryed;
-			_browserWrappers = gcnew Dictionary<int, CefBrowserWrapper^>();
-		}
+    private class CefAppUnmanagedWrapper : CefApp, CefRenderProcessHandler
+    {
+    private:
+        gcroot<Action<CefBrowserWrapper^>^> _onBrowserCreated;
+        gcroot<Action<CefBrowserWrapper^>^> _onBrowserDestroyed;
+        gcroot<Dictionary<int, CefBrowserWrapper^>^> _browserWrappers;
+        CefBrowserWrapper^ FindBrowserWrapper(CefRefPtr<CefBrowser> browser, bool mustExist);
+    public:
+        
+        CefAppUnmanagedWrapper(Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestoryed)
+        {
+            _onBrowserCreated = onBrowserCreated;
+            _onBrowserDestroyed = onBrowserDestoryed;
+            _browserWrappers = gcnew Dictionary<int, CefBrowserWrapper^>();
+        }
 
-		~CefAppUnmanagedWrapper()
-		{
-			delete _browserWrappers;
-			delete _javascriptRootObject;
-			delete _onBrowserCreated;
-			delete _onBrowserDestroyed;
-			delete _createBrowserProxyDelegate;
-		}
+        ~CefAppUnmanagedWrapper()
+        {
+            delete _browserWrappers;
+            delete _onBrowserCreated;
+            delete _onBrowserDestroyed;
+        }
 
-		virtual DECL CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() OVERRIDE;
-		virtual DECL void OnBrowserCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
-		virtual DECL void OnBrowserDestroyed(CefRefPtr<CefBrowser> browser) OVERRIDE;
-		virtual DECL void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context) OVERRIDE;
-		virtual DECL void OnContextReleased(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context) OVERRIDE;
+        virtual DECL CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() OVERRIDE;
+        virtual DECL void OnBrowserCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
+        virtual DECL void OnBrowserDestroyed(CefRefPtr<CefBrowser> browser) OVERRIDE;
+        virtual DECL void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context) OVERRIDE;
+        virtual DECL void OnContextReleased(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context) OVERRIDE;
 
-		void Bind(JavascriptRootObject^ rootObject, Func<IBrowserProcess^>^ createBrowserProxyDelegate);
-
-		IMPLEMENT_REFCOUNTING(CefAppUnmanagedWrapper);
-	};
+        IMPLEMENT_REFCOUNTING(CefAppUnmanagedWrapper);
+    };
 }

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
@@ -38,11 +38,4 @@ namespace CefSharp
 
         return CefExecuteProcess(cefMainArgs, (CefApp*)_cefApp.get(), NULL);
     }
-    
-    void CefAppWrapper::Bind(JavascriptRootObject^ rootObject, Func<IBrowserProcess^>^ createBrowserProxyDelegate)
-    {
-        auto app = _cefApp.get();
-        
-        app->Bind(rootObject, createBrowserProxyDelegate);
-    }
 }

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
@@ -29,8 +29,6 @@ namespace CefSharp
 
 		property TaskFactory^ RenderThreadTaskFactory;
 
-		void Bind(JavascriptRootObject^ rootObject, Func<IBrowserProcess^>^ createBrowserProxyDelegate);
-
 		virtual void OnBrowserCreated(CefBrowserWrapper^ cefBrowserWrapper) abstract;
 		virtual void OnBrowserDestroyed(CefBrowserWrapper^ cefBrowserWrapper) abstract;		
 	};

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -42,6 +42,8 @@ namespace CefSharp
         property int BrowserId;
         property bool IsPopup;
         property DuplexChannelFactory<IBrowserProcess^>^ ChannelFactory;
+        property JavascriptRootObject^ JavascriptRootObject;
+        property Func<IBrowserProcess^>^ CreateBrowserProxyDelegate;
 
         JavascriptResponse^ EvaluateScriptInContext(CefRefPtr<CefV8Context> context, CefString script)
         {

--- a/CefSharp.BrowserSubprocess/CefRenderProcess.cs
+++ b/CefSharp.BrowserSubprocess/CefRenderProcess.cs
@@ -72,7 +72,8 @@ namespace CefSharp.BrowserSubprocess
 
                 if (javascriptObject.MemberObjects.Count > 0)
                 {
-                    Bind(javascriptObject, channelFactory.CreateChannel);
+                    browser.JavascriptRootObject = javascriptObject;
+                    browser.CreateBrowserProxyDelegate = channelFactory.CreateChannel;
                 }
 
                 browser.ChannelFactory = channelFactory;


### PR DESCRIPTION
When `renderer-process-limit` is set to a low value (1) and multiple browser instances are used, all browser instances end up using the same JS binding object (the last one registered). 

The root cause is that the binding is kept per process (`CefAppUnmanagedWrapper`) instead of per browser instance (`CefBrowserWrapper`). 

The fix is to move the bindings from `CefAppUnmanagedWrapper` to `CefBrowserWrapper` class. I deleted the `Bind` method because it was no longer used.

---

According to [this comment](https://code.google.com/p/chromium/codesearch#chromium/src/content/public/common/content_switches.cc&q=kRendererProcessLimit&sq=package:chromium&type=cs&l=710) the number of processes is a calculated value. 

On our PCs we always get one process per browser instance if we use the defaut value for `renderer-process-limit`. Each process consumes at least 20 MB. Because our app may open up to 20 browser instances, we've decided to set `renderer-process-limit` to 5 to limit the memory consumed by our app.

We think this bug may occur even if you don't change `renderer-process-limit` because at some point, the number of browser instances can probably exceed the _calculated limit to the number of renderer processes_.
