### PR TITLE
Feature/device scale factor

### DIFF
--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -69,6 +69,7 @@ namespace CefSharp
                 }
 
                 screen_info.device_scale_factor = scaleFactor;
+
                 return true;
             }
 
@@ -80,7 +81,11 @@ namespace CefSharp
                     return false;
                 }
 
-                rect = CefRect(0, 0, _renderWebBrowser->Width, _renderWebBrowser->Height);
+                auto scaleFactor = _renderWebBrowser->GetScreenInfoScaleFactor();
+                auto scaledWidth = _renderWebBrowser->Width / scaleFactor;
+                auto scaledHeight = _renderWebBrowser->Height / scaleFactor;
+
+                rect = CefRect(0, 0, scaledWidth, scaledHeight);
                 return true;
             };
 

--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -69,7 +69,6 @@ namespace CefSharp
                 }
 
                 screen_info.device_scale_factor = scaleFactor;
-
                 return true;
             }
 


### PR DESCRIPTION
Minor change needed to function correctly. (Proper render area)

I've also investigated a bit on the scale transform. It seems like CreateBitmapSourceFromMemorySection returns an image source with DpiX and DpiY set to 96 regardless of the actual dpi on the system. This is probably why the image is bitmap up-scaled. So for now the transform is needed to compensate for this.