### PR TITLE
Feature/register object using a dictionary

### DIFF
--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace CefSharp.Example
-{
+{    
     public class BoundObject
     {
         public int MyProperty { get; set; }
@@ -10,6 +12,8 @@ namespace CefSharp.Example
         public string MyReadOnlyProperty { get; internal set; }
         public Type MyUnconvertibleProperty { get; set; }
         public SubBoundObject SubObject { get; set; }
+        // this will register a sub object (called subObjectUsingDict) - each key of the dictionary will appear as property of the object in javascript
+        public IDictionary SubObjectUsingDict { get; set; }
 
         public BoundObject()
         {
@@ -18,6 +22,11 @@ namespace CefSharp.Example
             IgnoredProperty = "I am an Ignored Property";
             MyUnconvertibleProperty = GetType();
             SubObject = new SubBoundObject();
+            SubObjectUsingDict = new Dictionary<string, string>
+            {
+                {"prop1", "value1"},
+                {"prop2", "value2"},
+            };
         }
 
         public void TestCallback(IJavascriptCallback javascriptCallback)

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -187,26 +187,25 @@ namespace CefSharp.Internals
             if (dict != null)
             {
                 // in case of dictionary, add each key/value pair as read only property of obj                              
-                foreach (var key in dict.Keys)
+                foreach (DictionaryEntry dictionaryEntry in dict)
                 {
-                    var name = key.ToString();
-                    var value = dict[key];                    
+                    var propertyName = dictionaryEntry.Key.ToString();
+                    var propertyValue = dictionaryEntry.Value;                    
 
                     var jsProperty = new JavascriptProperty();
-
-                    jsProperty.ManagedName = name;
-                    jsProperty.JavascriptName = LowercaseFirst(name);
+                    jsProperty.ManagedName = propertyName;
+                    jsProperty.JavascriptName = LowercaseFirst(propertyName);
                     jsProperty.SetValue = (o, v) => { };
-                    jsProperty.GetValue = (o) => value;
+                    jsProperty.GetValue = (o) => propertyValue;
 
-                    jsProperty.IsComplexType = IsComplexType(value.GetType());
+                    jsProperty.IsComplexType = IsComplexType(propertyValue.GetType());
                     jsProperty.IsReadOnly = true;
 
                     if (jsProperty.IsComplexType)
                     {
                         var jsObject = CreateJavascriptObject();
-                        jsObject.Name = name;
-                        jsObject.JavascriptName = LowercaseFirst(name);
+                        jsObject.Name = propertyName;
+                        jsObject.JavascriptName = LowercaseFirst(propertyName);
                         jsObject.Value = jsProperty.GetValue(obj.Value);
                         jsProperty.JsObject = jsObject;
 

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -291,7 +291,7 @@ namespace CefSharp.Internals
                 baseType = Nullable.GetUnderlyingType(type);
             }
 
-            if (baseType != null && baseType.Name.StartsWith("System.Collections"))
+            if (baseType != null && baseType.Namespace.StartsWith("System.Collections"))
             {
                 return true;
             }

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -189,18 +189,34 @@ namespace CefSharp.Internals
                 // in case of dictionary, add each key/value pair as read only property of obj                              
                 foreach (var key in dict.Keys)
                 {
-                    var strKey = key.ToString();
-                    var value = dict[key].ToString();
+                    var name = key.ToString();
+                    var value = dict[key];                    
 
                     var jsProperty = new JavascriptProperty();
 
-                    jsProperty.ManagedName = strKey;
-                    jsProperty.JavascriptName = LowercaseFirst(strKey);
+                    jsProperty.ManagedName = name;
+                    jsProperty.JavascriptName = LowercaseFirst(name);
                     jsProperty.SetValue = (o, v) => { };
                     jsProperty.GetValue = (o) => value;
 
-                    jsProperty.IsComplexType = false;
+                    jsProperty.IsComplexType = IsComplexType(value.GetType());
                     jsProperty.IsReadOnly = true;
+
+                    if (jsProperty.IsComplexType)
+                    {
+                        var jsObject = CreateJavascriptObject();
+                        jsObject.Name = name;
+                        jsObject.JavascriptName = LowercaseFirst(name);
+                        jsObject.Value = jsProperty.GetValue(obj.Value);
+                        jsProperty.JsObject = jsObject;
+
+                        AnalyseObjectForBinding(jsProperty.JsObject, analyseMethods, readPropertyValue);
+                    }
+                    else
+                    {
+                        jsProperty.PropertyValue = jsProperty.GetValue(obj.Value);
+                    }
+
                     obj.Properties.Add(jsProperty);
                 }
 


### PR DESCRIPTION
It's usefully to be able to register dynamic objects - objects with unknown structure until run-time.

This pull is about adding support for registering a Dictionary object to JS. This enables the above behavior - each key of the dictionary  becomes a property of the new JS object, e.g.

```c#
browser.RegisterJsObject("bound", new Dictionary<string, object>
{
	{"prop1", "value1"},
	{"prop2", new BoundObject()},
});
```

will produce the following in JS

```
bound.prop1 --> value1
bound.prop2 --> boundObject
bound.prop2.MyReadOnlyProperty --> "I'm immutable!"
```