### PR TITLE
Fixed mouse leave event issue (focus not entirely gone)

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -883,7 +883,7 @@ namespace CefSharp.Wpf
         protected override void OnMouseLeave(MouseEventArgs e)
         {
             var modifiers = GetModifiers(e);
-            managedCefBrowserAdapter.OnMouseMove(0, 0, true, modifiers);
+            managedCefBrowserAdapter.OnMouseMove(-1, -1, true, modifiers);
         }
 
         private void OnMouseButton(MouseButtonEventArgs e)


### PR DESCRIPTION
Cursor remained at 0,0 coordinate, and would mouse-over any element in the top left corner.
Just changed to -1,-1 and problem fixed :)
