### PR TITLE
Call GetZoomLevel On CEF UI Thread

### DIFF
--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -110,7 +110,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir)packages\$(CefSdkVer)\CEF;%(AdditionalIncludeDirectories);$(ProjectDir)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_WIN32_WINNT=0x0600;WINVER=0x0600;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;USING_CEF_SHARED;_CRT_SECURE_NO_WARNINGS;EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WIN32_WINNT=0x0600;WINVER=0x0600;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;USING_CEF_SHARED;_CRT_SECURE_NO_WARNINGS;EXPORT;OS_WIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
@@ -165,7 +165,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)packages\$(CefSdkVer)\CEF;%(AdditionalIncludeDirectories);$(ProjectDir)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_NDEBUG;_WIN32_WINNT=0x0600;WINVER=0x0600;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;USING_CEF_SHARED;_CRT_SECURE_NO_WARNINGS;EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_NDEBUG;_WIN32_WINNT=0x0600;WINVER=0x0600;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;USING_CEF_SHARED;_CRT_SECURE_NO_WARNINGS;EXPORT;OS_WIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -1,10 +1,13 @@
-// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 #pragma once
 
 #include "Stdafx.h"
+
+#include <include/cef_runnable.h>
+
 #include "BrowserSettings.h"
 #include "PaintElementType.h"
 #include "Internals/ClientAdapter.h"
@@ -16,6 +19,7 @@
 using namespace CefSharp::Internals;
 using namespace System::Diagnostics;
 using namespace System::ServiceModel;
+using namespace System::Threading;
 using namespace System::Threading::Tasks;
 
 namespace CefSharp
@@ -576,13 +580,37 @@ namespace CefSharp
             return _browserProcessServiceHost->EvaluateScriptAsync(browser->GetIdentifier(), frame->GetIdentifier(), script, timeout);
         }
 
+    private:
+        static void _GetZoomLevel(const CefRefPtr<CefBrowserHost> const host, HANDLE event, double *zoomLevel)
+        {
+            *zoomLevel = host->GetZoomLevel();
+            SetEvent(event);
+        }
+
+    public:
         double GetZoomLevel()
         {
             auto browser = _clientAdapter->GetCefBrowser();
 
             if (browser != nullptr)
             {
-                return browser->GetHost()->GetZoomLevel();
+                auto host = browser->GetHost();
+                if (CefCurrentlyOn(TID_UI))
+                {
+                    return host->GetZoomLevel();
+                }
+                else
+                {
+                    // TODO: Add an async version of GetZoomLevel at some point.
+                    // NOTE: Use of ManualResetEvent is required here in order
+                    // for simple marshaling of some kind of synchronization primitive
+                    // to the callback.
+                    ManualResetEvent^ event = gcnew ManualResetEvent(false);
+                    double zoomLevel;
+                    CefPostTask(TID_UI, NewCefRunnableFunction(_GetZoomLevel, host, (HANDLE)event->Handle.ToPointer(), &zoomLevel));
+                    event->WaitOne();
+                    return zoomLevel;
+                }
             }
 
             return 0;

--- a/CefSharp.WinForms.Example/BrowserForm.Designer.cs
+++ b/CefSharp.WinForms.Example/BrowserForm.Designer.cs
@@ -255,21 +255,21 @@
             this.zoomInToolStripMenuItem.Name = "zoomInToolStripMenuItem";
             this.zoomInToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.zoomInToolStripMenuItem.Text = "Zoom In";
-            this.zoomInToolStripMenuItem.Click += new System.EventHandler(this.zoomInToolStripMenuItem_Click);
+            this.zoomInToolStripMenuItem.Click += new System.EventHandler(this.ZoomInToolStripMenuItemClick);
             // 
             // zoomOutToolStripMenuItem
             // 
             this.zoomOutToolStripMenuItem.Name = "zoomOutToolStripMenuItem";
             this.zoomOutToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.zoomOutToolStripMenuItem.Text = "Zoom Out";
-            this.zoomOutToolStripMenuItem.Click += new System.EventHandler(this.zoomOutToolStripMenuItem_Click);
+            this.zoomOutToolStripMenuItem.Click += new System.EventHandler(this.ZoomOutToolStripMenuItemClick);
             // 
             // currentZoomLevelToolStripMenuItem
             // 
             this.currentZoomLevelToolStripMenuItem.Name = "currentZoomLevelToolStripMenuItem";
             this.currentZoomLevelToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.currentZoomLevelToolStripMenuItem.Text = "Current Zoom Level";
-            this.currentZoomLevelToolStripMenuItem.Click += new System.EventHandler(this.currentZoomLevelToolStripMenuItem_Click);
+            this.currentZoomLevelToolStripMenuItem.Click += new System.EventHandler(this.CurrentZoomLevelToolStripMenuItemClick);
             // 
             // BrowserForm
             // 

--- a/CefSharp.WinForms.Example/BrowserForm.Designer.cs
+++ b/CefSharp.WinForms.Example/BrowserForm.Designer.cs
@@ -36,6 +36,7 @@
             this.printToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showDevToolsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.closeDevToolsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -51,7 +52,10 @@
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.copySourceToClipBoardAsyncMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.browserTabControl = new System.Windows.Forms.TabControl();
-            this.closeDevToolsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.zoomLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.zoomInToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.zoomOutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.currentZoomLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -59,7 +63,8 @@
             // 
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
-            this.editToolStripMenuItem});
+            this.editToolStripMenuItem,
+            this.zoomLevelToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Size = new System.Drawing.Size(730, 24);
@@ -235,12 +240,36 @@
             this.browserTabControl.Size = new System.Drawing.Size(730, 466);
             this.browserTabControl.TabIndex = 2;
             // 
-            // closeDevToolsMenuItem
+            // zoomLevelToolStripMenuItem
             // 
-            this.closeDevToolsMenuItem.Name = "closeDevToolsMenuItem";
-            this.closeDevToolsMenuItem.Size = new System.Drawing.Size(158, 22);
-            this.closeDevToolsMenuItem.Text = "Close Dev Tools";
-            this.closeDevToolsMenuItem.Click += new System.EventHandler(this.CloseDevToolsMenuItemClick);
+            this.zoomLevelToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.zoomInToolStripMenuItem,
+            this.zoomOutToolStripMenuItem,
+            this.currentZoomLevelToolStripMenuItem});
+            this.zoomLevelToolStripMenuItem.Name = "zoomLevelToolStripMenuItem";
+            this.zoomLevelToolStripMenuItem.Size = new System.Drawing.Size(81, 20);
+            this.zoomLevelToolStripMenuItem.Text = "Zoom Level";
+            // 
+            // zoomInToolStripMenuItem
+            // 
+            this.zoomInToolStripMenuItem.Name = "zoomInToolStripMenuItem";
+            this.zoomInToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.zoomInToolStripMenuItem.Text = "Zoom In";
+            this.zoomInToolStripMenuItem.Click += new System.EventHandler(this.zoomInToolStripMenuItem_Click);
+            // 
+            // zoomOutToolStripMenuItem
+            // 
+            this.zoomOutToolStripMenuItem.Name = "zoomOutToolStripMenuItem";
+            this.zoomOutToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.zoomOutToolStripMenuItem.Text = "Zoom Out";
+            this.zoomOutToolStripMenuItem.Click += new System.EventHandler(this.zoomOutToolStripMenuItem_Click);
+            // 
+            // currentZoomLevelToolStripMenuItem
+            // 
+            this.currentZoomLevelToolStripMenuItem.Name = "currentZoomLevelToolStripMenuItem";
+            this.currentZoomLevelToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.currentZoomLevelToolStripMenuItem.Text = "Current Zoom Level";
+            this.currentZoomLevelToolStripMenuItem.Click += new System.EventHandler(this.currentZoomLevelToolStripMenuItem_Click);
             // 
             // BrowserForm
             // 
@@ -285,6 +314,10 @@
         private System.Windows.Forms.ToolStripMenuItem closeTabToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem printToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem closeDevToolsMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem zoomLevelToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem zoomInToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem zoomOutToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem currentZoomLevelToolStripMenuItem;
 
     }
 }

--- a/CefSharp.WinForms.Example/BrowserForm.cs
+++ b/CefSharp.WinForms.Example/BrowserForm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2010-2014 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
@@ -11,6 +11,9 @@ namespace CefSharp.WinForms.Example
     public partial class BrowserForm : Form
     {
         private const string DefaultUrlForAddedTabs = "https://www.google.com";
+
+        // Default to WPF default increment:
+        private double zoomIncrement = 0.10;
 
         public BrowserForm()
         {
@@ -228,6 +231,37 @@ namespace CefSharp.WinForms.Example
             if (control != null)
             {
                 control.Browser.CloseDevTools();
+            }
+        }
+
+        private void zoomInToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var control = GetCurrentTabControl();
+            if (control != null)
+            {
+                // NOTE: Because GetZoomLevel is async, non example apps
+                // should consider caching ZoomLevel (although, sadly CEF
+                // doesn't expose a 'OnZoomLevelChanged' callback)
+                // I'm not particularly sure, that such a thing is needed.
+                control.Browser.ZoomLevel += zoomIncrement;
+            }
+        }
+
+        private void zoomOutToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var control = GetCurrentTabControl();
+            if (control != null)
+            {
+                control.Browser.ZoomLevel -= zoomIncrement;
+            }
+        }
+
+        private void currentZoomLevelToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var control = GetCurrentTabControl();
+            if (control != null)
+            {
+                MessageBox.Show("Current ZoomLevel: " + control.Browser.ZoomLevel);
             }
         }
     }

--- a/CefSharp.WinForms.Example/BrowserForm.cs
+++ b/CefSharp.WinForms.Example/BrowserForm.cs
@@ -12,8 +12,8 @@ namespace CefSharp.WinForms.Example
     {
         private const string DefaultUrlForAddedTabs = "https://www.google.com";
 
-        // Default to WPF default increment:
-        private double zoomIncrement = 0.10;
+        // Default to a small increment:
+        private const double zoomIncrement = 0.10;
 
         public BrowserForm()
         {
@@ -234,7 +234,7 @@ namespace CefSharp.WinForms.Example
             }
         }
 
-        private void zoomInToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ZoomInToolStripMenuItemClick(object sender, EventArgs e)
         {
             var control = GetCurrentTabControl();
             if (control != null)
@@ -247,7 +247,7 @@ namespace CefSharp.WinForms.Example
             }
         }
 
-        private void zoomOutToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ZoomOutToolStripMenuItemClick(object sender, EventArgs e)
         {
             var control = GetCurrentTabControl();
             if (control != null)
@@ -256,7 +256,7 @@ namespace CefSharp.WinForms.Example
             }
         }
 
-        private void currentZoomLevelToolStripMenuItem_Click(object sender, EventArgs e)
+        private void CurrentZoomLevelToolStripMenuItemClick(object sender, EventArgs e)
         {
             var control = GetCurrentTabControl();
             if (control != null)


### PR DESCRIPTION
GetZoomLevel is required to be called from the UI thread, but it has a failure mode of just returning 0 when its not on the UI thread. Here's a cheesy temporary solution to avoid adding a full on GetZoomLevelAsync method that returns a .Net task.

Bill
