### PR TITLE
Fixed #542: Forward Ctrl key state for WPF

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -708,6 +708,23 @@ namespace CefSharp.Wpf
               modifiers |= CefEventFlags.ControlDown | CefEventFlags.IsRight;
             }
 
+            if (Keyboard.IsKeyDown(Key.LeftShift))
+            {
+              modifiers |= CefEventFlags.ShiftDown | CefEventFlags.IsLeft;
+            }
+
+            if (Keyboard.IsKeyDown(Key.RightShift)) {
+              modifiers |= CefEventFlags.ShiftDown | CefEventFlags.IsRight;
+            }
+
+            if (Keyboard.IsKeyDown(Key.LeftAlt)) {
+              modifiers |= CefEventFlags.AltDown| CefEventFlags.IsLeft;
+            }
+
+            if (Keyboard.IsKeyDown(Key.RightAlt)) {
+              modifiers |= CefEventFlags.AltDown | CefEventFlags.IsRight;
+            }
+
             return modifiers;
         }
 


### PR DESCRIPTION
When building the CefEventFlags to be forwarded to CEF, consider the
current state of the left and right control key.
