### PR TITLE
Add navigation type to IRequest.

### DIFF
--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -96,5 +96,10 @@ namespace CefSharp
 
             _wrappedRequest->SetHeaderMap(hm);
         }
+
+        CefSharp::NavigationType CefRequestWrapper::NavigationType::get()
+        {
+            return (CefSharp::NavigationType) _wrappedRequest->GetTransitionType();
+        }
     }
 }

--- a/CefSharp.Core/Internals/CefRequestWrapper.h
+++ b/CefSharp.Core/Internals/CefRequestWrapper.h
@@ -33,6 +33,7 @@ namespace CefSharp
             virtual property String^ Method { String^ get(); }
             virtual property String^ Body { String^ get(); }
             virtual property NameValueCollection^ Headers { NameValueCollection^ get(); void set(NameValueCollection^ url); }
+            virtual property CefSharp::NavigationType NavigationType { CefSharp::NavigationType get(); }
 
         };
     }

--- a/CefSharp/IRequest.cs
+++ b/CefSharp/IRequest.cs
@@ -6,11 +6,22 @@ using System.Collections.Specialized;
 
 namespace CefSharp
 {
+    public enum NavigationType
+    {
+        LinkClicked,
+        FormSubmitted,
+        BackForward,
+        Reload,
+        FormResubmitted,
+        Other
+    };
+
     public interface IRequest
     {
         string Url { get; set; }
         string Method { get; }
         string Body { get; }
         NameValueCollection Headers { get; set; }
+        NavigationType NavigationType { get; }
     }
 }


### PR DESCRIPTION
OnBeforeNavigation was deprecated in CEF and OnBeforeBrowse has not navigation type parameter anymore. So there is no way to get this info now. In this feature navigation type added in request interfacce accordingly CEF.
