### PR TITLE
Resolve: IsLoaded is unreliable

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -66,6 +66,7 @@ namespace CefSharp.OffScreen
         public event EventHandler<StatusMessageEventArgs> StatusMessage;
         public event EventHandler<NavStateChangedEventArgs> NavStateChanged;
         public event EventHandler<AddressChangedEventArgs> AddressChanged;
+        [Obsolete("IsLoadingChanged is unreliable and will be removed. Use NavStateChanged instead.")]
         public event EventHandler<IsLoadingChangedEventArgs> IsLoadingChanged;
 
         /// <summary>

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -232,6 +232,7 @@ namespace CefSharp.WinForms
         public event EventHandler<AddressChangedEventArgs> AddressChanged;
         public event EventHandler<TitleChangedEventArgs> TitleChanged;
         public event EventHandler<IsBrowserInitializedChangedEventArgs> IsBrowserInitializedChanged;
+        [Obsolete("IsLoadingChanged is unreliable and will be removed. Use NavStateChanged instead.")]
         public event EventHandler<IsLoadingChangedEventArgs> IsLoadingChanged;
 
         protected override void OnHandleCreated(EventArgs e)

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -318,7 +318,7 @@ namespace CefSharp.Wpf
 
         void IWebBrowserInternal.SetIsLoading(bool isLoading)
         {
-            UiThreadRunAsync(() => SetCurrentValue(IsLoadingProperty, isLoading));
+            
         }
 
         void IWebBrowserInternal.SetLoadingStateChange(bool canGoBack, bool canGoForward, bool isLoading)
@@ -328,6 +328,7 @@ namespace CefSharp.Wpf
                 SetCurrentValue(CanGoBackProperty, canGoBack);
                 SetCurrentValue(CanGoForwardProperty, canGoForward);
                 SetCurrentValue(CanReloadProperty, !isLoading);
+                SetCurrentValue(IsLoadingProperty, isLoading);
 
                 ((DelegateCommand)BackCommand).RaiseCanExecuteChanged();
                 ((DelegateCommand)ForwardCommand).RaiseCanExecuteChanged();


### PR DESCRIPTION
http://magpcss.org/ceforum/apidocs3/projects/%28default%29/CefLoadHandler.html#OnLoadStart%28CefRefPtr%3CCefBrowser%3E,CefRefPtr%3CCefFrame%3E%29

`For notification of overall browser load status use OnLoadingStateChange instead.`

Initially just migrating `WPF` control. When it's configured, update the other two flavours.