### PR TITLE
Use correct string encoding in CefRequest.Body

### DIFF
--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -133,7 +133,7 @@ namespace CefSharp
         String^ CefRequestWrapper::CharSet::get()
         {
             // Extract the Content-Type header value.
-            NameValueCollection^ headers = this->Headers;
+            auto headers = this->Headers;
             
             String^ contentType = nullptr;
             for each(String^ key in headers)

--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -51,6 +51,26 @@ namespace CefSharp
 
                         el->GetBytes(count, bytes);
 
+                        // Attempt to honour the charset specified by the request's Content-Type header.
+                        String^ charset = this->CharSet;
+                        if (charset != nullptr)
+                        {
+                            System::Text::Encoding^ encoding;
+                            try
+                            {
+                                encoding = System::Text::Encoding::GetEncoding(charset);
+                            }
+                            catch (ArgumentException^)
+                            {
+                                encoding = nullptr;
+                            }
+                            if (encoding != nullptr)
+                            {
+                                return gcnew String(bytes, 0, count, encoding);
+                            }
+                        }
+
+                        // Revert to using the system's default code page.
                         return gcnew String(bytes, 0, count);
                     }
                     else if (el->GetType() == PDE_TYPE_FILE)
@@ -100,6 +120,64 @@ namespace CefSharp
         TransitionType CefRequestWrapper::TransitionType::get()
         {
             return (CefSharp::TransitionType) _wrappedRequest->GetTransitionType();
+        }
+
+        /// <summary>
+        /// Extracts the charset argument from the content-type header.
+        /// The charset is optional, so a nullptr may be returned.
+        /// For example, given a Content-Type header "application/json; charset=UTF-8",
+        /// this function will return "UTF-8".
+        /// </summary>
+        String^ CefRequestWrapper::CharSet::get()
+        {
+            // Extract the Content-Type header value.
+            NameValueCollection^ headers = this->Headers;
+            
+            String^ contentType = nullptr;
+            for each(String^ key in headers)
+            {
+                if (key->Equals("content-type", System::StringComparison::InvariantCultureIgnoreCase))
+                {
+                    for each(String^ element in headers->GetValues(key))
+                    {
+                        contentType = element;
+                        break;
+                    }
+                    break;
+                }
+            }
+
+            if (contentType == nullptr)
+            {
+                return nullptr;
+            }
+
+            // Look for charset after the mime-type.
+            const int semiColonIndex = contentType->IndexOf(";");
+            if (semiColonIndex == -1)
+            {
+                return nullptr;
+            }
+
+            String^ charsetArgument = contentType->Substring(semiColonIndex + 1)->Trim();
+            const int equalsIndex = charsetArgument->IndexOf("=");
+            if (equalsIndex == -1)
+            {
+                return nullptr;
+            }
+
+            String^ argumentName = charsetArgument->Substring(0, equalsIndex)->Trim();
+            if (!argumentName->Equals("charset", System::StringComparison::InvariantCultureIgnoreCase))
+            {
+                return nullptr;
+            }
+
+            String^ charset = charsetArgument->Substring(equalsIndex + 1)->Trim();
+            // Remove redundant characters (e.g. "UTF-8"; -> UTF-8)
+            charset = charset->TrimStart(' ', '"');
+            charset = charset->TrimEnd(' ', '"', ';');
+
+            return charset;
         }
     }
 }

--- a/CefSharp.Core/Internals/CefRequestWrapper.cpp
+++ b/CefSharp.Core/Internals/CefRequestWrapper.cpp
@@ -5,6 +5,8 @@
 #include "Stdafx.h"
 #include "CefRequestWrapper.h"
 
+using namespace System::Text;
+
 namespace CefSharp
 {
     namespace Internals
@@ -55,10 +57,10 @@ namespace CefSharp
                         String^ charset = this->CharSet;
                         if (charset != nullptr)
                         {
-                            System::Text::Encoding^ encoding;
+                            Encoding^ encoding;
                             try
                             {
-                                encoding = System::Text::Encoding::GetEncoding(charset);
+                                encoding = Encoding::GetEncoding(charset);
                             }
                             catch (ArgumentException^)
                             {

--- a/CefSharp.Core/Internals/CefRequestWrapper.h
+++ b/CefSharp.Core/Internals/CefRequestWrapper.h
@@ -29,6 +29,9 @@ namespace CefSharp
                 _wrappedRequest = nullptr;
             }
 
+        protected:
+            virtual property String^ CharSet { String^ get(); }
+
         public:
             virtual property String^ Url { String^ get(); void set(String^ url); }
             virtual property String^ Method { String^ get(); }


### PR DESCRIPTION
This fixes a bug where unicode characters were not being decoded correctly in the POST request body in CefRequest.

This meant that Unicode text was being corrupted in custom schemes and `RequestHandler`.

For example, U with umlaut - `"Ü"` - that was sent correctly as utf-8 in an AJAX request, was then incorrectly decoded using the default ASCII codepage as `"Ã"`).
