### PR TITLE
Create ProxyConfig.cs

### DIFF
--- a/CefSharp/ProxyConfig.cs
+++ b/CefSharp/ProxyConfig.cs
@@ -1,0 +1,59 @@
+// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace CefSharp
+{
+    public class ProxyConfig
+    {
+        private const uint InternetOptionProxy = 38;
+
+        public static InternetProxyInfo GetProxyInformation()
+        {
+            int bufferLength = 0;
+            InternetQueryOption(IntPtr.Zero, InternetOptionProxy, IntPtr.Zero, ref bufferLength);
+            IntPtr buffer = IntPtr.Zero;
+            try
+            {
+                buffer = Marshal.AllocHGlobal(bufferLength);
+
+
+                if (InternetQueryOption(IntPtr.Zero, InternetOptionProxy, buffer, ref bufferLength))
+                {
+                    var ipi = (InternetProxyInfo)Marshal.PtrToStructure(buffer, typeof(InternetProxyInfo));
+                    return ipi;
+                }
+                else
+                {
+                    throw new Win32Exception();
+                }
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero) Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        [DllImport("wininet.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool InternetQueryOption(IntPtr hInternet, uint dwOption, IntPtr lpBuffer, ref int lpdwBufferLength);
+    }
+
+    public enum InternetOpenType
+    {
+        Preconfig = 0,
+        Direct = 1,
+        Proxy = 3,
+        PreconfigWithNoAutoProxy = 4
+    }
+
+    public struct InternetProxyInfo
+    {
+        public InternetOpenType AccessType;
+        public string ProxyAddress;
+        public string ProxyBypass;
+    }
+}


### PR DESCRIPTION
Added the ability to automatically configure the proxy in the CefExample Init class to use the proxy options set in IE. 
To use just call
```c#
var proxy = ProxyConfig.GetProxyInformation();
switch (proxy.AccessType)
{
	case InternetOpenType.Direct:
		//Don't use a proxy server, always make direct connections. Overrides any other proxy server flags that are passed.
		settings.CefCommandLineArgs.Add("no-proxy-server", "1");
		break;
	case InternetOpenType.Proxy:
		settings.CefCommandLineArgs.Add("proxy-server", proxy.ProxyAddress);
		break;
	case InternetOpenType.Preconfig:
		settings.CefCommandLineArgs.Add("proxy-auto-detect", "1");
		break;
}
```