### PR TITLE
Implement Focused property

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -344,6 +344,32 @@ namespace CefSharp.WinForms
             return taskStringVisitor.Task;
         }
 
+        /// <summary>
+        /// Manually implement Focused because cef does not implement it.
+        /// </summary>
+        /// <remarks>
+        /// This is also how the Microsoft's WebBrowserControl implements the Focused property.
+        /// </remarks>
+        public override bool Focused
+        {
+            get
+            {
+                if (base.Focused)
+                {
+                    return true;
+                }
+
+                if (!IsHandleCreated)
+                {
+                    return false;
+                }
+
+                // Ask Windows which control has the focus and then check if it's one of our children
+                IntPtr focus = User32.GetFocus();
+                return focus != IntPtr.Zero && User32.IsChild(Handle, focus);
+            }
+        }
+
         protected override void OnSizeChanged(EventArgs e)
         {
             base.OnSizeChanged(e);

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CefFileDialogMode.cs" />
+    <Compile Include="Internals\User32.cs" />
     <Compile Include="IsBrowserInitializedChangedEventArgs.cs" />
     <Compile Include="CefTerminationStatus.cs" />
     <Compile Include="IDialogHandler.cs" />

--- a/CefSharp/Internals/User32.cs
+++ b/CefSharp/Internals/User32.cs
@@ -1,0 +1,18 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace CefSharp.Internals
+{
+    public static class User32
+    {
+        [DllImport("User32.dll")]
+        public extern static IntPtr GetFocus();
+
+        [DllImport("user32.dll")]
+        public extern static bool IsChild(IntPtr parent, IntPtr child);
+    }
+}


### PR DESCRIPTION
Issue: `ChromiumWebBrowser.Focused` is always `false`
Cause : cef does not implement focused correctly (seems related to https://code.google.com/p/chromiumembedded/issues/detail?id=563)
Fix : Manually implement Focused
How to test: 
- In the Windows Form sample, replace the Go Button event handler by `MessageBox.Show(((Control)Browser).Focused.ToString())`. 
- run
- give the focus the the browser
- click Go
- result : false
- apply fix
- tests again 
- **result : true**
- click the address bar (to remove focus)
- click Go
- result : false

I think this should fix #570. However if it does not, then this fix is still relevant to any code that relies on the `Focused` property. I did not test the WPF side of this at all.

Background: We've been running with this fix for a while now (before we started contributing to this project). I recalled this fix while reading #570 so here is the PR (I'll be able to remove this from our custom ChromiumWebBrowser derived class too).
