### PR TITLE
OffScreen Performance Tweak

### DIFF
--- a/CefSharp.OffScreen.Example/Program.cs
+++ b/CefSharp.OffScreen.Example/Program.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using CefSharp.Example;
 
@@ -14,63 +13,73 @@ namespace CefSharp.OffScreen.Example
 {
     public class Program
     {
-        private static ChromiumWebBrowser browser;
-        private static bool captureFirstRenderedImage = false;
+        private const string TestUrl = "https://www.google.com/";
 
         public static void Main(string[] args)
         {
-            const string testUrl = "https://www.google.com/";
-
-            Console.WriteLine("This example application will load {0}, take a screenshot, and save it to your desktop.", testUrl);
+            Console.WriteLine("This example application will load {0}, take a screenshot, and save it to your desktop.", TestUrl);
             Console.WriteLine("You may see a lot of Chromium debugging output, please wait...");
             Console.WriteLine();
 
             // You need to replace this with your own call to Cef.Initialize();
             CefExample.Init();
 
-            // Create the offscreen Chromium browser.
-            using (browser = new ChromiumWebBrowser(testUrl))
-            {
+            MainAsync();
 
-                // An event that is fired when the first page is finished loading.
-                // This returns to us from another thread.
-                if (captureFirstRenderedImage)
-                {
-                    browser.ResourceHandlerFactory.RegisterHandler(testUrl, ResourceHandler.FromString("<html><body><h1>CefSharp OffScreen</h1></body></html>"));
-                    browser.ScreenshotAsync().ContinueWith(DisplayBitmap);
-                }
-                else
-                {
-                    browser.FrameLoadEnd += BrowserFrameLoadEnd;
-                }
-
-                // We have to wait for something, otherwise the process will exit too soon.
-                Console.ReadKey();
-            }
+            // We have to wait for something, otherwise the process will exit too soon.
+            Console.ReadKey();
 
             // Clean up Chromium objects.  You need to call this in your application otherwise
             // you will get a crash when closing.
             Cef.Shutdown();
         }
 
-        private static void BrowserFrameLoadEnd(object sender, FrameLoadEndEventArgs e)
+        private static async void MainAsync()
         {
-            // Check to ensure it is the main frame which has finished loading
-            // (rather than an iframe within the main frame).
-            if (e.IsMainFrame)
+
+            // Create the offscreen Chromium browser.
+            using (var browser = new ChromiumWebBrowser(TestUrl))
             {
-                // Remove the load event handler, because we only want one snapshot of the initial page.
-                browser.FrameLoadEnd -= BrowserFrameLoadEnd;
+                await LoadPageAsync(browser);
 
                 // Wait for the screenshot to be taken.
-                browser.ScreenshotAsync().ContinueWith(DisplayBitmap);
+                await browser.ScreenshotAsync().ContinueWith(DisplayBitmap);
+
+                await LoadPageAsync(browser, "http://github.com");
+
+                // Wait for the screenshot to be taken.
+                await browser.ScreenshotAsync().ContinueWith(DisplayBitmap);
             }
+        }
+
+        public static Task LoadPageAsync(IWebBrowser browser, string address = null)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            EventHandler<LoadingStateChangedEventArgs> handler = null;
+            handler += (sender, args) =>
+            {
+                //Wait for while page to finish loading not just the first frame
+                if (!args.IsLoading)
+                {
+                    browser.LoadingStateChanged -= handler;
+                    tcs.TrySetResult(true);
+                }
+            };
+
+            browser.LoadingStateChanged += handler;
+
+            if (!string.IsNullOrEmpty(address))
+            {
+                browser.Load(address);
+            }
+            return tcs.Task;
         }
 
         private static void DisplayBitmap(Task<Bitmap> task)
         {
             // Make a file to save it to (e.g. C:\Users\jan\Desktop\CefSharp screenshot.png)
-            var screenshotPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "CefSharp screenshot.png");
+            var screenshotPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "CefSharp screenshot" + DateTime.Now.Ticks + ".png");
 
             Console.WriteLine();
             Console.WriteLine("Screenshot ready. Saving to {0}", screenshotPath);

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -7,7 +7,6 @@ using System.Drawing;
 using System.Text;
 using System.Threading.Tasks;
 using CefSharp.Internals;
-using PixelFormat = System.Drawing.Imaging.PixelFormat;
 
 namespace CefSharp.OffScreen
 {
@@ -297,7 +296,7 @@ namespace CefSharp.OffScreen
                 throw new Exception("Implement IResourceHandlerFactory and assign to the ResourceHandlerFactory property to use this feature");
             }
 
-            factory.RegisterHandler(url, CefSharp.ResourceHandler.FromString(html, encoding, true));
+            factory.RegisterHandler(url, ResourceHandler.FromString(html, encoding, true));
 
             Load(url);
         }
@@ -397,9 +396,15 @@ namespace CefSharp.OffScreen
             return new GdiBitmapInfo { IsPopup = isPopup, BitmapLock = bitmapLock };
         }
 
+        /// <summary>
+        /// Invoked from CefRenderHandler.OnPaint
+        /// Locking provided by OnPaint as this method is called in it's lock scope
+        /// </summary>
+        /// <param name="bitmapInfo">information about the bitmap to be rendered</param>
         void IRenderWebBrowser.InvokeRenderAsync(BitmapInfo bitmapInfo)
         {
-            lock (bitmapLock)
+            var gdiBitmapInfo = (GdiBitmapInfo)bitmapInfo;
+            if (bitmapInfo.CreateNewBitmap)
             {
                 if (bitmap != null)
                 {
@@ -407,15 +412,13 @@ namespace CefSharp.OffScreen
                     bitmap = null;
                 }
 
-                var stride = bitmapInfo.Width * bitmapInfo.BytesPerPixel;
+                bitmap = gdiBitmapInfo.CreateBitmap();
+            }
 
-                bitmap = new Bitmap(bitmapInfo.Width, bitmapInfo.Height, stride, PixelFormat.Format32bppPArgb, bitmapInfo.BackBufferHandle);
-                
-                var handler = NewScreenshot;
-                if (handler != null)
-                {
-                    handler(this, EventArgs.Empty);
-                }
+            var handler = NewScreenshot;
+            if (handler != null)
+            {
+                handler(this, EventArgs.Empty);
             }
         }
 

--- a/CefSharp.OffScreen/GdiBitmapInfo.cs
+++ b/CefSharp.OffScreen/GdiBitmapInfo.cs
@@ -2,13 +2,17 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System.Drawing;
+using System.Drawing.Imaging;
 using CefSharp.Internals;
 
 namespace CefSharp.OffScreen
 {
     public class GdiBitmapInfo : BitmapInfo
     {
-        public bool IsCleared { get; private set; }
+        private Bitmap bitmap;
+
+        private bool createNewBitmap;
 
         public GdiBitmapInfo()
         {
@@ -17,12 +21,23 @@ namespace CefSharp.OffScreen
 
         public override bool CreateNewBitmap
         {
-            get { return IsCleared; }
+            get { return createNewBitmap; }
         }
 
         public override void ClearBitmap()
         {
-            IsCleared = true;
+            createNewBitmap = true;
+        }
+
+        public Bitmap CreateBitmap()
+        {
+            var stride = Width * BytesPerPixel;
+
+            bitmap = new Bitmap(Width, Height, stride, PixelFormat.Format32bppPArgb, BackBufferHandle);
+
+            createNewBitmap = false;
+
+            return bitmap;
         }
     }
 }


### PR DESCRIPTION
Attempt to improve efficiency of OffScreen rendering by only creating a new bitmap when the old one changes in size (same behavior as WPF).

Moved bitmap creation into GdiBitmapInfo