### PR TITLE
fix #553 by handling Initial resize and OnSizeChanged

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -481,16 +481,10 @@ namespace CefSharp
                 *(CefBrowserSettings*)browserSettings->_internalBrowserSettings, NULL);
         }
 
-        void OnPaint(IntPtr^ sourceHandle)
+        void Resize(int width, int height)
         {
-            HWND hWnd = static_cast<HWND>(sourceHandle->ToPointer());
-            RECT rect;
-            GetClientRect(hWnd, &rect);
-            HDWP hdwp = BeginDeferWindowPos(1);
-
             HWND browserHwnd = _renderClientAdapter->GetBrowserHwnd();
-            hdwp = DeferWindowPos(hdwp, browserHwnd, NULL, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, SWP_NOZORDER);
-            EndDeferWindowPos(hdwp);
+            SetWindowPos(browserHwnd, NULL, 0, 0, width, height, SWP_NOZORDER);
         }
 
         void RegisterJsObject(String^ name, Object^ object)

--- a/CefSharp.WinForms.Example/BrowserForm.cs
+++ b/CefSharp.WinForms.Example/BrowserForm.cs
@@ -40,7 +40,11 @@ namespace CefSharp.WinForms.Example
             {
                 Dock = DockStyle.Fill
             };
-            
+
+            //This call isn't required for the sample to work. 
+            //It's sole purpose is to demonstrate that #553 has been resolved.
+            browser.CreateControl();
+
             tabPage.Controls.Add(browser);
 
             if (insertIndex == null)

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -53,18 +53,11 @@ namespace CefSharp.WinForms
             Cef.AddDisposable(this);
             Address = address;
 
-            Paint += OnPaint;
-
-            //Redraw on Resize so Cef is notified and updates accordingly
-            SetStyle(ControlStyles.ResizeRedraw, true);
-
             Dock = DockStyle.Fill;
         }
 
         protected override void Dispose(bool disposing)
         {
-            Paint -= OnPaint;
-
             Cef.RemoveDisposable(this);
 
             if (disposing)
@@ -81,6 +74,8 @@ namespace CefSharp.WinForms
         void IWebBrowserInternal.OnInitialized()
         {
             IsBrowserInitialized = true;
+
+            ResizeBrowser();
 
             var handler = IsBrowserInitializedChanged;
 
@@ -349,12 +344,20 @@ namespace CefSharp.WinForms
             return taskStringVisitor.Task;
         }
 
-        private void OnPaint(object sender, PaintEventArgs e)
+        protected override void OnSizeChanged(EventArgs e)
         {
-            // Size is 0x0 when we are on a modeless Form which is minimized.
-            if (!Size.IsEmpty && managedCefBrowserAdapter != null)
+            base.OnSizeChanged(e);
+            if (managedCefBrowserAdapter != null)
             {
-                managedCefBrowserAdapter.OnPaint(Handle);
+                ResizeBrowser();
+            }
+        }
+
+        private void ResizeBrowser()
+        {
+            if (IsBrowserInitialized)
+            {
+                managedCefBrowserAdapter.Resize(Width, Height);
             }
         }
     }


### PR DESCRIPTION
This fixes two things:

1st, After re-sizing sometimes the browser does not react correctly. Changed from handling/forcing `OnPaint` to handling  `OnSizeChanged`.

2nd, #553 : The line added to `CefSharp.WinForms.Example\BrowserForm.cs` causes the bug. The call to `Resize()` inside `IWebBrowserInternal.OnInitialized` fixes it.
