### PR TITLE
NotifyMoveOrResizeStarted Method & Resize Function Changes

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -51,8 +51,6 @@ namespace CefSharp
     public:
 
 
-
-
         ManagedCefBrowserAdapter(IWebBrowserInternal^ webBrowserInternal)
         {
             _renderClientAdapter = new RenderClientAdapter(webBrowserInternal, gcnew Action<int>(this, &ManagedCefBrowserAdapter::OnAfterBrowserCreated));
@@ -510,12 +508,10 @@ namespace CefSharp
             }
         }
 
-
         void RegisterJsObject(String^ name, Object^ object)
         {
             _javaScriptObjectRepository->Register(name, object);
         }
-
 
         void ReplaceMisspelling(String^ word)
         {

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -34,7 +34,6 @@ namespace CefSharp.WinForms
         public bool CanReload { get; private set; }
         public bool IsBrowserInitialized { get; private set; }
 
-
         public double ZoomLevel
         {
             get { return managedCefBrowserAdapter.GetZoomLevel(); }
@@ -377,7 +376,6 @@ namespace CefSharp.WinForms
         {
             managedCefBrowserAdapter.AddWordToDictionary(word);
         }
-
 
     }
 }


### PR DESCRIPTION
Changed Resize function to better match the CefClient's - This maintains the fixes of #553, while resolving some issues in #656
Add NotifyMoveOrResizeStarted Method fixes some of #656 and #657 

Does not completely fix since we need to find a way to determine if the control was moved on screen.  OnlocationChange and OnMove do not fire.
