### PR TITLE
Fix #517 tooltip issue

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -177,6 +177,11 @@ namespace CefSharp
                 mouseEvent.modifiers = (uint32)modifiers;
 
                 cefHost->SendMouseMoveEvent(mouseEvent, mouseLeave);
+
+                if (mouseLeave == true)
+                {
+                    _webBrowserInternal->SetTooltipText(nullptr);
+                }
             }
         }
 


### PR DESCRIPTION
Tooltip remains visible when loosing mouse focus by a popup opening directly on top of the browser (where the cursor is positioned)
