### PR TITLE
Make DefaultFocusHandler public class

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -35,6 +35,17 @@ namespace CefSharp.WinForms
         public IDownloadHandler DownloadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }
+
+        /// <summary>
+        /// The <see cref="IFocusHandler"/> for this ChromiumWebBrowser.
+        /// </summary>
+        /// <remarks>
+        /// If you need customized focus handling behavior for WinForms, the suggested 
+        /// best practice would be to inherit from DefaultFocusHandler and try to avoid 
+        /// needing to override the logic in OnGotFocus. The implementation in 
+        /// DefaultFocusHandler relies on very detailed behavior of how WinForms and 
+        /// Windows interact during window activation.
+        /// </remarks>
         public IFocusHandler FocusHandler { get; set; }
         public IDragHandler DragHandler { get; set; }
         public IResourceHandlerFactory ResourceHandlerFactory { get; set; }

--- a/CefSharp.WinForms/Internals/DefaultFocusHandler.cs
+++ b/CefSharp.WinForms/Internals/DefaultFocusHandler.cs
@@ -7,7 +7,7 @@ using System;
 using System.Windows.Forms;
 namespace CefSharp.WinForms.Internals
 {
-    internal class DefaultFocusHandler : IFocusHandler
+    public class DefaultFocusHandler : IFocusHandler
     {
         private readonly ChromiumWebBrowser browser;
 
@@ -16,6 +16,11 @@ namespace CefSharp.WinForms.Internals
             this.browser = browser;
         }
 
+        /// <remarks>
+        /// Try to avoid needing to override this logic in a subclass. The implementation in 
+        /// DefaultFocusHandler relies on very detailed behavior of how WinForms and 
+        /// Windows interact during window activation.
+        /// </remarks>
         public virtual void OnGotFocus()
         {
             // During application activation, CEF receives a WM_SETFOCUS


### PR DESCRIPTION
instead of internal so that you can subclass and reuse the tricky default OnGotFocus implementation.

Add doc comment warnings about the danagers of overriding IFocusHandler.OnGotFocus for WinForm ChromiumWebBrowsers.

Thoughts?
Bill
