### PR TITLE
change c++ file copyright symbol (©) encoding to work on non-english system

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2013 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2013 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2013 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.h
+++ b/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2013 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.h
+++ b/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.h
+++ b/CefSharp.BrowserSubprocess.Core/CefTaskScheduler.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2013 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 #pragma once

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/Stdafx.h
+++ b/CefSharp.BrowserSubprocess.Core/Stdafx.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2013 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/Stdafx.h
+++ b/CefSharp.BrowserSubprocess.Core/Stdafx.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/Stdafx.h
+++ b/CefSharp.BrowserSubprocess.Core/Stdafx.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2013 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2013 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.h
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.h
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.h
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefRequestWrapper.h
+++ b/CefSharp.Core/Internals/CefRequestWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefRequestWrapper.h
+++ b/CefSharp.Core/Internals/CefRequestWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefRequestWrapper.h
+++ b/CefSharp.Core/Internals/CefRequestWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefWebPluginInfoWrapper.cpp
+++ b/CefSharp.Core/Internals/CefWebPluginInfoWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefWebPluginInfoWrapper.cpp
+++ b/CefSharp.Core/Internals/CefWebPluginInfoWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefWebPluginInfoWrapper.cpp
+++ b/CefSharp.Core/Internals/CefWebPluginInfoWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefWebPluginInfoWrapper.h
+++ b/CefSharp.Core/Internals/CefWebPluginInfoWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefWebPluginInfoWrapper.h
+++ b/CefSharp.Core/Internals/CefWebPluginInfoWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Project. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CefWebPluginInfoWrapper.h
+++ b/CefSharp.Core/Internals/CefWebPluginInfoWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Project. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CookieVisitor.h
+++ b/CefSharp.Core/Internals/CookieVisitor.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CookieVisitor.h
+++ b/CefSharp.Core/Internals/CookieVisitor.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/CookieVisitor.h
+++ b/CefSharp.Core/Internals/CookieVisitor.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/DownloadAdapter.h
+++ b/CefSharp.Core/Internals/DownloadAdapter.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/DownloadAdapter.h
+++ b/CefSharp.Core/Internals/DownloadAdapter.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/DownloadAdapter.h
+++ b/CefSharp.Core/Internals/DownloadAdapter.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/MCefRefPtr.h
+++ b/CefSharp.Core/Internals/MCefRefPtr.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/MCefRefPtr.h
+++ b/CefSharp.Core/Internals/MCefRefPtr.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/MCefRefPtr.h
+++ b/CefSharp.Core/Internals/MCefRefPtr.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StreamAdapter.cpp
+++ b/CefSharp.Core/Internals/StreamAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StreamAdapter.cpp
+++ b/CefSharp.Core/Internals/StreamAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StreamAdapter.cpp
+++ b/CefSharp.Core/Internals/StreamAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StreamAdapter.h
+++ b/CefSharp.Core/Internals/StreamAdapter.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StreamAdapter.h
+++ b/CefSharp.Core/Internals/StreamAdapter.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StreamAdapter.h
+++ b/CefSharp.Core/Internals/StreamAdapter.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringUtils.cpp
+++ b/CefSharp.Core/Internals/StringUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringUtils.cpp
+++ b/CefSharp.Core/Internals/StringUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringUtils.cpp
+++ b/CefSharp.Core/Internals/StringUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringUtils.h
+++ b/CefSharp.Core/Internals/StringUtils.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringUtils.h
+++ b/CefSharp.Core/Internals/StringUtils.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringUtils.h
+++ b/CefSharp.Core/Internals/StringUtils.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringVisitor.cpp
+++ b/CefSharp.Core/Internals/StringVisitor.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringVisitor.cpp
+++ b/CefSharp.Core/Internals/StringVisitor.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringVisitor.cpp
+++ b/CefSharp.Core/Internals/StringVisitor.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringVisitor.h
+++ b/CefSharp.Core/Internals/StringVisitor.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringVisitor.h
+++ b/CefSharp.Core/Internals/StringVisitor.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/StringVisitor.h
+++ b/CefSharp.Core/Internals/StringVisitor.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/MouseButtonType.h
+++ b/CefSharp.Core/MouseButtonType.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/MouseButtonType.h
+++ b/CefSharp.Core/MouseButtonType.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/MouseButtonType.h
+++ b/CefSharp.Core/MouseButtonType.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerResponse.cpp
+++ b/CefSharp.Core/SchemeHandlerResponse.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerResponse.cpp
+++ b/CefSharp.Core/SchemeHandlerResponse.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerResponse.cpp
+++ b/CefSharp.Core/SchemeHandlerResponse.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerResponse.h
+++ b/CefSharp.Core/SchemeHandlerResponse.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerResponse.h
+++ b/CefSharp.Core/SchemeHandlerResponse.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerResponse.h
+++ b/CefSharp.Core/SchemeHandlerResponse.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerWrapper.cpp
+++ b/CefSharp.Core/SchemeHandlerWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerWrapper.cpp
+++ b/CefSharp.Core/SchemeHandlerWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerWrapper.cpp
+++ b/CefSharp.Core/SchemeHandlerWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerWrapper.h
+++ b/CefSharp.Core/SchemeHandlerWrapper.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerWrapper.h
+++ b/CefSharp.Core/SchemeHandlerWrapper.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/SchemeHandlerWrapper.h
+++ b/CefSharp.Core/SchemeHandlerWrapper.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Stdafx.cpp
+++ b/CefSharp.Core/Stdafx.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Stdafx.cpp
+++ b/CefSharp.Core/Stdafx.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Stdafx.cpp
+++ b/CefSharp.Core/Stdafx.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Stdafx.h
+++ b/CefSharp.Core/Stdafx.h
@@ -1,4 +1,4 @@
-// Copyright � 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Stdafx.h
+++ b/CefSharp.Core/Stdafx.h
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Stdafx.h
+++ b/CefSharp.Core/Stdafx.h
@@ -1,4 +1,4 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright Â© 2010-2014 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 


### PR DESCRIPTION
change c++ file copyright symbol (©) encoding from 0xa9(cp1252) to 0xc2 0xa9(cp65001 with bom) ,
now work on non-english system.
Note:* .cs files encoded correct, do not need changes.