### PR TITLE
Add late binding to Javascript object

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
@@ -5,6 +5,7 @@
 #include "Stdafx.h"
 #include "TypeUtils.h"
 #include "JavascriptMethodHandler.h"
+#include "JavascriptObjectWrapper.h"
 
 using namespace CefSharp::Internals;
 
@@ -59,39 +60,6 @@ namespace CefSharp
 
     CefRefPtr<CefV8Value> JavascriptMethodHandler::ConvertToCefObject(Object^ obj)
     {
-        if (obj == nullptr)
-        {
-            return CefV8Value::CreateNull();
-        }
-
-        auto type = obj->GetType();
-
-        if (type == JavascriptObject::typeid)
-        {
-            JavascriptObject^ javascriptObject = (JavascriptObject^)obj;
-            CefRefPtr<CefV8Value> cefObject = CefV8Value::CreateObject(NULL);
-
-            for (int i = 0; i < javascriptObject->Properties->Count; i++)
-            {
-                auto prop = javascriptObject->Properties[i];
-
-                if (prop->IsComplexType)
-                {
-                    auto v8Value = ConvertToCefObject(prop->JsObject);
-
-                    cefObject->SetValue(StringUtils::ToNative(prop->JavascriptName), v8Value, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                }
-                else
-                {
-                    auto v8Value = TypeUtils::ConvertToCef(prop->PropertyValue, nullptr);
-
-                    cefObject->SetValue(StringUtils::ToNative(prop->JavascriptName), v8Value, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                }
-            }
-
-            return cefObject;
-        }
-
         return TypeUtils::ConvertToCef(obj, nullptr);
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.cpp
@@ -6,6 +6,7 @@
 #include "Stdafx.h"
 
 #include "JavascriptMethodWrapper.h"
+#include "JavascriptObjectWrapper.h"
 
 using namespace System;
 
@@ -21,6 +22,13 @@ namespace CefSharp
 
     BrowserProcessResponse^ JavascriptMethodWrapper::Execute(array<Object^>^ parameters)
     {
-        return _browserProcess->CallMethod(_ownerId, _javascriptMethod->JavascriptName, parameters);
+        auto resp = _browserProcess->CallMethod(_ownerId, _javascriptMethod->JavascriptName, parameters);
+        if (resp->Result->GetType() == JavascriptObject::typeid) {
+            auto obj = safe_cast<JavascriptObject^>(resp->Result);
+            auto j = gcnew JavascriptObjectWrapper(obj, _browserProcess);
+            j->Bind();
+            resp->Result = j;
+        }
+        return resp;
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptObjectWrapper.h
@@ -24,7 +24,7 @@ namespace CefSharp
     private:
         JavascriptObject^ _object;
         List<JavascriptMethodWrapper^>^ _wrappedMethods;
-        List<JavascriptPropertyWrapper^>^ _wrappedProperties;
+        Dictionary<String^, JavascriptPropertyWrapper^>^ _wrappedProperties;
         IBrowserProcess^ _browserProcess;
         MCefRefPtr<JavascriptPropertyHandler> _jsPropertyHandler;
 
@@ -39,7 +39,7 @@ namespace CefSharp
             _browserProcess = browserProcess;
 
             _wrappedMethods = gcnew List<JavascriptMethodWrapper^>();
-            _wrappedProperties = gcnew List<JavascriptPropertyWrapper^>();
+            _wrappedProperties = gcnew Dictionary<String^, JavascriptPropertyWrapper^>();
         }
 
         ~JavascriptObjectWrapper()
@@ -53,7 +53,7 @@ namespace CefSharp
             {
                 delete var;
             }
-            for each (JavascriptPropertyWrapper^ var in _wrappedProperties)
+            for each (JavascriptPropertyWrapper^ var in _wrappedProperties->Values)
             {
                 delete var;
             }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.cpp
@@ -15,21 +15,7 @@ namespace CefSharp
     void JavascriptPropertyWrapper::Bind()
     {
         auto propertyName = StringUtils::ToNative(_javascriptProperty->JavascriptName);
-        auto clrPropertyName = _javascriptProperty->JavascriptName;
-
-        if (_javascriptProperty->IsComplexType)
-        {
-            auto javascriptObjectWrapper = gcnew JavascriptObjectWrapper(_javascriptProperty->JsObject, _browserProcess);
-            javascriptObjectWrapper->V8Value = V8Value.get();
-            javascriptObjectWrapper->Bind();
-
-            _javascriptObjectWrapper = javascriptObjectWrapper;
-        }
-        else
-        {
-            auto propertyAttribute = _javascriptProperty->IsReadOnly ? V8_PROPERTY_ATTRIBUTE_READONLY : V8_PROPERTY_ATTRIBUTE_NONE;
-
-            V8Value->SetValue(propertyName, V8_ACCESS_CONTROL_DEFAULT, propertyAttribute);
-        }
-    };
+        auto propertyAttribute = _javascriptProperty->IsReadOnly ? V8_PROPERTY_ATTRIBUTE_READONLY : V8_PROPERTY_ATTRIBUTE_NONE;
+        V8Value->SetValue(propertyName, V8_ACCESS_CONTROL_DEFAULT, propertyAttribute);
+    }
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyWrapper.h
@@ -17,9 +17,9 @@ namespace CefSharp
         JavascriptProperty^ _javascriptProperty;
         int64 _ownerId;
         IBrowserProcess^ _browserProcess;
+    internal:
         //TODO: Strongly type this variable - currently trying to include JavascriptObjectWrapper.h creates a circular reference, so won't compile
         Object^ _javascriptObjectWrapper;
-    internal:
         MCefRefPtr<CefV8Value> V8Value;
 
     public:

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -7,6 +7,7 @@
 #include "Stdafx.h"
 #include ".\..\CefSharp.Core\Internals\StringUtils.h"
 #include "TypeUtils.h"
+#include "JavascriptObjectWrapper.h"
 
 using namespace CefSharp::Internals;
 using namespace System;
@@ -28,6 +29,11 @@ namespace CefSharp
         if (type == nullptr)
         {
             type = obj->GetType();
+        }
+
+        if (type == JavascriptObjectWrapper::typeid) {
+            auto j = safe_cast<JavascriptObjectWrapper^>(obj);
+            return j->V8Value.get();
         }
 
         Type^ underlyingType = Nullable::GetUnderlyingType(type);

--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -11,6 +11,17 @@ namespace CefSharp.Example
         public Type MyUnconvertibleProperty { get; set; }
         public SubBoundObject SubObject { get; set; }
 
+        public SubBoundObject[] MyObjects
+        {
+            get
+            {
+                return new SubBoundObject[] {
+                    new SubBoundObject() {SimpleProperty="Hello"}, new SubBoundObject() {SimpleProperty="CefSharp"}
+                };
+            }
+            set { }
+        }
+
         public uint[] MyUintArray
         {
             get

--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -11,13 +11,55 @@ namespace CefSharp.Example
         public Type MyUnconvertibleProperty { get; set; }
         public SubBoundObject SubObject { get; set; }
 
+        public uint[] MyUintArray
+        {
+            get
+            {
+                return new uint[] { 4, 5, 6, 7, 8 };
+            }
+            set
+            {
+            }
+        }
+
+        public int[] MyIntArray
+        {
+            get
+            {
+                return new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            }
+            set
+            {
+            }
+        }
+
+        public Array MyArray
+        {
+            get {
+                return new short[] { 1, 2, 3 };
+            }
+            set
+            {
+            }
+        }
+
+        public byte[] MyBytes
+        {
+            get
+            {
+                return new byte[] { 3, 4, 5 };
+            }
+            set
+            {
+            }
+        }
         public BoundObject()
         {
             MyProperty = 42;
             MyReadOnlyProperty = "I'm immutable!";
             IgnoredProperty = "I am an Ignored Property";
             MyUnconvertibleProperty = GetType();
-            SubObject = new SubBoundObject();
+            SubObject = new SubBoundObject() { Parent = this };
         }
 
         public void TestCallback(IJavascriptCallback javascriptCallback)

--- a/CefSharp.Example/SubBoundObject.cs
+++ b/CefSharp.Example/SubBoundObject.cs
@@ -2,6 +2,8 @@
 {
 	public class SubBoundObject
 	{
+        public BoundObject Parent { get; set; }
+
 		public string SimpleProperty { get; set; }
 
 		public SubBoundObject()

--- a/CefSharp/Internals/BrowserProcessResponse.cs
+++ b/CefSharp/Internals/BrowserProcessResponse.cs
@@ -2,11 +2,27 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace CefSharp.Internals
 {
 	[DataContract]
+    [KnownType(typeof(JavascriptObject))]
+    [KnownType(typeof(bool[]))]
+    [KnownType(typeof(byte[]))]
+    [KnownType(typeof(short[]))]
+    [KnownType(typeof(int[]))]
+    [KnownType(typeof(long[]))]
+    [KnownType(typeof(ushort[]))]
+    [KnownType(typeof(uint[]))]
+    [KnownType(typeof(ulong[]))]
+    [KnownType(typeof(float[]))]
+    [KnownType(typeof(double[]))]
+    [KnownType(typeof(string[]))]
+    [KnownType(typeof(JavascriptObject[]))]
 	public class BrowserProcessResponse
 	{
 		[DataMember]

--- a/CefSharp/Internals/JavascriptObject.cs
+++ b/CefSharp/Internals/JavascriptObject.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -10,6 +11,8 @@ namespace CefSharp.Internals
     [DataContract]
     public class JavascriptObject //: DynamicObject maybe later
     {
+        private bool bound = false;
+
         /// <summary>
         /// Identifies the <see cref="JavascriptObject" /> for BrowserProcess to RenderProcess communication
         /// </summary>
@@ -23,6 +26,11 @@ namespace CefSharp.Internals
         public string JavascriptName { get; set; }
 
         /// <summary>
+        /// Indicate if JavascriptName is camel case or not
+        /// </summary>
+        internal bool CamelCaseJavascriptNames { get; set; }
+
+        /// <summary>
         /// Gets the methods of the <see cref="JavascriptObject" />.
         /// </summary>
         [DataMember]
@@ -33,6 +41,23 @@ namespace CefSharp.Internals
         /// </summary>
         [DataMember]
         public List<JavascriptProperty> Properties { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a delegate which is called when binding occured.  
+        /// </summary>
+        internal Action LateBinding { private get; set; }
+
+        /// <summary>
+        /// Calls <see cref="LateBinding" /> if not already bound.
+        /// </summary>
+        /// <returns>this, so that calls can be chained.</returns>
+        internal JavascriptObject Bind()
+        {
+            if (!bound && LateBinding != null)
+                LateBinding();
+            bound = true;
+            return this;
+        }
 
         /// <summary>
         /// Gets or sets the value.

--- a/CefSharp/Internals/JavascriptObject.cs
+++ b/CefSharp/Internals/JavascriptObject.cs
@@ -12,6 +12,7 @@ namespace CefSharp.Internals
     public class JavascriptObject //: DynamicObject maybe later
     {
         private bool bound = false;
+        private object value = null;
 
         /// <summary>
         /// Identifies the <see cref="JavascriptObject" /> for BrowserProcess to RenderProcess communication
@@ -43,7 +44,15 @@ namespace CefSharp.Internals
         public List<JavascriptProperty> Properties { get; private set; }
 
         /// <summary>
-        /// Gets or sets a delegate which is called when binding occured.  
+        /// Indicate if the <see cref="JavascriptObject" /> is null, so that on browser side we don't need to create an cef object.
+        /// </summary>
+        [DataMember]
+        public bool IsNull { get; private set; }
+
+        internal bool IsArray { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate which is called when binding occurred.  
         /// </summary>
         internal Action LateBinding { private get; set; }
 
@@ -62,7 +71,15 @@ namespace CefSharp.Internals
         /// <summary>
         /// Gets or sets the value.
         /// </summary>
-        public object Value { get; set; }
+        public object Value
+        {
+            get { return value; }
+            set
+            {
+                this.value = value;
+                IsNull = value == null;
+            }
+        }
 
         public JavascriptObject()
         {

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -22,14 +22,14 @@ namespace CefSharp.Internals
             RootObject = new JavascriptRootObject();
         }
 
-        internal JavascriptObject CreateJavascriptObject()
+        internal JavascriptObject CreateJavascriptObject(bool lowercased)
         {
             long id;
             lock (Lock)
             {
                 id = lastId++;
             }
-            var result = new JavascriptObject { Id = id };
+            var result = new JavascriptObject { Id = id, CamelCaseJavascriptNames = lowercased };
             objects[id] = result;
 
             return result;
@@ -37,12 +37,12 @@ namespace CefSharp.Internals
 
         public void Register(string name, object value, bool camelCaseJavascriptNames)
         {
-            var jsObject = CreateJavascriptObject();
+            var jsObject = CreateJavascriptObject(camelCaseJavascriptNames);
             jsObject.Value = value;
             jsObject.Name = name;
             jsObject.JavascriptName = name;
 
-            AnalyseObjectForBinding(jsObject, analyseMethods: true, readPropertyValue: false, camelCaseJavascriptNames: camelCaseJavascriptNames);
+            AnalyseObjectForBinding(jsObject, camelCaseJavascriptNames);
 
             RootObject.MemberObjects.Add(jsObject);
         }
@@ -83,12 +83,12 @@ namespace CefSharp.Internals
 
                 if(result != null && IsComplexType(result.GetType()))
                 {
-                    var jsObject = CreateJavascriptObject();
+                    var jsObject = CreateJavascriptObject(obj.CamelCaseJavascriptNames);
                     jsObject.Value = result;
                     jsObject.Name = "FunctionResult(" + name + ")";
                     jsObject.JavascriptName = jsObject.Name;
 
-                    AnalyseObjectForBinding(jsObject, analyseMethods: false, readPropertyValue: true, camelCaseJavascriptNames:true);
+                    AnalyseObjectForBinding(jsObject, obj.CamelCaseJavascriptNames);
 
                     result = jsObject;
                 }
@@ -117,6 +117,12 @@ namespace CefSharp.Internals
             if (property == null)
             {
                 throw new InvalidOperationException(string.Format("Property {0} not found on Object of Type {1}", name, obj.Value.GetType()));
+            }
+
+            if (property.JsObject != null)
+            {
+                result = property.JsObject.Bind();
+                return true;
             }
 
             try
@@ -164,13 +170,11 @@ namespace CefSharp.Internals
         /// <summary>
         /// Analyse the object and generate metadata which will
         /// be used by the browser subprocess to interact with Cef.
-        /// Method is called recursively
+        /// Method is NOT called recursively and use late binding instead
         /// </summary>
         /// <param name="obj">Javascript object</param>
-        /// <param name="analyseMethods">Analyse methods for inclusion in metadata model</param>
-        /// <param name="readPropertyValue">When analysis is done on a property, if true then get it's value for transmission over WCF</param>
         /// <param name="camelCaseJavascriptNames">camel case the javascript names of properties/methods</param>
-        private void AnalyseObjectForBinding(JavascriptObject obj, bool analyseMethods, bool readPropertyValue, bool camelCaseJavascriptNames)
+        private void AnalyseObjectForBinding(JavascriptObject obj, bool camelCaseJavascriptNames)
         {
             if (obj.Value == null)
             {
@@ -183,19 +187,16 @@ namespace CefSharp.Internals
                 return;
             }
 
-            if (analyseMethods)
+            foreach (var methodInfo in type.GetMethods(BindingFlags.Instance | BindingFlags.Public).Where(p => !p.IsSpecialName))
             {
-                foreach (var methodInfo in type.GetMethods(BindingFlags.Instance | BindingFlags.Public).Where(p => !p.IsSpecialName))
+                // Type objects can not be serialized.
+                if (methodInfo.ReturnType == typeof(Type) || Attribute.IsDefined(methodInfo, typeof(JavascriptIgnoreAttribute)))
                 {
-                    // Type objects can not be serialized.
-                    if (methodInfo.ReturnType == typeof (Type) || Attribute.IsDefined(methodInfo, typeof (JavascriptIgnoreAttribute)))
-                    {
-                        continue;
-                    }
-
-                    var jsMethod = CreateJavaScriptMethod(methodInfo, camelCaseJavascriptNames);
-                    obj.Methods.Add(jsMethod);
+                    continue;
                 }
+
+                var jsMethod = CreateJavaScriptMethod(methodInfo, camelCaseJavascriptNames);
+                obj.Methods.Add(jsMethod);
             }
 
             foreach (var propertyInfo in type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => !p.IsSpecialName))
@@ -208,18 +209,17 @@ namespace CefSharp.Internals
                 var jsProperty = CreateJavaScriptProperty(propertyInfo, camelCaseJavascriptNames);
                 if (jsProperty.IsComplexType)
                 {
-                    var jsObject = CreateJavascriptObject();
+                    var jsObject = CreateJavascriptObject(camelCaseJavascriptNames);
                     jsObject.Name = propertyInfo.Name;
                     jsObject.JavascriptName = GetJavascriptName(propertyInfo.Name, camelCaseJavascriptNames);
-                    jsObject.Value = jsProperty.GetValue(obj.Value);
+                    jsObject.LateBinding = () =>
+                    {
+                        jsObject.Value = jsProperty.GetValue(obj.Value);
+                        AnalyseObjectForBinding(jsObject, camelCaseJavascriptNames);
+                    };
                     jsProperty.JsObject = jsObject;
+                }
 
-                    AnalyseObjectForBinding(jsProperty.JsObject, analyseMethods, readPropertyValue, camelCaseJavascriptNames);
-                }
-                else if (readPropertyValue)
-                {
-                    jsProperty.PropertyValue = jsProperty.GetValue(obj.Value);
-                }
                 obj.Properties.Add(jsProperty);
             }
         }


### PR DESCRIPTION
Added late binding to JavaScript object, so that objects with cyclic
reference don't cause stack overflow (updated example to prove that),
and also improve performance when binding objects with large or deep
object tree.

For consistency, modified method calls to return a true object, just
like property calls. Also pass down camelCaseJavascriptNames flag to
sub-objects so that naming remain the same.

Added a few KnownTypes to support value type arrays.