### PR TITLE
Cleanup Loading and NavState code

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -62,8 +62,6 @@ namespace CefSharp
 
         void ClientAdapter::OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bool isLoading, bool canGoBack, bool canGoForward)
         {
-            _browserControl->SetIsLoading(isLoading);
-
             auto canReload = !isLoading;
             _browserControl->SetNavState(canGoBack, canGoForward, canReload);
         }
@@ -163,7 +161,6 @@ namespace CefSharp
             if (frame->IsMain())
             {
                 _browserControl->SetIsLoading(true);
-                _browserControl->SetNavState(false, false, false);
             }
 
             _browserControl->OnFrameLoadStart(StringUtils::ToClr(frame->GetURL()), frame->IsMain());


### PR DESCRIPTION
Cleanup Loading and NavState code, there's currently additional calls to both which are slightly confusing (and don't provide any benefit).

So simplify by setting SetIsLoading(true) on LoadStart and SetIsLoading(false) on LoadEnd. Then only set NavState in ClientAdapter::OnLoadingStateChange

Needs a little more testing before merge.
