### PR TITLE
Allow sending MouseWheel events to the browser

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -122,6 +122,11 @@ namespace CefSharp.WinForms
             return managedCefBrowserAdapter.EvaluateScriptAsync(script, timeout);
         }
 
+        public void SendMouseWheelEvent(int x, int y, int deltaX, int deltaY)
+        {
+            managedCefBrowserAdapter.OnMouseWheel(x, y, deltaX, deltaY);
+        }
+
         public event EventHandler<LoadErrorEventArgs> LoadError;
         public event EventHandler<FrameLoadStartEventArgs> FrameLoadStart;
         public event EventHandler<FrameLoadEndEventArgs> FrameLoadEnd;


### PR DESCRIPTION
Hi this change is to allow sending MouseWheel events to the browser. We need this to support scrolling in the browser even when the browser is not `Focused`. In the host application we handle all mouse wheel events and if the mouse is over the browser, we dispatch the message to the browser.
