### PR TITLE
Feature: Expose OnCertificateError to allow host application to decide whether or not it should continue

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -207,6 +207,23 @@ namespace CefSharp
             return handler->OnBeforeBrowse(_browserControl, wrapper, isRedirect);
         }
 
+        bool ClientAdapter::OnCertificateError(cef_errorcode_t cert_error, const CefString& request_url, CefRefPtr<CefAllowCertificateErrorCallback> callback)
+        {
+            IRequestHandler^ handler = _browserControl->RequestHandler;
+            if (handler == nullptr)
+            {
+                return false;
+            }
+
+            if (handler->OnCertificateError(_browserControl, (CefErrorCode)cert_error, StringUtils::ToClr(request_url)))
+            {
+                callback->Continue(true);
+                return true;
+            }
+
+            return false;
+        }
+
         // CEF3 API: public virtual bool OnBeforePluginLoad( CefRefPtr< CefBrowser > browser, const CefString& url, const CefString& policy_url, CefRefPtr< CefWebPluginInfo > info );
         // ---
         // return value:

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -87,6 +87,8 @@ namespace CefSharp
             virtual DECL bool GetAuthCredentials(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, bool isProxy,
                 const CefString& host, int port, const CefString& realm, const CefString& scheme, CefRefPtr<CefAuthCallback> callback) OVERRIDE;
             virtual DECL bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool isRedirect) OVERRIDE;
+            virtual DECL bool OnCertificateError(cef_errorcode_t cert_error, const CefString& request_url, CefRefPtr<CefAllowCertificateErrorCallback> callback) OVERRIDE;            
+
             virtual DECL bool OnBeforePluginLoad( CefRefPtr< CefBrowser > browser, const CefString& url, const CefString& policy_url, CefRefPtr< CefWebPluginInfo > info ) OVERRIDE;
             virtual DECL void OnPluginCrashed(CefRefPtr<CefBrowser> browser, const CefString& plugin_path) OVERRIDE;
             virtual DECL void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status) OVERRIDE;

--- a/CefSharp.Example/RequestHandler.cs
+++ b/CefSharp.Example/RequestHandler.cs
@@ -14,6 +14,11 @@ namespace CefSharp.Example
             return false;
         }
 
+        bool IRequestHandler.OnCertificateError(IWebBrowser browser, CefErrorCode errorCode, string requestUrl)
+        {
+            return false;
+        }
+
         void IRequestHandler.OnPluginCrashed(IWebBrowser browser, string pluginPath)
         {
             // TODO: Add your own code here for handling scenarios where a plugin crashed, for one reason or another.

--- a/CefSharp.WinForms.Example/BrowserTabUserControl.cs
+++ b/CefSharp.WinForms.Example/BrowserTabUserControl.cs
@@ -24,6 +24,7 @@ namespace CefSharp.WinForms.Example
             Browser = browser;
 
             browser.MenuHandler = new MenuHandler();
+            browser.RequestHandler = new RequestHandler();
             browser.NavStateChanged += OnBrowserNavStateChanged;
             browser.ConsoleMessage += OnBrowserConsoleMessage;
             browser.TitleChanged += OnBrowserTitleChanged;

--- a/CefSharp/IRequestHandler.cs
+++ b/CefSharp/IRequestHandler.cs
@@ -19,6 +19,15 @@ namespace CefSharp
         bool OnBeforeBrowse(IWebBrowser browser, IRequest request, bool isRedirect);
 
         /// <summary>
+        /// Called when a certificate error is thrown.
+        /// </summary>
+        /// <param name="browser">the browser object</param>
+        /// <param name="errorCode">the error code for this invalid certificate</param>
+        /// <param name="requestUrl">the url of the request for the invalid certificate</param>
+        /// <returns>Return true to allow the invalid certificate and continue the request.</returns>
+        bool OnCertificateError(IWebBrowser browser, CefErrorCode errorCode, string requestUrl);
+
+        /// <summary>
         /// Called when a plugin has crashed
         /// </summary>
         /// <param name="browser">the browser object</param>


### PR DESCRIPTION
This change adds `OnCertificateError` to the  `IRequestHandler` interface. 

Implementers that are not interested in handling certificate errors should return `false` to indicate that the browser must not proceed with an invalid certificate. 

However, applications that what to proceed (after prompting the user) can now implement `OnCertificateError` and return `true` to proceed even if there is a certificate error.
