### PR TITLE
Implement DependencyChecker

### DIFF
--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -139,21 +139,27 @@ namespace CefSharp
         /// <return>true if successful; otherwise, false.</return>
         static bool Initialize(CefSettings^ cefSettings)
         {
-            return Initialize(cefSettings, true);
+            return Initialize(cefSettings, true, false);
         }
 
         /// <summary>Initializes CefSharp with user-provided settings.</summary>
         /// <param name="cefSettings">CefSharp configuration settings.</param>
         /// <param name="shutdownOnProcessExit">When the Current AppDomain (relative to the thread called on)
         /// Exits(ProcessExit event) then Shudown will be called.</param>
+        /// <param name="performDependencyCheck">Check that all relevant dependencies avaliable, throws exception if any are missing</param>
         /// <return>true if successful; otherwise, false.</return>
-        static bool Initialize(CefSettings^ cefSettings, bool shutdownOnProcessExit)
+        static bool Initialize(CefSettings^ cefSettings, bool shutdownOnProcessExit, bool performDependencyCheck)
         {
             bool success = false;
 
             // NOTE: Can only initialize Cef once, so subsiquent calls are ignored.
             if (!IsInitialized)
             {
+                if(performDependencyCheck)
+                {
+                    DependencyChecker::AssetAllDependenciesPresent(cefSettings->Locale, cefSettings->LocalesDirPath, cefSettings->ResourcesDirPath, cefSettings->PackLoadingDisabled);
+                }
+
                 CefMainArgs main_args;
                 CefRefPtr<CefSharpApp> app(new CefSharpApp(cefSettings));
 

--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -157,7 +157,7 @@ namespace CefSharp
             {
                 if(performDependencyCheck)
                 {
-                    DependencyChecker::AssetAllDependenciesPresent(cefSettings->Locale, cefSettings->LocalesDirPath, cefSettings->ResourcesDirPath, cefSettings->PackLoadingDisabled);
+                    DependencyChecker::AssertAllDependenciesPresent(cefSettings->Locale, cefSettings->LocalesDirPath, cefSettings->ResourcesDirPath, cefSettings->PackLoadingDisabled);
                 }
 
                 CefMainArgs main_args;

--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -79,6 +79,12 @@ namespace CefSharp
             void set(String^ value) { StringUtils::AssignNativeFromClr(_cefSettings->locales_dir_path, value); }
         }
 
+        virtual property String^ ResourcesDirPath
+        {
+            String^ get() { return StringUtils::ToClr(_cefSettings->resources_dir_path); }
+            void set(String^ value) { StringUtils::AssignNativeFromClr(_cefSettings->resources_dir_path, value); }
+        }		
+
         virtual property String^ LogFile
         {
             String^ get() { return StringUtils::ToClr(_cefSettings->log_file); }

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -57,10 +57,7 @@ namespace CefSharp.Example
 
             localPackPath += locale + ".pak";
 
-            if (!DependencyChecker.AreAllDependenciesPresent(localPackPath))
-            {
-                throw new Exception("Missing Dependencies");
-            }
+            DependencyChecker.AssetAllDependenciesPresent(localPackPath);
 
             if (!Cef.Initialize(settings))
             {

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -51,13 +51,7 @@ namespace CefSharp.Example
                 SchemeHandlerFactory = new CefSharpSchemeHandlerFactory()
             });
 
-            var locale = string.IsNullOrEmpty(settings.Locale) ? "en-US" : settings.Locale;
-
-            var localPackPath = string.IsNullOrEmpty(settings.LocalesDirPath) ? @"locales\" : settings.LocalesDirPath;
-
-            localPackPath += locale + ".pak";
-
-            DependencyChecker.AssetAllDependenciesPresent(localPackPath);
+            DependencyChecker.AssetAllDependenciesPresent(settings.Locale, settings.LocalesDirPath, settings.ResourcesDirPath);
 
             if (!Cef.Initialize(settings))
             {

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -51,6 +51,9 @@ namespace CefSharp.Example
                 SchemeHandlerFactory = new CefSharpSchemeHandlerFactory()
             });
 
+            //For special case when Checking Windows Xp Dependencies
+            //DependencyChecker.IsWindowsXp = true;
+
             DependencyChecker.AssetAllDependenciesPresent(settings.Locale, settings.LocalesDirPath, settings.ResourcesDirPath, settings.PackLoadingDisabled);
 
             if (!Cef.Initialize(settings))

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -51,7 +51,7 @@ namespace CefSharp.Example
                 SchemeHandlerFactory = new CefSharpSchemeHandlerFactory()
             });
 
-            DependencyChecker.AssetAllDependenciesPresent(settings.Locale, settings.LocalesDirPath, settings.ResourcesDirPath);
+            DependencyChecker.AssetAllDependenciesPresent(settings.Locale, settings.LocalesDirPath, settings.ResourcesDirPath, settings.PackLoadingDisabled);
 
             if (!Cef.Initialize(settings))
             {

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 
 namespace CefSharp.Example
 {
@@ -15,6 +14,11 @@ namespace CefSharp.Example
 
         public static void Init()
         {
+            if(!DependencyChecker.AreAllDependenciesPresent())
+            {
+                throw new Exception("Missing Dependencies");
+            }
+
             // Set Google API keys, used for Geolocation requests sans GPS.  See http://www.chromium.org/developers/how-tos/api-keys
             // Environment.SetEnvironmentVariable("GOOGLE_API_KEY", "");
             // Environment.SetEnvironmentVariable("GOOGLE_DEFAULT_CLIENT_ID", "");

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -14,11 +14,6 @@ namespace CefSharp.Example
 
         public static void Init()
         {
-            if(!DependencyChecker.AreAllDependenciesPresent())
-            {
-                throw new Exception("Missing Dependencies");
-            }
-
             // Set Google API keys, used for Geolocation requests sans GPS.  See http://www.chromium.org/developers/how-tos/api-keys
             // Environment.SetEnvironmentVariable("GOOGLE_API_KEY", "");
             // Environment.SetEnvironmentVariable("GOOGLE_DEFAULT_CLIENT_ID", "");
@@ -55,6 +50,17 @@ namespace CefSharp.Example
                 SchemeName = CefSharpSchemeHandlerFactory.SchemeName,
                 SchemeHandlerFactory = new CefSharpSchemeHandlerFactory()
             });
+
+            var locale = string.IsNullOrEmpty(settings.Locale) ? "en-US" : settings.Locale;
+
+            var localPackPath = string.IsNullOrEmpty(settings.LocalesDirPath) ? @"locales\" : settings.LocalesDirPath;
+
+            localPackPath += locale + ".pak";
+
+            if (!DependencyChecker.AreAllDependenciesPresent(localPackPath))
+            {
+                throw new Exception("Missing Dependencies");
+            }
 
             if (!Cef.Initialize(settings))
             {

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -51,12 +51,11 @@ namespace CefSharp.Example
                 SchemeHandlerFactory = new CefSharpSchemeHandlerFactory()
             });
 
+            //Cef will check if all dependencies are present
             //For special case when Checking Windows Xp Dependencies
             //DependencyChecker.IsWindowsXp = true;
 
-            DependencyChecker.AssetAllDependenciesPresent(settings.Locale, settings.LocalesDirPath, settings.ResourcesDirPath, settings.PackLoadingDisabled);
-
-            if (!Cef.Initialize(settings))
+            if (!Cef.Initialize(settings, shutdownOnProcessExit: true, performDependencyCheck: true))
             {
                 throw new Exception("Unable to Initialize Cef");
             }

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -21,7 +21,7 @@ namespace CefSharp.Example
 
             //Chromium Command Line args
             //http://peter.sh/experiments/chromium-command-line-switches/
-            //NOTE: Note all relevant in relation to `CefSharp`, use for reference purposes only.
+            //NOTE: Not all relevant in relation to `CefSharp`, use for reference purposes only.
 
             var settings = new CefSettings();
             settings.RemoteDebuggingPort = 8088;

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -91,6 +91,7 @@
     <Compile Include="CefDirtyRect.cs" />
     <Compile Include="CefFileDialogMode.cs" />
     <Compile Include="DefaultResourceHandlerFactory.cs" />
+    <Compile Include="DependencyChecker.cs" />
     <Compile Include="IJavascriptCallback.cs" />
     <Compile Include="Internals\JavascriptCallbackProxy.cs" />
     <Compile Include="Internals\JavascriptCallback.cs" />

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -90,7 +90,9 @@ namespace CefSharp
                 }
             }
 
-            var localePath = Path.Combine(path, localePackFile);
+            //If path path is not rooted (doesn't start with a drive letter + folder)
+            //then make it relative to the executing assembly.
+            var localePath = Path.IsPathRooted(localePackFile) ? localePackFile : Path.Combine(path, localePackFile);
 
             if (!File.Exists(localePath))
             {
@@ -101,7 +103,7 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Shortcut method that calls <see cref="CheckDependencies()"/>
+        /// Shortcut method that calls <see cref="CheckDependencies(string)"/>
         /// </summary>
         /// <returns>Returns true of missing dependency count is 0</returns>
         public static bool AreAllDependenciesPresent()

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -11,10 +11,13 @@ using System.Text;
 namespace CefSharp
 {
     /// <summary>
-    /// TODO: Expand to support optional dependencies
+    /// DependencyChecker provides a known list of Cef/CefSharp dependencies and 
+    /// provides helper methods to check for their existance.
     /// </summary>
     public static class DependencyChecker
     {
+        public const string LocalesPackFile = @"locales\en-US.pak";
+
         /// <summary>
         /// List of Cef Dependencies
         /// </summary>
@@ -72,11 +75,11 @@ namespace CefSharp
         /// </summary>
         /// <param name="checkOptional">check to see if optional dependencies are present</param>
         /// <param name="path">path to check for dependencies</param>
-        /// <param name="localePackFile">The locale pack file e.g. locales\en-US.pak</param>
         /// <param name="resourcesDirPath"></param>
         /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
+        /// <param name="localePackFile">The locale pack file e.g. <see cref="LocalesPackFile"/> </param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies(bool checkOptional, string path, string localePackFile, string resourcesDirPath, bool packLoadingDisabled)
+        public static List<string> CheckDependencies(bool checkOptional, string path, string resourcesDirPath, bool packLoadingDisabled, string localePackFile = LocalesPackFile)
         {
             var missingDependencies = new List<string>();
 
@@ -172,7 +175,7 @@ namespace CefSharp
                 resourcesDirPath = path;
             }
 
-            var missingDependencies = CheckDependencies(true, path, localesDirPath + locale + ".pak", resourcesDirPath, packLoadingDisabled);
+            var missingDependencies = CheckDependencies(true, path, resourcesDirPath, packLoadingDisabled, localesDirPath + locale + ".pak");
 
             if (missingDependencies.Count > 0)
             {

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -13,6 +13,8 @@ namespace CefSharp
     /// </summary>
     public static class DependencyChecker
     {
+        private const string LocalPackPath = @"locales\en-US.pak";
+
         /// <summary>
         /// List of Cef Dependencies - currently contains all possabilties
         /// </summary>
@@ -46,9 +48,9 @@ namespace CefSharp
         /// <summary>
         /// Check Dependencies relative to the executing assembly
         /// </summary>
-        /// <param name="localePackFile">The local pack file, if empty then locales\en-US.pak will be used</param>
+        /// <param name="localePackFile">The locale pack file, if empty then locales\en-US.pak will be used</param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies(string localePackFile = @"locales\en-US.pak")
+        public static List<string> CheckDependencies(string localePackFile = LocalPackPath)
         {
             var executingAssembly = Assembly.GetExecutingAssembly();
 
@@ -62,7 +64,7 @@ namespace CefSharp
         /// relative to the path provided and returns a list of missing ones
         /// </summary>
         /// <param name="path">path to check for dependencies</param>
-        /// <param name="localePackFile">The local pack file e.g. en-US</param>
+        /// <param name="localePackFile">The locale pack file e.g. locales\en-US.pak</param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
         public static List<string> CheckDependencies(string path, string localePackFile)
         {
@@ -105,10 +107,11 @@ namespace CefSharp
         /// <summary>
         /// Shortcut method that calls <see cref="CheckDependencies(string)"/>
         /// </summary>
+        /// <param name="localePackPath">The locale pack file, if empty then locales\en-US.pak will be used</param>
         /// <returns>Returns true of missing dependency count is 0</returns>
-        public static bool AreAllDependenciesPresent()
+        public static bool AreAllDependenciesPresent(string localePackPath = LocalPackPath)
         {
-            var missingDependencies = CheckDependencies();
+            var missingDependencies = CheckDependencies(localePackPath);
 
             return missingDependencies.Count == 0;
         }

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -17,6 +17,11 @@ namespace CefSharp
     public static class DependencyChecker
     {
         public const string LocalesPackFile = @"locales\en-US.pak";
+        
+        /// <summary>
+        /// IsWindowsXp - Special case for legacy XP support
+        /// </summary>
+        public static bool IsWindowsXp { get; set; }
 
         /// <summary>
         /// List of Cef Dependencies
@@ -48,8 +53,7 @@ namespace CefSharp
             // Note: Without these components HTML5 accelerated content like 2D canvas, 3D CSS and WebGL will not function.
             "libEGL.dll",
             "libGLESv2.dll",
-            "d3dcompiler_43.dll",
-            "d3dcompiler_47.dll",
+            (IsWindowsXp ? "d3dcompiler_43.dll" : "d3dcompiler_47.dll"),
             // PDF support
             // Note: Without this component printing will not function.
             "pdf.dll",
@@ -167,7 +171,7 @@ namespace CefSharp
 
             if (string.IsNullOrEmpty(localesDirPath))
             {
-                localesDirPath = @"locales\";
+                localesDirPath = @"locales";
             }
 
             if (string.IsNullOrEmpty(resourcesDirPath))
@@ -175,7 +179,7 @@ namespace CefSharp
                 resourcesDirPath = path;
             }
 
-            var missingDependencies = CheckDependencies(true, packLoadingDisabled, path, resourcesDirPath, localesDirPath + locale + ".pak");
+            var missingDependencies = CheckDependencies(true, packLoadingDisabled, path, resourcesDirPath, Path.Combine(localesDirPath, locale + ".pak"));
 
             if (missingDependencies.Count > 0)
             {

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -1,0 +1,113 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace CefSharp
+{
+	/// <summary>
+	/// TODO: Expand to support optional dependencies
+	/// </summary>
+	public static class DependencyChecker
+	{
+		/// <summary>
+		/// List of Cef Dependencies - currently contains all possabilties
+		/// </summary>
+		public static string[] CefDependencies =
+		{
+			"libcef.dll",
+			"libEGL.dll",
+			"libGLESv2.dll",
+			"pdf.dll",
+			"icudtl.dat",
+			"ffmpegsumo.dll",
+			"d3dcompiler_43.dll",
+			"d3dcompiler_47.dll",
+			"devtools_resources.pak",
+			"cef.pak",
+			"cef_100_percent.pak",
+			"cef_200_percent.pak"
+		};
+
+		/// <summary>
+		/// List of CefSharp Dependencies
+		/// </summary>
+		public static string[] CefSharpDependencies =
+		{
+			"CefSharp.Core.dll",
+			"CefSharp.dll",
+			"CefSharp.BrowserSubprocess.Core.dll",
+			"CefSharp.BrowserSubprocess.exe"
+		};
+
+		/// <summary>
+		/// Check Dependencies relative to the executing assembly
+		/// </summary>
+		/// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
+		public static List<string> CheckDependencies()
+		{
+			var executingAssembly = Assembly.GetExecutingAssembly();
+
+			var path = Path.GetDirectoryName(executingAssembly.Location);
+
+			return CheckDependencies(path);
+		}
+
+		/// <summary>
+		/// CheckDependencies iterates through the list of Cef and CefSharp dependencines
+		/// relative to the path provided and returns a list of missing ones
+		/// </summary>
+		/// <param name="path">path to check for dependencies</param>
+		/// <param name="localePackFile">The local pack file</param>
+		/// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
+		public static List<string> CheckDependencies(string path, string localePackFile = @"locales\en-US.pak")
+		{
+			var missingDependencies = new List<string>();
+
+			//Loop through Cef dependencies and add to list if not found
+			foreach (var cefDependency in CefDependencies)
+			{
+				var dependencyPath = Path.Combine(path, cefDependency);
+
+				if (!File.Exists(dependencyPath))
+				{
+					missingDependencies.Add(cefDependency);
+				}
+			}
+
+			// Loop through CefSharp dependencies and add to list if not found
+			foreach (var cefSharpDependency in CefSharpDependencies)
+			{
+				var dependencyPath = Path.Combine(path, cefSharpDependency);
+
+				if (!File.Exists(dependencyPath))
+				{
+					missingDependencies.Add(cefSharpDependency);
+				}
+			}
+
+			var localePath = Path.Combine(path, localePackFile);
+
+			if (!File.Exists(localePath))
+			{
+				missingDependencies.Add(localePackFile);
+			}
+
+			return missingDependencies;
+		}
+
+		/// <summary>
+		/// Shortcut method that calls <see cref="CheckDependencies()"/>
+		/// </summary>
+		/// <returns>Returns true of missing dependency count is 0</returns>
+		public static bool AreAllDependenciesPresent()
+		{
+			var missingDependencies = CheckDependencies();
+
+			return missingDependencies.Count == 0;
+		}
+	}
+}

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -74,8 +74,9 @@ namespace CefSharp
         /// <param name="path">path to check for dependencies</param>
         /// <param name="localePackFile">The locale pack file e.g. locales\en-US.pak</param>
         /// <param name="resourcesDirPath"></param>
+        /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies(bool checkOptional, string path, string localePackFile, string resourcesDirPath)
+        public static List<string> CheckDependencies(bool checkOptional, string path, string localePackFile, string resourcesDirPath, bool packLoadingDisabled)
         {
             var missingDependencies = new List<string>();
 
@@ -90,14 +91,17 @@ namespace CefSharp
                 }
             }
 
-            //Loop through Cef Resources and add to list if not found
-            foreach (var cefResource in CefResources)
+            if (!packLoadingDisabled)
             {
-                var resourcePath = Path.Combine(resourcesDirPath, cefResource);
-
-                if (!File.Exists(resourcePath))
+                //Loop through Cef Resources and add to list if not found
+                foreach (var cefResource in CefResources)
                 {
-                    missingDependencies.Add(cefResource);
+                    var resourcePath = Path.Combine(resourcesDirPath, cefResource);
+
+                    if (!File.Exists(resourcePath))
+                    {
+                        missingDependencies.Add(cefResource);
+                    }
                 }
             }
 
@@ -145,8 +149,9 @@ namespace CefSharp
         /// <param name="locale">The locale, if empty then en-US will be used.</param>
         /// <param name="localesDirPath">The path to the locales directory, if empty locales\ will be used.</param>
         /// <param name="resourcesDirPath">The path to the resources directory, if empty the Executing Assembly path is used.</param>
+        /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
         /// <exception cref="Exception">Throw when not all dependencies are present</exception>
-        public static void AssetAllDependenciesPresent(string locale, string localesDirPath, string resourcesDirPath)
+        public static void AssetAllDependenciesPresent(string locale, string localesDirPath, string resourcesDirPath, bool packLoadingDisabled)
         {
             var executingAssembly = Assembly.GetExecutingAssembly();
 
@@ -167,7 +172,7 @@ namespace CefSharp
                 resourcesDirPath = path;
             }
 
-            var missingDependencies = CheckDependencies(true, path, localesDirPath + locale + ".pak", resourcesDirPath);
+            var missingDependencies = CheckDependencies(true, path, localesDirPath + locale + ".pak", resourcesDirPath, packLoadingDisabled);
 
             if (missingDependencies.Count > 0)
             {

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -46,14 +46,15 @@ namespace CefSharp
         /// <summary>
         /// Check Dependencies relative to the executing assembly
         /// </summary>
+        /// <param name="localePackFile">The local pack file, if empty then locales\en-US.pak will be used</param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies()
+        public static List<string> CheckDependencies(string localePackFile = @"locales\en-US.pak")
         {
             var executingAssembly = Assembly.GetExecutingAssembly();
 
             var path = Path.GetDirectoryName(executingAssembly.Location);
 
-            return CheckDependencies(path);
+            return CheckDependencies(path, localePackFile);
         }
 
         /// <summary>
@@ -61,9 +62,9 @@ namespace CefSharp
         /// relative to the path provided and returns a list of missing ones
         /// </summary>
         /// <param name="path">path to check for dependencies</param>
-        /// <param name="localePackFile">The local pack file</param>
+        /// <param name="localePackFile">The local pack file e.g. en-US</param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies(string path, string localePackFile = @"locales\en-US.pak")
+        public static List<string> CheckDependencies(string path, string localePackFile)
         {
             var missingDependencies = new List<string>();
 

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -8,106 +8,106 @@ using System.Reflection;
 
 namespace CefSharp
 {
-	/// <summary>
-	/// TODO: Expand to support optional dependencies
-	/// </summary>
-	public static class DependencyChecker
-	{
-		/// <summary>
-		/// List of Cef Dependencies - currently contains all possabilties
-		/// </summary>
-		public static string[] CefDependencies =
-		{
-			"libcef.dll",
-			"libEGL.dll",
-			"libGLESv2.dll",
-			"pdf.dll",
-			"icudtl.dat",
-			"ffmpegsumo.dll",
-			"d3dcompiler_43.dll",
-			"d3dcompiler_47.dll",
-			"devtools_resources.pak",
-			"cef.pak",
-			"cef_100_percent.pak",
-			"cef_200_percent.pak"
-		};
+    /// <summary>
+    /// TODO: Expand to support optional dependencies
+    /// </summary>
+    public static class DependencyChecker
+    {
+        /// <summary>
+        /// List of Cef Dependencies - currently contains all possabilties
+        /// </summary>
+        public static string[] CefDependencies =
+        {
+            "libcef.dll",
+            "libEGL.dll",
+            "libGLESv2.dll",
+            "pdf.dll",
+            "icudtl.dat",
+            "ffmpegsumo.dll",
+            "d3dcompiler_43.dll",
+            "d3dcompiler_47.dll",
+            "devtools_resources.pak",
+            "cef.pak",
+            "cef_100_percent.pak",
+            "cef_200_percent.pak"
+        };
 
-		/// <summary>
-		/// List of CefSharp Dependencies
-		/// </summary>
-		public static string[] CefSharpDependencies =
-		{
-			"CefSharp.Core.dll",
-			"CefSharp.dll",
-			"CefSharp.BrowserSubprocess.Core.dll",
-			"CefSharp.BrowserSubprocess.exe"
-		};
+        /// <summary>
+        /// List of CefSharp Dependencies
+        /// </summary>
+        public static string[] CefSharpDependencies =
+        {
+            "CefSharp.Core.dll",
+            "CefSharp.dll",
+            "CefSharp.BrowserSubprocess.Core.dll",
+            "CefSharp.BrowserSubprocess.exe"
+        };
 
-		/// <summary>
-		/// Check Dependencies relative to the executing assembly
-		/// </summary>
-		/// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-		public static List<string> CheckDependencies()
-		{
-			var executingAssembly = Assembly.GetExecutingAssembly();
+        /// <summary>
+        /// Check Dependencies relative to the executing assembly
+        /// </summary>
+        /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
+        public static List<string> CheckDependencies()
+        {
+            var executingAssembly = Assembly.GetExecutingAssembly();
 
-			var path = Path.GetDirectoryName(executingAssembly.Location);
+            var path = Path.GetDirectoryName(executingAssembly.Location);
 
-			return CheckDependencies(path);
-		}
+            return CheckDependencies(path);
+        }
 
-		/// <summary>
-		/// CheckDependencies iterates through the list of Cef and CefSharp dependencines
-		/// relative to the path provided and returns a list of missing ones
-		/// </summary>
-		/// <param name="path">path to check for dependencies</param>
-		/// <param name="localePackFile">The local pack file</param>
-		/// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-		public static List<string> CheckDependencies(string path, string localePackFile = @"locales\en-US.pak")
-		{
-			var missingDependencies = new List<string>();
+        /// <summary>
+        /// CheckDependencies iterates through the list of Cef and CefSharp dependencines
+        /// relative to the path provided and returns a list of missing ones
+        /// </summary>
+        /// <param name="path">path to check for dependencies</param>
+        /// <param name="localePackFile">The local pack file</param>
+        /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
+        public static List<string> CheckDependencies(string path, string localePackFile = @"locales\en-US.pak")
+        {
+            var missingDependencies = new List<string>();
 
-			//Loop through Cef dependencies and add to list if not found
-			foreach (var cefDependency in CefDependencies)
-			{
-				var dependencyPath = Path.Combine(path, cefDependency);
+            //Loop through Cef dependencies and add to list if not found
+            foreach (var cefDependency in CefDependencies)
+            {
+                var dependencyPath = Path.Combine(path, cefDependency);
 
-				if (!File.Exists(dependencyPath))
-				{
-					missingDependencies.Add(cefDependency);
-				}
-			}
+                if (!File.Exists(dependencyPath))
+                {
+                    missingDependencies.Add(cefDependency);
+                }
+            }
 
-			// Loop through CefSharp dependencies and add to list if not found
-			foreach (var cefSharpDependency in CefSharpDependencies)
-			{
-				var dependencyPath = Path.Combine(path, cefSharpDependency);
+            // Loop through CefSharp dependencies and add to list if not found
+            foreach (var cefSharpDependency in CefSharpDependencies)
+            {
+                var dependencyPath = Path.Combine(path, cefSharpDependency);
 
-				if (!File.Exists(dependencyPath))
-				{
-					missingDependencies.Add(cefSharpDependency);
-				}
-			}
+                if (!File.Exists(dependencyPath))
+                {
+                    missingDependencies.Add(cefSharpDependency);
+                }
+            }
 
-			var localePath = Path.Combine(path, localePackFile);
+            var localePath = Path.Combine(path, localePackFile);
 
-			if (!File.Exists(localePath))
-			{
-				missingDependencies.Add(localePackFile);
-			}
+            if (!File.Exists(localePath))
+            {
+                missingDependencies.Add(localePackFile);
+            }
 
-			return missingDependencies;
-		}
+            return missingDependencies;
+        }
 
-		/// <summary>
-		/// Shortcut method that calls <see cref="CheckDependencies()"/>
-		/// </summary>
-		/// <returns>Returns true of missing dependency count is 0</returns>
-		public static bool AreAllDependenciesPresent()
-		{
-			var missingDependencies = CheckDependencies();
+        /// <summary>
+        /// Shortcut method that calls <see cref="CheckDependencies()"/>
+        /// </summary>
+        /// <returns>Returns true of missing dependency count is 0</returns>
+        public static bool AreAllDependenciesPresent()
+        {
+            var missingDependencies = CheckDependencies();
 
-			return missingDependencies.Count == 0;
-		}
-	}
+            return missingDependencies.Count == 0;
+        }
+    }
 }

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -74,12 +74,12 @@ namespace CefSharp
         /// relative to the path provided and returns a list of missing ones
         /// </summary>
         /// <param name="checkOptional">check to see if optional dependencies are present</param>
+        /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
         /// <param name="path">path to check for dependencies</param>
         /// <param name="resourcesDirPath"></param>
-        /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
         /// <param name="localePackFile">The locale pack file e.g. <see cref="LocalesPackFile"/> </param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies(bool checkOptional, string path, string resourcesDirPath, bool packLoadingDisabled, string localePackFile = LocalesPackFile)
+        public static List<string> CheckDependencies(bool checkOptional, bool packLoadingDisabled, string path, string resourcesDirPath, string localePackFile = LocalesPackFile)
         {
             var missingDependencies = new List<string>();
 
@@ -175,7 +175,7 @@ namespace CefSharp
                 resourcesDirPath = path;
             }
 
-            var missingDependencies = CheckDependencies(true, path, resourcesDirPath, packLoadingDisabled, localesDirPath + locale + ".pak");
+            var missingDependencies = CheckDependencies(true, packLoadingDisabled, path, resourcesDirPath, localesDirPath + locale + ".pak");
 
             if (missingDependencies.Count > 0)
             {

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -158,7 +158,7 @@ namespace CefSharp
         /// <param name="resourcesDirPath">The path to the resources directory, if empty the Executing Assembly path is used.</param>
         /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
         /// <exception cref="Exception">Throw when not all dependencies are present</exception>
-        public static void AssetAllDependenciesPresent(string locale, string localesDirPath, string resourcesDirPath, bool packLoadingDisabled)
+        public static void AssertAllDependenciesPresent(string locale, string localesDirPath, string resourcesDirPath, bool packLoadingDisabled)
         {
             var executingAssembly = Assembly.GetExecutingAssembly();
 

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -47,7 +47,7 @@ namespace CefSharp
             "pdf.dll",
             //FFmpeg audio and video support
             // Note: Without this component HTML5 audio and video will not function.
-            "ffmpegsumo.dll",
+            "ffmpegsumo.dll"
         };
 
         /// <summary>
@@ -65,10 +65,11 @@ namespace CefSharp
         /// CheckDependencies iterates through the list of Cef and CefSharp dependencines
         /// relative to the path provided and returns a list of missing ones
         /// </summary>
+        /// <param name="checkOptional">check to see if optional dependencies are present</param>
         /// <param name="path">path to check for dependencies</param>
         /// <param name="localePackFile">The locale pack file e.g. locales\en-US.pak</param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
-        public static List<string> CheckDependencies(string path, string localePackFile)
+        public static List<string> CheckDependencies(bool checkOptional, string path, string localePackFile)
         {
             var missingDependencies = new List<string>();
 
@@ -83,14 +84,17 @@ namespace CefSharp
                 }
             }
 
-            //Loop through Cef Optional dependencies and add to list if not found
-            foreach (var cefDependency in CefOptionalDependencies)
+            if (checkOptional)
             {
-                var dependencyPath = Path.Combine(path, cefDependency);
-
-                if (!File.Exists(dependencyPath))
+                //Loop through Cef Optional dependencies and add to list if not found
+                foreach (var cefDependency in CefOptionalDependencies)
                 {
-                    missingDependencies.Add(cefDependency);
+                    var dependencyPath = Path.Combine(path, cefDependency);
+
+                    if (!File.Exists(dependencyPath))
+                    {
+                        missingDependencies.Add(cefDependency);
+                    }
                 }
             }
 
@@ -129,7 +133,7 @@ namespace CefSharp
 
             var path = Path.GetDirectoryName(executingAssembly.Location);
 
-            var missingDependencies = CheckDependencies(path, localePackPath);
+            var missingDependencies = CheckDependencies(true, path, localePackPath);
 
             if (missingDependencies.Count > 0)
             {

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -22,18 +22,32 @@ namespace CefSharp
         /// </summary>
         public static string[] CefDependencies =
         {
+            // CEF core library
             "libcef.dll",
-            "libEGL.dll",
-            "libGLESv2.dll",
-            "pdf.dll",
+            // Unicode support
             "icudtl.dat",
-            "ffmpegsumo.dll",
-            "d3dcompiler_43.dll",
-            "d3dcompiler_47.dll",
+            // Pack Files
+            // Note: Contains WebKit image and inspector resources.
             "devtools_resources.pak",
             "cef.pak",
             "cef_100_percent.pak",
             "cef_200_percent.pak"
+        };
+
+        public static string[] CefOptionalDependencies =
+        {
+            // Angle and Direct3D support
+            // Note: Without these components HTML5 accelerated content like 2D canvas, 3D CSS and WebGL will not function.
+            "libEGL.dll",
+            "libGLESv2.dll",
+            "d3dcompiler_43.dll",
+            "d3dcompiler_47.dll",
+            // PDF support
+            // Note: Without this component printing will not function.
+            "pdf.dll",
+            //FFmpeg audio and video support
+            // Note: Without this component HTML5 audio and video will not function.
+            "ffmpegsumo.dll",
         };
 
         /// <summary>
@@ -60,6 +74,17 @@ namespace CefSharp
 
             //Loop through Cef dependencies and add to list if not found
             foreach (var cefDependency in CefDependencies)
+            {
+                var dependencyPath = Path.Combine(path, cefDependency);
+
+                if (!File.Exists(dependencyPath))
+                {
+                    missingDependencies.Add(cefDependency);
+                }
+            }
+
+            //Loop through Cef Optional dependencies and add to list if not found
+            foreach (var cefDependency in CefOptionalDependencies)
             {
                 var dependencyPath = Path.Combine(path, cefDependency);
 


### PR DESCRIPTION
This is a rough first draft of `DependencyChecker`. Basically loops through list of all Cef/CefSharp dependencies.

Creating this PR before I go too far, some questions to be answered I think.

- Should we provide the option to validate have some dependencies marked as optional?
- What's the expected output if calling from user land? Is a list of strings containing which files are missing ok? Would people just prefer a formatted string?
- Anyone have any thoughts on obtaining the path? I've started with the `ExecutingAssembly` and allowed an overload so that users can call themselves.

Will include an overload for `Cef.Initialize()` that enables/disables the dependency check when I'm happy the other questions have been answered.

Resolves #876