### PR TITLE
Added Drag Drop support to allow dragging objects into the browser

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -1,0 +1,3 @@
+SET ThisScriptsDirectory=%~dp0
+SET PowerShellScriptPath=%ThisScriptsDirectory%Build.ps1
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File ""%PowerShellScriptPath%""' -Verb RunAs}";

--- a/CefSharp.Core/Internals/CefDragDataWrapper.h
+++ b/CefSharp.Core/Internals/CefDragDataWrapper.h
@@ -41,6 +41,24 @@ namespace CefSharp
             virtual property bool IsFragment;
             virtual property bool IsLink;
 
+            ///
+            // Create a new CefDragData object.
+            ///
+            /*--cef()--*/
+            static CefDragDataWrapper^ Create(){
+                CefRefPtr<CefDragData> cefDragData = CefDragData::Create();
+                return gcnew CefDragDataWrapper(cefDragData);
+            }
+
+
+            virtual property CefRefPtr<CefDragData>* _internalDragData
+            {
+                CefRefPtr<CefDragData>* get() 
+                { 
+                    return new CefRefPtr<CefDragData>(_wrappedDragData.get()); 
+                }
+            }
+
             //TODO: Vector is a pointer, so can potentially be updated (items may be possibly removed)
             virtual property IList<String^>^ FileNames
             {

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -9,6 +9,7 @@
 #include "MouseButtonType.h"
 #include "PaintElementType.h"
 #include "Internals/ClientAdapter.h"
+#include "Internals/CefDragDataWrapper.h"
 #include "Internals/RenderClientAdapter.h"
 #include "Internals/MCefRefPtr.h"
 #include "Internals/StringVisitor.h"
@@ -667,5 +668,60 @@ namespace CefSharp
                 browser->GetHost()->AddWordToDictionary(wordNative);
             }
         }
+
+        CefMouseEvent GetCefMouseEvent(IMouseEvent^ mouseEvent){
+            CefMouseEvent cefMouseEvent;
+            cefMouseEvent.x = mouseEvent->X;
+            cefMouseEvent.y = mouseEvent->Y;
+            cefMouseEvent.modifiers = (uint32)mouseEvent->Modifiers;
+            return cefMouseEvent;
+        }
+
+        void OnDragTargetDragEnter(CefDragDataWrapper^ dragData, IMouseEvent^ mouseEvent, CefDragOperationsMask allowedOperations)
+        {
+            auto browser = _clientAdapter->GetCefBrowser();
+
+            if (browser != nullptr)
+            {
+                dragData->ResetFileContents(); // Recommended by documentation to reset before calling DragEnter
+                browser->GetHost()->DragTargetDragEnter(*dragData->_internalDragData, GetCefMouseEvent(mouseEvent), (CefBrowserHost::DragOperationsMask) allowedOperations);
+            }
+        }
+
+
+
+
+        void OnDragTargetDragOver(IMouseEvent^ mouseEvent, CefDragOperationsMask allowedOperations)
+        {
+            auto browser = _clientAdapter->GetCefBrowser();
+
+            if (browser != nullptr)
+            {
+                browser->GetHost()->DragTargetDragOver(GetCefMouseEvent(mouseEvent), (CefBrowserHost::DragOperationsMask) allowedOperations);
+            }
+        }
+
+
+        void OnDragTargetDragLeave()
+        {
+            auto browser = _clientAdapter->GetCefBrowser();
+
+            if (browser != nullptr)
+            {
+                browser->GetHost()->DragTargetDragLeave();
+            }
+        }
+
+
+        void OnDragTargetDragDrop(IMouseEvent^ mouseEvent)
+        {
+            auto browser = _clientAdapter->GetCefBrowser();
+
+            if (browser != nullptr)
+            {
+                browser->GetHost()->DragTargetDrop(GetCefMouseEvent(mouseEvent));
+            }
+        }
+
     };
 }

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
@@ -172,6 +172,7 @@
                                   Opacity="{Binding ElementName=opacitySlider, Path=Value}"
                                   Address="{Binding Address, Mode=TwoWay}"
                                   Title="{Binding Title, Mode=OneWayToSource}"
+                                  AllowDrop="True"
                                   WebBrowser="{Binding WebBrowser, Mode=OneWayToSource}">
                     <!-- Just an example of how you may override the BrowserSettings. Disabled by default since it looks so
                          incredibly ugly... -->

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -7,7 +7,9 @@ using CefSharp.Internals;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -422,6 +424,12 @@ namespace CefSharp.Wpf
             GotKeyboardFocus += OnGotKeyboardFocus;
             LostKeyboardFocus += OnLostKeyboardFocus;
 
+            // Drag Drop events
+            DragEnter += OnDragEnter;
+            DragOver += OnDragOver;
+            DragLeave += OnDragLeave;
+            Drop += OnDrop;
+
             IsVisibleChanged += OnIsVisibleChanged;
 
             ToolTip = toolTip = new ToolTip();
@@ -458,6 +466,151 @@ namespace CefSharp.Wpf
 
             PresentationSource.AddSourceChangedHandler(this, PresentationSourceChangedHandler);
         }
+
+        void OnDrop(object sender, DragEventArgs e)
+        {
+            managedCefBrowserAdapter.OnDragTargetDragDrop(GetMouseEvent(e));
+        }
+
+        void OnDragLeave(object sender, DragEventArgs e)
+        {
+            managedCefBrowserAdapter.OnDragTargetDragLeave();
+        }
+
+        void OnDragOver(object sender, DragEventArgs e)
+        {
+            managedCefBrowserAdapter.OnDragTargetDragOver(GetMouseEvent(e), GetDragOperationsMask(e.AllowedEffects));
+        }
+
+        
+
+        void OnDragEnter(object sender, DragEventArgs e)
+        {
+            managedCefBrowserAdapter.OnDragTargetDragEnter(GetDragDataWrapper(e), GetMouseEvent(e), GetDragOperationsMask(e.AllowedEffects));
+        }
+
+        /// <summary>
+        /// Converts .NET drag drop effects to CEF Drag Operations
+        /// </summary>s
+        private CefDragOperationsMask GetDragOperationsMask(DragDropEffects dragDropEffects)
+        {
+            var operations = CefDragOperationsMask.None;
+
+            if (dragDropEffects.HasFlag(DragDropEffects.All))
+            {
+                operations |= CefDragOperationsMask.Every;
+            }
+            if (dragDropEffects.HasFlag(DragDropEffects.Copy))
+            {
+                operations |= CefDragOperationsMask.Copy;
+            }
+            if (dragDropEffects.HasFlag(DragDropEffects.Move))
+            {
+                operations |= CefDragOperationsMask.Move;
+            }
+            if (dragDropEffects.HasFlag(DragDropEffects.Link))
+            {
+                operations |= CefDragOperationsMask.Link;
+            }
+
+            return operations;
+        
+        }
+
+        private CefDragDataWrapper GetDragDataWrapper(DragEventArgs e)
+        {
+            // Convert Drag Data
+            var dragData = CefDragDataWrapper.Create();
+
+            // Files            
+            dragData.IsFile = e.Data.GetDataPresent(DataFormats.FileDrop);
+            if (dragData.IsFile)
+            {
+                // As per documentation, we only need to specify FileNames, not FileName, when dragging into the browser (http://magpcss.org/ceforum/apidocs3/projects/(default)/CefDragData.html)
+                foreach (var filePath in (string[])e.Data.GetData(DataFormats.FileDrop))
+                {
+                    var displayName = System.IO.Path.GetFileName(filePath);
+
+                    dragData.AddFile(filePath.Replace("\\", "/"), displayName);
+                }
+            }
+
+            // Link/Url
+            var link = GetLink(e.Data);
+            dragData.IsLink = !string.IsNullOrEmpty(link);
+            if (dragData.IsLink)
+            {
+                dragData.LinkUrl = link;
+            }
+
+            // Text/HTML
+            dragData.IsFragment = e.Data.GetDataPresent(DataFormats.Text);
+            if (dragData.IsFragment)
+            {
+                dragData.FragmentText = (string)e.Data.GetData(DataFormats.Text);
+                dragData.FragmentHtml = (string)e.Data.GetData(DataFormats.Html);
+            }
+
+            
+
+            
+            
+
+            return dragData;
+        }
+
+        private string GetLink(IDataObject data)
+        {
+            const string asciiUrlDataFormatName = "UniformResourceLocator";
+            const string unicodeUrlDataFormatName = "UniformResourceLocatorW";
+
+            // Try Unicode
+            if (data.GetDataPresent(unicodeUrlDataFormatName))
+            {
+                // Try to read a Unicode URL from the data
+                var unicodeUrl = ReadUrlFromDragDropData(data, unicodeUrlDataFormatName, Encoding.Unicode);
+                if (unicodeUrl != null)
+                {
+                    return unicodeUrl;
+                }
+            }
+            
+            // Try ASCII
+            if (data.GetDataPresent(asciiUrlDataFormatName)){
+                // Try to read an ASCII URL from the data
+                return ReadUrlFromDragDropData(data, asciiUrlDataFormatName, Encoding.ASCII);
+            }
+
+            // Not a valid link
+            return null;
+
+        }
+
+
+        /// <summary>Reads a URL using a particular text encoding from drag-and-drop data.</summary>
+        /// <param name="data">The drag-and-drop data.</param>
+        /// <param name="urlDataFormatName">The data format name of the URL type.</param>
+        /// <param name="urlEncoding">The text encoding of the URL type.</param>
+        /// <returns>A URL, or <see langword="null"/> if <paramref name="data"/> does not contain a URL
+        /// of the correct type.</returns>
+        private string ReadUrlFromDragDropData(IDataObject data, string urlDataFormatName, Encoding urlEncoding)
+        {
+            // Read the URL from the data
+            string url;
+            using (Stream urlStream = (Stream)data.GetData(urlDataFormatName))
+            {
+                using (TextReader reader = new StreamReader(urlStream, urlEncoding))
+                {
+                    url = reader.ReadToEnd();
+                }
+            }
+
+            // URLs in drag/drop data are often padded with null characters so remove these
+            return url.TrimEnd('\0');
+        }
+
+
+
 
         ~ChromiumWebBrowser()
         {
@@ -736,6 +889,37 @@ namespace CefSharp.Wpf
             UiThreadRunAsync(() => { popup.IsOpen = isOpen; });
         }
 
+        /// <summary>
+        /// Converts a .NET Mouse event to a CefSharp MouseEvent
+        /// </summary>
+        private MouseEvent GetMouseEvent(MouseEventArgs e)
+        {
+            var point = GetPixelPosition(e);
+            var modifiers = GetModifiers(e);
+
+            return new MouseEvent
+            {
+                X = (int)point.X,
+                Y = (int)point.Y,
+                Modifiers = modifiers
+            };
+        }
+
+        /// <summary>
+        /// Converts a .NET Drag event to a CefSharp MouseEvent
+        /// </summary>
+        private MouseEvent GetMouseEvent(DragEventArgs e)
+        {
+            var point = e.GetPosition(this);
+
+            return new MouseEvent
+            {
+                X = (int)point.X,
+                Y = (int)point.Y,
+                //Modifiers = modifiers // TODO: Add support for modifiers in drag events (might not be need as it can be accessed via the mouse events)
+            };
+        }
+
         private static CefEventFlags GetModifiers(MouseEventArgs e)
         {
             CefEventFlags modifiers = 0;
@@ -752,6 +936,7 @@ namespace CefSharp.Wpf
             {
                 modifiers |= CefEventFlags.RightMouseButton;
             }
+
 
             if (Keyboard.IsKeyDown(Key.LeftCtrl))
             {
@@ -1284,5 +1469,7 @@ namespace CefSharp.Wpf
         {
             managedCefBrowserAdapter.Invalidate(type);
         }
+
+
     }
 }

--- a/CefSharp/CefDragOperationsMask.cs
+++ b/CefSharp/CefDragOperationsMask.cs
@@ -1,0 +1,24 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Drag operation mask types
+    /// </summary>
+    [Flags]
+    public enum CefDragOperationsMask
+    {
+        None = 0,
+        Copy = 1,
+        Link = 2,
+        Generic = 4,
+        Private = 8,
+        Move = 16,
+        Delete = 32,
+        Every = int.MaxValue,
+    }
+}

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -89,7 +89,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CefFileDialogMode.cs" />
+    <Compile Include="CefDragOperationsMask.cs" />
     <Compile Include="DefaultResourceHandler.cs" />
+    <Compile Include="IMouseEvent.cs" />
+    <Compile Include="MouseEvent.cs" />
     <Compile Include="DragOperationsMask.cs" />
     <Compile Include="IDragData.cs" />
     <Compile Include="IFocusHandler.cs" />

--- a/CefSharp/IMouseEvent.cs
+++ b/CefSharp/IMouseEvent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace CefSharp
+{
+    public interface IMouseEvent
+    {
+        int X { get; set; }
+        int Y { get; set; }
+        CefEventFlags Modifiers { get; set; }
+    }
+}

--- a/CefSharp/MouseEvent.cs
+++ b/CefSharp/MouseEvent.cs
@@ -1,0 +1,17 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CefSharp
+{
+    public class MouseEvent : IMouseEvent
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public CefEventFlags Modifiers { get; set; }
+    }
+}


### PR DESCRIPTION
Supports files, links, text, html etc.
Currently only supported in WPF (would be easy to add WinForm support though, by just copy-pasting the WPF ChromiumBrowser code)

FYI #171 