### PR TITLE
#672: Notify CEF when our owning form moves (WM_MOVE or WM_MOVING) just ...

### DIFF
--- a/CefSharp.Example/Resources/TooltipTest.html
+++ b/CefSharp.Example/Resources/TooltipTest.html
@@ -14,6 +14,11 @@
                 <option>one</option>
                 <option>two</option>
             </select>
+            <select style="float: right">
+                <option selected>testRight</option>
+                <option>three</option>
+                <option>four</option>
+            </select>
         </form>
 	</body>
 </html>

--- a/CefSharp.WinForms/CefSharp.WinForms.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="Internals\DefaultFocusHandler.cs" />
     <Compile Include="Internals\ControlExtensions.cs" />
+    <Compile Include="Internals\MovingListener.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ChromiumWebBrowser.cs">
       <SubType>Component</SubType>

--- a/CefSharp.WinForms/CefSharp.WinForms.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/CefSharp.WinForms/CefSharp.WinForms.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.csproj
@@ -54,7 +54,8 @@
   <ItemGroup>
     <Compile Include="Internals\DefaultFocusHandler.cs" />
     <Compile Include="Internals\ControlExtensions.cs" />
-    <Compile Include="Internals\MovingListener.cs" />
+    <Compile Include="Internals\ParentFormMessageInterceptor.cs" />
+    <Compile Include="Internals\NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ChromiumWebBrowser.cs">
       <SubType>Component</SubType>

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -114,7 +114,7 @@ namespace CefSharp.WinForms
             {
                 this.BeginInvoke((MethodInvoker)delegate 
                 {
-                    movingListener = new MovingListener(this.FindForm());
+                    movingListener = new MovingListener(this);
                     movingListener.Moving += movingListener_Moving;
                 });
             }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -14,7 +14,7 @@ namespace CefSharp.WinForms
     public class ChromiumWebBrowser : Control, IWebBrowserInternal, IWinFormsWebBrowser
     {
         private ManagedCefBrowserAdapter managedCefBrowserAdapter;
-        private MovingListener movingListener;
+        private ParentFormMessageInterceptor parentFormMessageInterceptor;
 
         public BrowserSettings BrowserSettings { get; set; }
         public string Title { get; set; }
@@ -107,13 +107,13 @@ namespace CefSharp.WinForms
             IsBrowserInitialized = true;
 
             // By the time this callback gets called, this control
-            // is most likely hooked into a parent Form of some sort. 
-            // (Which is what MovingListener relies on.)
-            // Ensure the MovingListener construction occurs on the WinForms UI thread:
+            // is most likely hooked into a browser Form of some sort. 
+            // (Which is what ParentFormMessageInterceptor relies on.)
+            // Ensure the ParentFormMessageInterceptor construction occurs on the WinForms UI thread:
             this.InvokeOnUiThreadIfRequired(() =>
             {
-                movingListener = new MovingListener(this);
-                movingListener.Moving += MovingListenerMoving;
+                parentFormMessageInterceptor = new ParentFormMessageInterceptor(this);
+                parentFormMessageInterceptor.Moving += MovingListenerMoving;
             });
 
             ResizeBrowser();

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -94,7 +94,7 @@ namespace CefSharp.WinForms
             base.Dispose(disposing);
         }
 
-        void movingListener_Moving(object sender, EventArgs e)
+        private void MovingListenerMoving(object sender, EventArgs e)
         {
             if (IsBrowserInitialized)
             {
@@ -109,15 +109,12 @@ namespace CefSharp.WinForms
             // By the time this callback gets called, this control
             // is most likely hooked into a parent Form of some sort. 
             // (Which is what MovingListener relies on.)
-            // Ensure the MovingListener contruction occurs on the WinForms UI thread:
-            if (InvokeRequired)
+            // Ensure the MovingListener construction occurs on the WinForms UI thread:
+            this.InvokeOnUiThreadIfRequired(() =>
             {
-                this.BeginInvoke((MethodInvoker)delegate 
-                {
-                    movingListener = new MovingListener(this);
-                    movingListener.Moving += movingListener_Moving;
-                });
-            }
+                movingListener = new MovingListener(this);
+                movingListener.Moving += MovingListenerMoving;
+            });
 
             ResizeBrowser();
 

--- a/CefSharp.WinForms/Internals/MovingListener.cs
+++ b/CefSharp.WinForms/Internals/MovingListener.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright © 2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/CefSharp.WinForms/Internals/MovingListener.cs
+++ b/CefSharp.WinForms/Internals/MovingListener.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace CefSharp.WinForms.Internals
+{
+    internal class MovingListener : NativeWindow
+    {
+        public event EventHandler<EventArgs> Moving;
+
+        private Form ParentForm { get; set; }
+
+        public MovingListener(Form parent)
+        {
+            ParentForm = parent;
+            if (ParentForm.IsHandleCreated)
+            {
+                OnHandleCreated(ParentForm, null);
+            }
+            else
+            {
+                ParentForm.HandleCreated += OnHandleCreated;
+            }
+            ParentForm.HandleDestroyed += OnHandleDestroyed;
+        }
+
+        private void OnHandleCreated(object sender, EventArgs e)
+        {
+            AssignHandle(((Form)sender).Handle);
+        }
+
+        private void OnHandleDestroyed(object sender, EventArgs e)
+        {
+            ReleaseHandle();
+        }
+        protected override void WndProc(ref Message m)
+        {
+            // Listen for operating system messages 
+            switch (m.Msg)
+            {
+            // WM_MOVE
+            case 0x3:
+            // WM_MOVING:
+            case 0x0216:
+                OnMoving();
+                break;
+            }
+            base.WndProc(ref m);
+        }
+
+        protected virtual void OnMoving()
+        {
+            if (Moving != null)
+            {
+                Moving(this, null);
+            }
+        }
+    }
+}

--- a/CefSharp.WinForms/Internals/MovingListener.cs
+++ b/CefSharp.WinForms/Internals/MovingListener.cs
@@ -2,10 +2,10 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using CefSharp.Internals;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace CefSharp.WinForms.Internals
@@ -14,25 +14,58 @@ namespace CefSharp.WinForms.Internals
     {
         public event EventHandler<EventArgs> Moving;
 
+        private bool isMoving = false;
+        private Rectangle movingRectangle;
+
+        private Control ParentControl { get; set; }
+
         private Form ParentForm { get; set; }
 
-        public MovingListener(Form parent)
+        public MovingListener(Control parent)
         {
-            ParentForm = parent;
-            if (ParentForm.IsHandleCreated)
+            ParentControl = parent;
+            // Get notified if our parent window changes:
+            ParentControl.ParentChanged += parent_ParentChanged;
+            // Find the parent form to subclass to monitor WM_MOVE/WM_MOVING
+            RefindParentForm();
+        }
+
+        public void RefindParentForm()
+        {
+            parent_ParentChanged(ParentControl, null);
+        }
+
+        private void parent_ParentChanged(object sender, EventArgs e)
+        {
+            Control control = (Control)sender;
+            Form oldForm = ParentForm;
+            Form newForm = control.FindForm();
+            if (oldForm == null
+                || newForm == null
+                || oldForm.Handle != newForm.Handle
+                )
             {
-                OnHandleCreated(ParentForm, null);
+                if (this.Handle != IntPtr.Zero)
+                {
+                    ReleaseHandle();
+                }
+                if (oldForm != null)
+                {
+                    oldForm.HandleCreated -= OnHandleCreated;
+                    oldForm.HandleDestroyed -= OnHandleDestroyed;
+                }
+                ParentForm = newForm;
+                if (newForm != null)
+                {
+                    OnHandleCreated(newForm, null);
+                }
             }
-            else
-            {
-                ParentForm.HandleCreated += OnHandleCreated;
-            }
-            ParentForm.HandleDestroyed += OnHandleDestroyed;
         }
 
         private void OnHandleCreated(object sender, EventArgs e)
         {
             AssignHandle(((Form)sender).Handle);
+            Kernel32.OutputDebugString(String.Format("Attaching '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
         }
 
         private void OnHandleDestroyed(object sender, EventArgs e)
@@ -41,25 +74,82 @@ namespace CefSharp.WinForms.Internals
         }
         protected override void WndProc(ref Message m)
         {
+            bool care = false;
+
+            // Negative initial values keeps the compiler quiet:
+            int x = -1;
+            int y = -1;
+
             // Listen for operating system messages 
             switch (m.Msg)
             {
-            // WM_MOVE
-            case 0x3:
             // WM_MOVING:
             case 0x0216:
-                OnMoving();
+                movingRectangle = (Rectangle)Marshal.PtrToStructure(m.LParam, typeof(Rectangle));
+                x = movingRectangle.Left;
+                y = movingRectangle.Top;
+                care = true;
+                break;
+            // WM_MOVE
+            case 0x3:
+                x = (m.LParam.ToInt32() & 0xffff);
+                y = ((m.LParam.ToInt32() >> 16) & 0xffff);
+                care = true;
                 break;
             }
-            base.WndProc(ref m);
+
+            // Only notify about movement if:
+            // * ParentForm Created
+            // * ParentControl Created
+            // * ParentForm Actually moved
+            // * Not currently moving (on the UI thread only of course)
+            // * The current WindowState is Normal.
+            //      This check is to simplify the effort here.
+            //      Other logic already handles the maximize/minimize
+            //      cases just fine.
+            // You might consider checking ParentControl.Visible and
+            // not notifying our parent control if the parent control isn't visible.
+            // However, if you do that, the non-Visible CEF tab will still
+            // have any SELECT drop downs rendering where they shouldn't.
+            if (care
+                && ParentForm != null
+                && ParentForm.IsHandleCreated
+                && ParentControl.IsHandleCreated
+                && ParentForm.WindowState == FormWindowState.Normal
+                && (ParentForm.Left != x
+                    || ParentForm.Top != y)
+                && !isMoving)
+            {
+                // .Left & .Right are negative when the window
+                // is transitioning from maximized to normal.
+                // If we are transitioning, the form will also receive
+                // a WM_SIZE which can deal with the move/size combo itself.
+                if (ParentForm.Left > 0
+                    && ParentForm.Right > 0)
+                {
+                    OnMoving();
+                    Kernel32.OutputDebugString(String.Format("Called OnMoving from control '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
+                }
+                else
+                {
+                    Kernel32.OutputDebugString(String.Format("Skipped OnMoving from control '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
+                }
+            }
+            else if (care)
+            {
+                Kernel32.OutputDebugString(String.Format("Skipped OnMoving from control '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
+            }
+            this.DefWndProc(ref m);
         }
 
         protected virtual void OnMoving()
         {
+            isMoving = true;
             if (Moving != null)
             {
                 Moving(this, null);
             }
+            isMoving = false;
         }
     }
 }

--- a/CefSharp.WinForms/Internals/NativeMethods.cs
+++ b/CefSharp.WinForms/Internals/NativeMethods.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CefSharp.WinForms.Internals
+{
+    internal static class NativeMethods
+    {
+        public const int WM_MOVE = 0x3;
+        public const int WM_MOVING = 0x216;
+    }
+}

--- a/CefSharp.WinForms/Internals/ParentFormMessageInterceptor.cs
+++ b/CefSharp.WinForms/Internals/ParentFormMessageInterceptor.cs
@@ -10,31 +10,40 @@ using System.Windows.Forms;
 
 namespace CefSharp.WinForms.Internals
 {
-    internal class MovingListener : NativeWindow
+    internal class ParentFormMessageInterceptor : NativeWindow, IDisposable
     {
         public event EventHandler<EventArgs> Moving;
 
         private bool isMoving = false;
         private Rectangle movingRectangle;
 
-        private Control ParentControl { get; set; }
+        private ChromiumWebBrowser Browser { get; set; }
 
         private Form ParentForm { get; set; }
 
-        public MovingListener(Control parent)
+        public ParentFormMessageInterceptor(ChromiumWebBrowser browser)
         {
-            ParentControl = parent;
-            // Get notified if our parent window changes:
-            ParentControl.ParentChanged += ParentParentChanged;
-            // Find the parent form to subclass to monitor WM_MOVE/WM_MOVING
+            Browser = browser;
+            // Get notified if our browser window parent changes:
+            Browser.ParentChanged += ParentParentChanged;
+            // Find the browser form to subclass to monitor WM_MOVE/WM_MOVING
             RefindParentForm();
         }
 
+        /// <summary>
+        /// Call to force refinding of the parent Form. 
+        /// (i.e. top level window that owns the ChromiumWebBrowserControl)
+        /// </summary>
         public void RefindParentForm()
         {
-            ParentParentChanged(ParentControl, null);
+            ParentParentChanged(Browser, null);
         }
 
+        /// <summary>
+        /// Adjust the form to listen to if the ChromiumWebBrowserControl's parent changes.
+        /// </summary>
+        /// <param name="sender">The ChromiumWebBrowser whose parent has changed.</param>
+        /// <param name="e"></param>
         private void ParentParentChanged(object sender, EventArgs e)
         {
             Control control = (Control)sender;
@@ -59,6 +68,8 @@ namespace CefSharp.WinForms.Internals
                 {
                     newForm.HandleCreated += OnHandleCreated;
                     newForm.HandleDestroyed += OnHandleDestroyed;
+                    // If newForm's Handle has been created already,
+                    // our event listener won't be called, so call it now.
                     if (newForm.IsHandleCreated)
                     {
                         OnHandleCreated(newForm, null);
@@ -70,7 +81,6 @@ namespace CefSharp.WinForms.Internals
         private void OnHandleCreated(object sender, EventArgs e)
         {
             AssignHandle(((Form)sender).Handle);
-            Kernel32.OutputDebugString(String.Format("Attaching '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
         }
 
         private void OnHandleDestroyed(object sender, EventArgs e)
@@ -80,7 +90,7 @@ namespace CefSharp.WinForms.Internals
 
         protected override void WndProc(ref Message m)
         {
-            bool care = false;
+            bool isMovingMessage = false;
 
             // Negative initial values keeps the compiler quiet and to
             // ensure we have actual window movement to notify CEF about.
@@ -91,27 +101,29 @@ namespace CefSharp.WinForms.Internals
             // Listen for operating system messages 
             switch (m.Msg)
             {
-            // WM_MOVING:
-            case 0x0216:
-                movingRectangle = (Rectangle)Marshal.PtrToStructure(m.LParam, typeof(Rectangle));
-                x = movingRectangle.Left;
-                y = movingRectangle.Top;
-                care = true;
-                break;
-            // WM_MOVE
-            case 0x3:
-                x = (m.LParam.ToInt32() & 0xffff);
-                y = ((m.LParam.ToInt32() >> 16) & 0xffff);
-                care = true;
-                break;
+            case NativeMethods.WM_MOVING:
+                {
+                    movingRectangle = (Rectangle)Marshal.PtrToStructure(m.LParam, typeof(Rectangle));
+                    x = movingRectangle.Left;
+                    y = movingRectangle.Top;
+                    isMovingMessage = true;
+                    break;
+                }
+            case NativeMethods.WM_MOVE:
+                {
+                    x = (m.LParam.ToInt32() & 0xffff);
+                    y = ((m.LParam.ToInt32() >> 16) & 0xffff);
+                    isMovingMessage = true;
+                    break;
+                }
             }
 
             // Only notify about movement if:
-            // * ParentControl Handle Created
+            // * Browser Handle Created
             //   NOTE: This is checked for paranoia. 
             //         This WndProc can't be called unless ParentForm has 
             //         its handle created, but that doesn't necessarily mean 
-            //         ParentControl has had its handle created.
+            //         Browser has had its handle created.
             //         WinForm controls don't usually get eagerly created Handles
             //         in their constructors.
             // * ParentForm Actually moved
@@ -120,12 +132,12 @@ namespace CefSharp.WinForms.Internals
             //      This check is to simplify the effort here.
             //      Other logic already handles the maximize/minimize
             //      cases just fine.
-            // You might consider checking ParentControl.Visible and
-            // not notifying our parent control if the parent control isn't visible.
+            // You might consider checking Browser.Visible and
+            // not notifying our browser control if the browser control isn't visible.
             // However, if you do that, the non-Visible CEF tab will still
             // have any SELECT drop downs rendering where they shouldn't.
-            if (care
-                && ParentControl.IsHandleCreated
+            if (isMovingMessage
+                && Browser.IsHandleCreated
                 && ParentForm.WindowState == FormWindowState.Normal
                 && (ParentForm.Left != x
                     || ParentForm.Top != y)
@@ -139,16 +151,7 @@ namespace CefSharp.WinForms.Internals
                     && ParentForm.Right >= 0)
                 {
                     OnMoving();
-                    Kernel32.OutputDebugString(String.Format("Called OnMoving from control '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
                 }
-                else
-                {
-                    Kernel32.OutputDebugString(String.Format("Skipped OnMoving from control '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
-                }
-            }
-            else if (care)
-            {
-                Kernel32.OutputDebugString(String.Format("Skipped OnMoving from control '{1:x}' to form '{0:x}'\r\n", ParentForm.Handle, ParentControl.Handle));
             }
             this.DefWndProc(ref m);
         }
@@ -163,6 +166,47 @@ namespace CefSharp.WinForms.Internals
                 handler(this, null);
             }
             isMoving = false;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (ParentForm != null)
+                {
+                    ParentForm.HandleCreated -= OnHandleCreated;
+                    ParentForm.HandleDestroyed -= OnHandleDestroyed;
+                    ParentForm = null;
+                }
+
+                // Unmanaged resource, but release here anyway.
+                // NativeWindow has its own finalization logic 
+                // that should be run if this instance isn't disposed
+                // properly before arriving at the finalization thread.
+                // See: http://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/NativeWindow.cs,147
+                // for the gruesome details.
+                if (this.Handle != IntPtr.Zero)
+                {
+                    ReleaseHandle();
+                }
+
+                if (Browser != null)
+                {
+                    Browser.ParentChanged -= ParentParentChanged;
+                    Browser = null;
+                }
+            }
+        }
+
+        protected override void OnThreadException(Exception e)
+        {
+            // TODO: Do something more interesting here, logging, whatever, something.
+            base.OnThreadException(e);
         }
     }
 }

--- a/CefSharp.WinForms/Internals/ParentFormMessageInterceptor.cs
+++ b/CefSharp.WinForms/Internals/ParentFormMessageInterceptor.cs
@@ -12,9 +12,14 @@ namespace CefSharp.WinForms.Internals
 {
     internal class ParentFormMessageInterceptor : NativeWindow, IDisposable
     {
-        public event EventHandler<EventArgs> Moving;
-
+        /// <summary>
+        /// Keep track of whether a move is in progress.
+        /// </summary>
         private bool isMoving = false;
+
+        /// <summary>
+        /// Used to determine the coordinates involved in the move
+        /// </summary>
         private Rectangle movingRectangle;
 
         private ChromiumWebBrowser Browser { get; set; }
@@ -159,12 +164,7 @@ namespace CefSharp.WinForms.Internals
         protected virtual void OnMoving()
         {
             isMoving = true;
-            var handler = Moving;
-
-            if (handler != null)
-            {
-                handler(this, null);
-            }
+            Browser.NotifyMoveOrResizeStarted();
             isMoving = false;
         }
 


### PR DESCRIPTION
WM_MOVE and WM_MOVING only get sent to parent windows, so add a MovingListener that attaches to the control's parent form and sends the notifications to CEF.

Fyi,
Bill


