### PR TITLE
Enhance StreamAdapter to more effeciently deal with MemoryStream

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -333,9 +333,8 @@ namespace CefSharp
                 {
                     CefResponse::HeaderMap map = SchemeHandlerWrapper::ToHeaderMap(resourceHandler->Headers);
 
-                    //TODO: Investigate crash when using full response
-                    //return new CefStreamResourceHandler(resourceHandler->StatusCode, statusText, mimeType, map, stream);
-                    return new CefStreamResourceHandler(mimeType, stream);
+                    //NOTE: This will crash in a debug build due to a CEF bug.
+                    return new CefStreamResourceHandler(resourceHandler->StatusCode, statusText, mimeType, map, stream);
                 }
             }
 

--- a/CefSharp.Core/Internals/StreamAdapter.cpp
+++ b/CefSharp.Core/Internals/StreamAdapter.cpp
@@ -81,7 +81,7 @@ namespace CefSharp
 
         bool StreamAdapter::MayBlock()
         {
-            if (isMemoryStream)
+            if (_isMemoryStream)
             {
                 return false;
             }

--- a/CefSharp.Core/Internals/StreamAdapter.cpp
+++ b/CefSharp.Core/Internals/StreamAdapter.cpp
@@ -37,6 +37,11 @@ namespace CefSharp
         {
             System::IO::SeekOrigin seekOrigin;
 
+            if (!_stream->CanSeek)
+            {
+                return -1;
+            }
+
             switch (whence)
             {
             case SEEK_CUR:
@@ -76,6 +81,10 @@ namespace CefSharp
 
         bool StreamAdapter::MayBlock()
         {
+            if (isMemoryStream)
+            {
+                return false;
+            }
             return true;
         }
     }

--- a/CefSharp.Core/Internals/StreamAdapter.h
+++ b/CefSharp.Core/Internals/StreamAdapter.h
@@ -17,6 +17,7 @@ namespace CefSharp
         {
             CriticalSection _syncRoot;
             gcroot<Stream^> _stream;
+            bool isMemoryStream = false;
 
         public:
             virtual ~StreamAdapter();
@@ -24,6 +25,7 @@ namespace CefSharp
             {
                 //Reset stream position
                 stream->Position = 0;
+                isMemoryStream = (dynamic_cast<MemoryStream^>(stream)) != nullptr;
             }
 
             virtual size_t Read(void* ptr, size_t size, size_t n);

--- a/CefSharp.Core/Internals/StreamAdapter.h
+++ b/CefSharp.Core/Internals/StreamAdapter.h
@@ -17,7 +17,7 @@ namespace CefSharp
         {
             CriticalSection _syncRoot;
             gcroot<Stream^> _stream;
-            bool isMemoryStream = false;
+            bool _isMemoryStream;
 
         public:
             virtual ~StreamAdapter();
@@ -25,7 +25,7 @@ namespace CefSharp
             {
                 //Reset stream position
                 stream->Position = 0;
-                isMemoryStream = (dynamic_cast<MemoryStream^>(stream)) != nullptr;
+                _isMemoryStream = (dynamic_cast<MemoryStream^>(stream)) != nullptr;
             }
 
             virtual size_t Read(void* ptr, size_t size, size_t n);

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -64,7 +64,9 @@ namespace CefSharp.Example
             if (handler != null)
             {
                 const string responseBody = "<html><body><h1>Success</h1><p>This document is loaded from a System.IO.Stream</p></body></html>";
-                handler.RegisterHandler(TestResourceUrl, ResourceHandler.FromString(responseBody));
+                var response = ResourceHandler.FromString(responseBody);
+                response.Headers.Add("HeaderTest1", "HeaderTest1Value");
+                handler.RegisterHandler(TestResourceUrl, response);
 
                 const string unicodeResponseBody = "<html><body>整体满意度</body></html>";
                 handler.RegisterHandler(TestUnicodeResourceUrl, ResourceHandler.FromString(unicodeResponseBody));

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -49,6 +49,7 @@ namespace CefSharp
             StatusCode = 200;
             StatusText = "OK";
             MimeType = "text/html";
+            Headers = new NameValueCollection();
         }
 
         /// <summary>
@@ -60,6 +61,7 @@ namespace CefSharp
             StatusCode = 200;
             StatusText = "OK";
             MimeType = mimeType;
+            Headers = new NameValueCollection();
         }
 
         /// <summary>


### PR DESCRIPTION
...emoryStreams, and add lame header to ResourceHandler usage in CefExample.cs.

Additionally, allocate Headers NameValueCollection in constructor of ResourceHandler.

Sadly, without a change to ClientAdapter.cpp to pass the header data to CEF due to a debug flavor bug in CEF, you can't easily test this change. :(

If you do test this with the CEF change or a Release flavor with the ClientAdapter.cpp change, then this works correctly.

Bill