### PR TITLE
Check for null object to prevent NullException in SetFocus

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -475,7 +475,10 @@ namespace CefSharp.WinForms
         /// </summary>
         public void SetFocus(bool isFocused)
         {
-            managedCefBrowserAdapter.SetFocus(isFocused);
+            if (IsBrowserInitialized && managedCefBrowserAdapter != null)
+            {
+                managedCefBrowserAdapter.SetFocus(isFocused);
+            }
         }
     }
 }


### PR DESCRIPTION
CEF.Shutdown in some cases would call SetFocus when managedCefBrowserAdapter was null. 