### PR TITLE
CefRenderProcess process creates too many channels and does not close them

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -50,7 +50,7 @@ namespace CefSharp
         {
             auto window = context->GetGlobal();
 
-            auto jsRootWrapper = gcnew JavascriptRootObjectWrapper(wrapper->JavascriptRootObject, wrapper->CreateBrowserProxyDelegate);
+            auto jsRootWrapper = gcnew JavascriptRootObjectWrapper(wrapper->JavascriptRootObject, wrapper->BrowserProcess);
 
             jsRootWrapper->V8Value = window;
             jsRootWrapper->Bind();

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -43,7 +43,7 @@ namespace CefSharp
         property bool IsPopup;
         property DuplexChannelFactory<IBrowserProcess^>^ ChannelFactory;
         property JavascriptRootObject^ JavascriptRootObject;
-        property Func<IBrowserProcess^>^ CreateBrowserProxyDelegate;
+        property IBrowserProcess^ BrowserProcess;
 
         JavascriptResponse^ EvaluateScriptInContext(CefRefPtr<CefV8Context> context, CefString script)
         {

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
@@ -22,8 +22,6 @@ namespace CefSharp
 
     BrowserProcessResponse^ JavascriptMethodWrapper::Execute(array<Object^>^ parameters)
     {
-        auto browserProxy = _createBrowserProxyDelegate();
-
-        return browserProxy->CallMethod(_ownerId, _javascriptMethod->JavascriptName, parameters);
+        return _browserProcess->CallMethod(_ownerId, _javascriptMethod->JavascriptName, parameters);
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
@@ -19,17 +19,17 @@ namespace CefSharp
         MCefRefPtr<JavascriptMethodHandler> _javascriptMethodHandler;
         JavascriptMethod^ _javascriptMethod;
         int64 _ownerId;
-        Func<IBrowserProcess^>^ _createBrowserProxyDelegate;
+        IBrowserProcess^ _browserProcess;
 
     internal:
         MCefRefPtr<CefV8Value> V8Value;
 
     public:
-        JavascriptMethodWrapper(JavascriptMethod^ javascriptMethod, int64 ownerId, Func<IBrowserProcess^>^ createBrowserProxyDelegate)
+        JavascriptMethodWrapper(JavascriptMethod^ javascriptMethod, int64 ownerId, IBrowserProcess^ browserProcess)
         {
             _javascriptMethod = javascriptMethod;
             _ownerId = ownerId;
-            _createBrowserProxyDelegate = createBrowserProxyDelegate;
+            _browserProcess = browserProcess;
             _javascriptMethodHandler = new JavascriptMethodHandler(gcnew Func<array<Object^>^, BrowserProcessResponse^>(this, &JavascriptMethodWrapper::Execute));
         }
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
@@ -28,7 +28,7 @@ namespace CefSharp
 
 		for each (JavascriptMethod^ method in Enumerable::OfType<JavascriptMethod^>(_object->Methods))
 		{
-			auto wrappedMethod = gcnew JavascriptMethodWrapper(method, _object->Id, _createBrowserProxyDelegate);
+			auto wrappedMethod = gcnew JavascriptMethodWrapper(method, _object->Id, _browserProcess);
 			wrappedMethod->V8Value = javascriptObject;
 			wrappedMethod->Bind();
 
@@ -37,7 +37,7 @@ namespace CefSharp
 
 		for each (JavascriptProperty^ prop in Enumerable::OfType<JavascriptProperty^>(_object->Properties))
 		{
-			auto wrappedproperty = gcnew JavascriptPropertyWrapper(prop, _object->Id, _createBrowserProxyDelegate);
+			auto wrappedproperty = gcnew JavascriptPropertyWrapper(prop, _object->Id, _browserProcess);
 			wrappedproperty->V8Value = javascriptObject;
 			wrappedproperty->Bind();
 
@@ -47,15 +47,11 @@ namespace CefSharp
 
 	BrowserProcessResponse^ JavascriptObjectWrapper::GetProperty(String^ memberName)
 	{
-		auto browserProxy = _createBrowserProxyDelegate();
-
-		return browserProxy->GetProperty(_object->Id, memberName);
+		return _browserProcess->GetProperty(_object->Id, memberName);
 	};
 
 	BrowserProcessResponse^ JavascriptObjectWrapper::SetProperty(String^ memberName, Object^ value)
 	{
-		auto browserProxy = _createBrowserProxyDelegate();
-
-		return browserProxy->SetProperty(_object->Id, memberName, value);
+		return _browserProcess->SetProperty(_object->Id, memberName, value);
 	};
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
@@ -24,17 +24,17 @@ namespace CefSharp
         JavascriptObject^ _object;
         List<JavascriptMethodWrapper^>^ _wrappedMethods;
         List<JavascriptPropertyWrapper^>^ _wrappedProperties;
-        Func<IBrowserProcess^>^ _createBrowserProxyDelegate;
+        IBrowserProcess^ _browserProcess;
 
     internal:
         MCefRefPtr<CefV8Value> V8Value;
         MCefRefPtr<JavascriptPropertyHandler> JsPropertyHandler;
 
     public:
-        JavascriptObjectWrapper(JavascriptObject^ object, Func<IBrowserProcess^>^ createBrowserProxyDelegate)
+        JavascriptObjectWrapper(JavascriptObject^ object, IBrowserProcess^ browserProcess)
         {
             _object = object;
-            _createBrowserProxyDelegate = createBrowserProxyDelegate;
+            _browserProcess = browserProcess;
 
             _wrappedMethods = gcnew List<JavascriptMethodWrapper^>();
             _wrappedProperties = gcnew List<JavascriptPropertyWrapper^>();

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
@@ -19,7 +19,7 @@ namespace CefSharp
 
         if (_javascriptProperty->IsComplexType)
         {
-            auto wrapperObject = gcnew JavascriptObjectWrapper(_javascriptProperty->JsObject, _createBrowserProxyDelegate);
+            auto wrapperObject = gcnew JavascriptObjectWrapper(_javascriptProperty->JsObject, _browserProcess);
             wrapperObject->V8Value = V8Value.get();
             wrapperObject->Bind();
         }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
@@ -18,17 +18,17 @@ namespace CefSharp
     private:
         JavascriptProperty^ _javascriptProperty;
         int64 _ownerId;
-        Func<IBrowserProcess^>^ _createBrowserProxyDelegate;
+        IBrowserProcess^ _browserProcess;
 
     internal:
         MCefRefPtr<CefV8Value> V8Value;
 
     public:
-        JavascriptPropertyWrapper(JavascriptProperty^ javascriptProperty, int64 ownerId, Func<IBrowserProcess^>^ createBrowserProxyDelegate)
+        JavascriptPropertyWrapper(JavascriptProperty^ javascriptProperty, int64 ownerId, IBrowserProcess^ browserProcess)
         {
             _javascriptProperty = javascriptProperty;
             _ownerId = ownerId;
-            _createBrowserProxyDelegate = createBrowserProxyDelegate;
+            _browserProcess = browserProcess;
         }
 
         ~JavascriptPropertyWrapper()

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -24,16 +24,16 @@ namespace CefSharp
     private:
         JavascriptRootObject^ _rootObject;
         List<JavascriptObjectWrapper^>^ _wrappedObjects;
-        Func<IBrowserProcess^>^ _createBrowserProxyDelegate;
+        IBrowserProcess^ _browserProcess;
 
     internal:
         MCefRefPtr<CefV8Value> V8Value;
 
     public:
-        JavascriptRootObjectWrapper(JavascriptRootObject^ rootObject, Func<IBrowserProcess^>^ createBrowserProxyDelegate)
+        JavascriptRootObjectWrapper(JavascriptRootObject^ rootObject, IBrowserProcess^ browserProcess)
         {
             _rootObject = rootObject;
-            _createBrowserProxyDelegate = createBrowserProxyDelegate;
+            _browserProcess = browserProcess;
             _wrappedObjects = gcnew List<JavascriptObjectWrapper^>();
         }
 
@@ -41,13 +41,13 @@ namespace CefSharp
         {
             V8Value = nullptr;
         }
-        
+
         void Bind()
         {
             auto memberObjects = _rootObject->MemberObjects;
             for each (JavascriptObject^ obj in Enumerable::OfType<JavascriptObject^>(memberObjects))
             {
-                auto wrapperObject = gcnew JavascriptObjectWrapper(obj, _createBrowserProxyDelegate);
+                auto wrapperObject = gcnew JavascriptObjectWrapper(obj, _browserProcess);
                 wrapperObject->V8Value = V8Value.get();
                 wrapperObject->Bind();
 

--- a/CefSharp.BrowserSubprocess/CefRenderProcess.cs
+++ b/CefSharp.BrowserSubprocess/CefRenderProcess.cs
@@ -58,30 +58,26 @@ namespace CefSharp.BrowserSubprocess
 
             channelFactory.Open();
 
-            var proxy = channelFactory.CreateChannel();
+            var browserProcess = channelFactory.CreateChannel();
+            var clientChannel = ((IClientChannel)browserProcess);
 
-            var clientChannel = ((IClientChannel)proxy);
-            
             try
             {
                 clientChannel.Open();
+                browserProcess.Connect();
 
-                proxy.Connect();
-
-                var javascriptObject = proxy.GetRegisteredJavascriptObjects();
+                var javascriptObject = browserProcess.GetRegisteredJavascriptObjects();
 
                 if (javascriptObject.MemberObjects.Count > 0)
                 {
                     browser.JavascriptRootObject = javascriptObject;
-                    browser.CreateBrowserProxyDelegate = channelFactory.CreateChannel;
                 }
 
                 browser.ChannelFactory = channelFactory;
-
+                browser.BrowserProcess = browserProcess;
             }
             catch(Exception)
             {
-
             }
         }
 
@@ -96,8 +92,15 @@ namespace CefSharp.BrowserSubprocess
                 channelFactory.Close();
             }
 
+            var clientChannel = ((IClientChannel)browser.BrowserProcess);
+
+            if (clientChannel.State == CommunicationState.Opened)
+            {
+                clientChannel.Close();
+            }
+
             browser.ChannelFactory = null;
-            browser.CreateBrowserProxyDelegate = null;
+            browser.BrowserProcess = null;
             browser.JavascriptRootObject = null;
         }
 

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -33,6 +33,20 @@
             </script>
         </p>
 
+        <p>
+            Stress Test
+            <br />
+            <script type="text/javascript">
+                var stressTestCallCount = 1000;
+                for (var i = 1; i <= stressTestCallCount; i++) {
+                    bound.repeat("hi ", 5);
+                }
+
+                document.write("Stress Test done with : " + stressTestCallCount + " call to bound.repeat(\"hi \", 5)");
+            </script>
+        </p>
+
+
         Methods on bound object 'bound':<br />
         <ul>
             <script type="text/javascript">


### PR DESCRIPTION
This PR is a re-submission of https://github.com/cefsharp/CefSharp/pull/589 based on `master`. Here is the original description. 
# 

We found out that if the JavaScript code calls into the host application (via the JS binding) too aggressively (a thousand times in a row), the application hangs. 

Although we cannot explain the symptom (the hang itself), we know that it's caused by the fact that the channels created by the renderer are never closed. 

A fix would be to close the channel after each usage (after each call to `_createBrowserProxyDelegate();`) like this:

```
  auto browserProxy = _createBrowserProxyDelegate();
  auto clientChannel = ((IClientChannel)browserProxy);
  auto result = browserProxy->DoSomeThing();
  clientChannel->Close();
  return result;
```

This fix works, however, we also realized that this is creating a new channel for each call from the `CefRenderProcess` to the host application. This is unnecessary and slows down things a lot. With a channel-per-call, making 10,000 calls takes about 10 seconds. With a channel-per-browser, making 10,000 calls takes about 4.5 seconds. 

Therefore, this change includes: 
- Modifications to use only one channel 
- Modifications to the sample application to add a load test 
  - You can try it first with no modifications to the code. It always hangs before it reaches 1000 calls.  
  - Then you can try it with the correct disposal of the channel. Now it finishes. 
  - Then you can test it with the final code. Now it finishes fast.  
# 
