### PR TITLE
Implement CefGeolocationHandler::OnRequestGeolocationPermission

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -569,5 +569,31 @@ namespace CefSharp
 
             return handler->OnDragEnter(_browserControl, dragDataWrapper, (CefSharp::DragOperationsMask)mask);
         }
+
+        bool ClientAdapter::OnRequestGeolocationPermission(CefRefPtr<CefBrowser> browser, const CefString& requesting_url, int request_id, CefRefPtr<CefGeolocationCallback> callback)
+        {
+            IGeolocationHandler^ handler = _browserControl->GeolocationHandler;
+            if (handler == nullptr)
+            {
+                // Default deny, as CEF does.
+                return false;
+            }
+
+            if (handler->OnRequestGeolocationPermission(_browserControl, StringUtils::ToClr(requesting_url), request_id)) {
+                callback->Continue(true);
+                return true;
+            }
+
+            return false;
+        }
+
+        void ClientAdapter::OnCancelGeolocationPermission(CefRefPtr<CefBrowser> browser, const CefString& requesting_url, int request_id)
+        {
+            IGeolocationHandler^ handler = _browserControl->GeolocationHandler;
+            if (handler != nullptr)
+            {
+                handler->OnCancelGeolocationPermission(_browserControl, StringUtils::ToClr(requesting_url), request_id);
+            }
+        }
     }
 }

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -579,7 +579,8 @@ namespace CefSharp
                 return false;
             }
 
-            if (handler->OnRequestGeolocationPermission(_browserControl, StringUtils::ToClr(requesting_url), request_id)) {
+            if (handler->OnRequestGeolocationPermission(_browserControl, StringUtils::ToClr(requesting_url), request_id))
+            {
                 callback->Continue(true);
                 return true;
             }

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -29,7 +29,8 @@ namespace CefSharp
             public CefKeyboardHandler,
             public CefJSDialogHandler,
             public CefDialogHandler,
-            public CefDragHandler
+            public CefDragHandler,
+            public CefGeolocationHandler
         {
         private:
             CriticalSection _syncRoot;
@@ -75,6 +76,7 @@ namespace CefSharp
             virtual CefRefPtr<CefJSDialogHandler> GetJSDialogHandler() OVERRIDE{ return this; }
             virtual CefRefPtr<CefDialogHandler> GetDialogHandler() OVERRIDE{ return this; }
             virtual CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE{ return this; }
+            virtual CefRefPtr<CefGeolocationHandler> GetGeolocationHandler() OVERRIDE{ return this; }
 
             // CefLifeSpanHandler
             virtual DECL bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
@@ -135,6 +137,11 @@ namespace CefSharp
 
             //CefDragHandler
             virtual DECL bool OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, DragOperationsMask mask) OVERRIDE;
+
+            //CefGeolocationHandler
+            virtual DECL bool OnRequestGeolocationPermission(CefRefPtr<CefBrowser> browser, const CefString& requesting_url, int request_id,
+                CefRefPtr<CefGeolocationCallback> callback) OVERRIDE;
+            virtual DECL void OnCancelGeolocationPermission(CefRefPtr<CefBrowser> browser, const CefString& requesting_url, int request_id) OVERRIDE;
 
             IMPLEMENT_REFCOUNTING(ClientAdapter);
         };

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -15,6 +15,11 @@ namespace CefSharp.Example
 
         public static void Init()
         {
+            // Set Google API keys, used for Geolocation requests sans GPS.  See http://www.chromium.org/developers/how-tos/api-keys
+            // Environment.SetEnvironmentVariable("GOOGLE_API_KEY", "");
+            // Environment.SetEnvironmentVariable("GOOGLE_DEFAULT_CLIENT_ID", "");
+            // Environment.SetEnvironmentVariable("GOOGLE_DEFAULT_CLIENT_SECRET", "");
+
             var settings = new CefSettings();
             settings.RemoteDebuggingPort = 8088;
             //settings.CefCommandLineArgs.Add("renderer-process-limit", "1");

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -169,6 +169,7 @@ namespace CefSharp.OffScreen
         public IRequestHandler RequestHandler { get; set; }
         public IDragHandler DragHandler { get; set; }
         public IResourceHandler ResourceHandler { get; set; }
+        public IGeolocationHandler GeolocationHandler { get; set; }
 
         public event EventHandler<LoadErrorEventArgs> LoadError;
         public event EventHandler<FrameLoadStartEventArgs> FrameLoadStart;

--- a/CefSharp.WinForms.Example/BrowserTabUserControl.cs
+++ b/CefSharp.WinForms.Example/BrowserTabUserControl.cs
@@ -26,6 +26,7 @@ namespace CefSharp.WinForms.Example
             browser.MenuHandler = new MenuHandler();
             browser.RequestHandler = new RequestHandler();
             browser.JsDialogHandler = new JsDialogHandler();
+            browser.GeolocationHandler = new GeolocationHandler();
             //browser.FocusHandler = new FocusHandler(browser, urlTextBox);
             browser.NavStateChanged += OnBrowserNavStateChanged;
             browser.ConsoleMessage += OnBrowserConsoleMessage;

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -78,6 +78,7 @@
       <DependentUpon>BrowserTabUserControl.cs</DependentUpon>
     </Compile>
     <Compile Include="FocusHandler.cs" />
+    <Compile Include="GeolocationHandler.cs" />
     <Compile Include="MenuHandler.cs" />
     <Compile Include="Minimal\SimpleBrowserForm.cs">
       <SubType>Form</SubType>

--- a/CefSharp.WinForms.Example/GeolocationHandler.cs
+++ b/CefSharp.WinForms.Example/GeolocationHandler.cs
@@ -11,7 +11,7 @@ namespace CefSharp.WinForms.Example
     {
         public bool OnRequestGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId)
         {
-            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?", requestingUrl), "Geolocation", MessageBoxButtons.YesNo);
+            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButtons.YesNo);
             return result == DialogResult.Yes;
         }
 

--- a/CefSharp.WinForms.Example/GeolocationHandler.cs
+++ b/CefSharp.WinForms.Example/GeolocationHandler.cs
@@ -1,0 +1,22 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Windows.Forms;
+
+namespace CefSharp.WinForms.Example
+{
+    internal class GeolocationHandler : IGeolocationHandler
+    {
+        public bool OnRequestGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId)
+        {
+            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?", requestingUrl), "Geolocation", MessageBoxButtons.YesNo);
+            return result == DialogResult.Yes;
+        }
+
+        public void OnCancelGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId)
+        {
+        }
+    }
+}

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -31,6 +31,7 @@ namespace CefSharp.WinForms
         public IFocusHandler FocusHandler { get; set; }
         public IDragHandler DragHandler { get; set; }
         public IResourceHandler ResourceHandler { get; set; }
+        public IGeolocationHandler GeolocationHandler { get; set; }
 
         public bool CanGoForward { get; private set; }
         public bool CanGoBack { get; private set; }

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -105,6 +105,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Controls\NonReloadingTabControl.cs" />
+    <Compile Include="Handlers\GeolocationHandler.cs" />
     <Compile Include="Handlers\MenuHandler.cs" />
     <Compile Include="Mvvm\DelegateCommand.cs" />
     <Compile Include="Mvvm\DelegateCommandT.cs" />

--- a/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
@@ -1,0 +1,22 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Windows;
+
+namespace CefSharp.Wpf.Example.Handlers
+{
+    internal class GeolocationHandler : IGeolocationHandler
+    {
+        public bool OnRequestGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId)
+        {
+            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?", requestingUrl), "Geolocation", MessageBoxButton.YesNo);
+            return result == MessageBoxResult.Yes;
+        }
+
+        public void OnCancelGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId)
+        {
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
@@ -11,7 +11,7 @@ namespace CefSharp.Wpf.Example.Handlers
     {
         public bool OnRequestGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId)
         {
-            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?", requestingUrl), "Geolocation", MessageBoxButton.YesNo);
+            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButton.YesNo);
             return result == MessageBoxResult.Yes;
         }
 

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -19,6 +19,7 @@ namespace CefSharp.Wpf.Example.Views
             browser.RegisterJsObject("bound", new BoundObject());
 
             browser.MenuHandler = new Handlers.MenuHandler();
+            browser.GeolocationHandler = new Handlers.GeolocationHandler();
 
             CefExample.RegisterTestResources(browser);
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -48,6 +48,7 @@ namespace CefSharp.Wpf
         public IFocusHandler FocusHandler { get; set; }
         public IDragHandler DragHandler { get; set; }
         public IResourceHandler ResourceHandler { get; set; }
+        public IGeolocationHandler GeolocationHandler { get; set; }
 
         public event EventHandler<ConsoleMessageEventArgs> ConsoleMessage;
         public event EventHandler<StatusMessageEventArgs> StatusMessage;

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -94,6 +94,7 @@
     <Compile Include="IDragData.cs" />
     <Compile Include="IFocusHandler.cs" />
     <Compile Include="IDragHandler.cs" />
+    <Compile Include="IGeolocationHandler.cs" />
     <Compile Include="IResourceHandler.cs" />
     <Compile Include="IsBrowserInitializedChangedEventArgs.cs" />
     <Compile Include="CefTerminationStatus.cs" />

--- a/CefSharp/IGeolocationHandler.cs
+++ b/CefSharp/IGeolocationHandler.cs
@@ -1,0 +1,26 @@
+﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+    public interface IGeolocationHandler
+    {
+        /// <summary>
+        /// Called when a page requests permission to access geolocation information.
+        /// </summary>
+        /// <param name="browser">the browser object</param>
+        /// <param name="requestingUrl">the URL requesting permission</param>
+        /// <param name="requestId">the unique ID for the permission request</param>
+        /// <returns>true to allow the request and false to deny</returns>
+        bool OnRequestGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId);
+
+        /// <summary>
+        /// Called when a geolocation access request is canceled.
+        /// </summary>
+        /// <param name="browser">the browser object</param>
+        /// <param name="requestingUrl">the URL that originally requested permission</param>
+        /// <param name="requestId">the unique ID for the permission request, as seen in <see cref="OnRequestGeolocationPermission"/></param>
+        void OnCancelGeolocationPermission(IWebBrowser browser, string requestingUrl, int requestId);
+    }
+}

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -155,6 +155,11 @@ namespace CefSharp
         IResourceHandler ResourceHandler { get; set; }
 
         /// <summary>
+        /// Implement <see cref="IGeolocationHandler"/> and assign to handle requests for permission to use geolocation.
+        /// </summary>
+        IGeolocationHandler GeolocationHandler { get; set; }
+
+        /// <summary>
         /// A flag that indicates whether the WebBrowser is initialized (true) or not (false).
         /// </summary>
         /// <remarks>In the WPF control, this property is implemented as a Dependency Property and fully supports data


### PR DESCRIPTION
delegating the request to a CefSharp.IGeolocationHandler implementation.  This allows CefSharp to permit geolocation requests.

This implements https://github.com/cefsharp/CefSharp/issues/332 .