### PR TITLE
Fix 641 - Memory leak: JavascriptRootObjectWrapper is not released on Reload

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -50,15 +50,22 @@ namespace CefSharp
         {
             auto window = context->GetGlobal();
 
-            auto jsRootWrapper = gcnew JavascriptRootObjectWrapper(wrapper->JavascriptRootObject, wrapper->BrowserProcess);
+            wrapper->JavascriptRootObjectWrapper = gcnew JavascriptRootObjectWrapper(wrapper->JavascriptRootObject, wrapper->BrowserProcess);
 
-            jsRootWrapper->V8Value = window;
-            jsRootWrapper->Bind();
+            wrapper->JavascriptRootObjectWrapper->V8Value = window;
+            wrapper->JavascriptRootObjectWrapper->Bind();
         }
     };
 
     void CefAppUnmanagedWrapper::OnContextReleased(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context)
-    {        
+    { 
+        auto wrapper = FindBrowserWrapper(browser, true);
+
+        if (wrapper->JavascriptRootObjectWrapper != nullptr)
+        {
+            delete wrapper->JavascriptRootObjectWrapper;
+            wrapper->JavascriptRootObjectWrapper = nullptr;
+        }
     };
 
     CefBrowserWrapper^ CefAppUnmanagedWrapper::FindBrowserWrapper(CefRefPtr<CefBrowser> browser, bool mustExist)

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -43,6 +43,7 @@ namespace CefSharp
         property bool IsPopup;
         property DuplexChannelFactory<IBrowserProcess^>^ ChannelFactory;
         property JavascriptRootObject^ JavascriptRootObject;
+        property JavascriptRootObjectWrapper^ JavascriptRootObjectWrapper;
         property IBrowserProcess^ BrowserProcess;
 
         JavascriptResponse^ EvaluateScriptInContext(CefRefPtr<CefV8Context> context, CefString script)

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
@@ -23,6 +23,7 @@ namespace CefSharp
 
 		//V8Value that represents this javascript object - only one per complex type
 		auto javascriptObject = V8Value->CreateObject(JsPropertyHandler.get());
+
 		auto objectName = StringUtils::ToNative(_object->JavascriptName);
 		V8Value->SetValue(objectName, javascriptObject, V8_PROPERTY_ATTRIBUTE_NONE);
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
@@ -9,6 +9,7 @@
 
 #include "JavascriptMethodWrapper.h"
 #include "JavascriptPropertyWrapper.h"
+#include "JavascriptPropertyHandler.h"
 
 using namespace System::Runtime::Serialization;
 using namespace System::Linq;
@@ -43,7 +44,17 @@ namespace CefSharp
         ~JavascriptObjectWrapper()
         {
             V8Value = nullptr;
+            JsPropertyHandler->DeleteGetterSetter();
             JsPropertyHandler = nullptr;
+
+            for each (JavascriptMethodWrapper^ var in _wrappedMethods)
+            {
+                delete var;
+            }
+            for each (JavascriptPropertyWrapper^ var in _wrappedProperties)
+            {
+                delete var;
+            }
         }
 
         void Bind();

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
@@ -25,6 +25,11 @@ namespace CefSharp
             _setter = setter;
         }
 
+        void DeleteGetterSetter(){
+            delete _getter;
+            delete _setter;
+        }
+
         ~JavascriptPropertyHandler()
         {
             delete _getter;

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
@@ -19,9 +19,11 @@ namespace CefSharp
 
         if (_javascriptProperty->IsComplexType)
         {
-            auto wrapperObject = gcnew JavascriptObjectWrapper(_javascriptProperty->JsObject, _browserProcess);
-            wrapperObject->V8Value = V8Value.get();
-            wrapperObject->Bind();
+            auto javascriptObjectWrapper = gcnew JavascriptObjectWrapper(_javascriptProperty->JsObject, _browserProcess);
+            javascriptObjectWrapper->V8Value = V8Value.get();
+            javascriptObjectWrapper->Bind();
+
+            _javascriptObjectWrapper = javascriptObjectWrapper;
         }
         else
         {

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
@@ -7,7 +7,7 @@
 #include "Stdafx.h"
 #include "include/cef_v8.h"
 
-#include "JavascriptPropertyHandler.h"
+#include "JavascriptMethodWrapper.h"
 
 using namespace CefSharp::Internals;
 
@@ -19,7 +19,7 @@ namespace CefSharp
         JavascriptProperty^ _javascriptProperty;
         int64 _ownerId;
         IBrowserProcess^ _browserProcess;
-
+        Object^ _javascriptObjectWrapper;
     internal:
         MCefRefPtr<CefV8Value> V8Value;
 
@@ -34,6 +34,12 @@ namespace CefSharp
         ~JavascriptPropertyWrapper()
         {
             V8Value = nullptr;
+
+            if (_javascriptObjectWrapper != nullptr)
+            {
+                delete _javascriptObjectWrapper;
+                _javascriptObjectWrapper = nullptr;
+            }
         }
 
         void Bind();

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -40,6 +40,10 @@ namespace CefSharp
         ~JavascriptRootObjectWrapper()
         {
             V8Value = nullptr;
+            for each (JavascriptObjectWrapper^ var in _wrappedObjects)
+            {
+                delete var;
+            }
         }
 
         void Bind()


### PR DESCRIPTION
Temporary fix for #641 until a better fix is found. See discussion on #641 for more detail.
