### PR TITLE
WPF Popup - Change to absolute positioning

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -929,7 +929,7 @@ namespace CefSharp.Wpf
             {
                 Child = popupImage = CreateImage(),
                 PlacementTarget = this,
-                Placement = PlacementMode.Relative,
+                Placement = PlacementMode.Absolute,
             };
 
             newPopup.MouseEnter += PopupMouseEnter;
@@ -1068,8 +1068,11 @@ namespace CefSharp.Wpf
             popup.Height = height;
 
             var popupOffset = new Point(x, y);
-            popup.HorizontalOffset = popupOffset.X / matrix.M11;
-            popup.VerticalOffset = popupOffset.Y / matrix.M22;
+            var locationFromScreen = this.PointToScreen(popupOffset);
+            var targetPoint =
+                PresentationSource.FromVisual(this).CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
+            popup.HorizontalOffset = targetPoint.X;
+            popup.VerticalOffset = targetPoint.Y;
         }
 
         private void OnTooltipTimerTick(object sender, EventArgs e)

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1064,8 +1064,8 @@ namespace CefSharp.Wpf
 
         private void SetPopupSizeAndPositionImpl(int width, int height, int x, int y)
         {
-            popup.Width = width;
-            popup.Height = height;
+            popup.Width = width / matrix.M11;
+            popup.Height = height / matrix.M22;
 
             var popupOffset = new Point(x / matrix.M11, y / matrix.M22);
             var locationFromScreen = PointToScreen(popupOffset);

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1067,12 +1067,10 @@ namespace CefSharp.Wpf
             popup.Width = width;
             popup.Height = height;
 
-            var popupOffset = new Point(x, y);
-            var locationFromScreen = this.PointToScreen(popupOffset);
-            var targetPoint =
-                PresentationSource.FromVisual(this).CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
-            popup.HorizontalOffset = targetPoint.X;
-            popup.VerticalOffset = targetPoint.Y;
+            var popupOffset = new Point(x / matrix.M11, y / matrix.M22);
+            var locationFromScreen = PointToScreen(popupOffset);
+            popup.HorizontalOffset = locationFromScreen.X / matrix.M11;
+            popup.VerticalOffset = locationFromScreen.Y / matrix.M22;
         }
 
         private void OnTooltipTimerTick(object sender, EventArgs e)


### PR DESCRIPTION
This avoids win 8/8.1 menu alignment settings where they can cause devices to not show relative positioned popups where expected.  

This fixes issue #906