### PR TITLE
Propagate TaskWrapper exceptions somewhere

### DIFF
--- a/CefSharp.Core/Internals/CefTaskScheduler.h
+++ b/CefSharp.Core/Internals/CefTaskScheduler.h
@@ -5,8 +5,10 @@
 #pragma once
 
 #include "Stdafx.h"
-#include "include/cef_runnable.h"
-#include "include/cef_task.h"
+
+#include <include/cef_runnable.h>
+#include <include/cef_task.h>
+
 #include "CefTaskWrapper.h"
 
 using namespace System;

--- a/CefSharp.Core/Internals/CefTaskWrapper.h
+++ b/CefSharp.Core/Internals/CefTaskWrapper.h
@@ -62,7 +62,7 @@ namespace CefSharp
                     // AppDomain::UnhandledException event handler will get called 
                     // with the exception.
                     ThreadPool::UnsafeQueueUserWorkItem(
-                        gcnew WaitCallback(&CefTaskWrapper::ReportUnhanledException),
+                        gcnew WaitCallback(&CefTaskWrapper::ReportUnhandledException),
                         static_cast<Object^>(e));
                 }
             };

--- a/CefSharp.Core/Internals/CefTaskWrapper.h
+++ b/CefSharp.Core/Internals/CefTaskWrapper.h
@@ -25,8 +25,8 @@ namespace CefSharp
             // in order to report a .net exception from a CEF thread.
             static void ReportUnhanledException(Object ^state)
             {
-                String ^msg = dynamic_cast<String^>(state);
-                throw gcnew InvalidOperationException(msg);
+                Exception ^e = dynamic_cast<Exception^>(state);
+                throw gcnew InvalidOperationException(gcnew String(L"CefTaskWrapper caught an unexpected exception. This should never happen, please contact CefSharp for assistance."), e);
             }
 
         public:
@@ -63,7 +63,7 @@ namespace CefSharp
                     // with the exception.
                     ThreadPool::UnsafeQueueUserWorkItem(
                         gcnew WaitCallback(&CefTaskWrapper::ReportUnhanledException),
-                        static_cast<Object^>(msg));
+                        static_cast<Object^>(e));
                 }
             };
 

--- a/CefSharp.Core/Internals/CefTaskWrapper.h
+++ b/CefSharp.Core/Internals/CefTaskWrapper.h
@@ -6,6 +6,8 @@
 
 #include "Stdafx.h"
 
+#include <include/base/cef_logging.h>
+
 using namespace System;
 using namespace System::Threading::Tasks;
 using namespace System::Runtime::InteropServices;
@@ -18,6 +20,15 @@ namespace CefSharp
     {
         private class CefTaskWrapper
         {
+        private:
+            // Throw the exception, this method executes on the thread pool
+            // in order to report a .net exception from a CEF thread.
+            static void ReportUnhanledException(Object ^state)
+            {
+                String ^msg = dynamic_cast<String^>(state);
+                throw gcnew InvalidOperationException(msg);
+            }
+
         public:
             gcroot<Task^> _task;
             gcroot<ITaskScheduler^> _scheduler;
@@ -39,13 +50,20 @@ namespace CefSharp
                 {
                     _scheduler->ExecuteTask(_task);
                 }
-                catch (Exception^)
+                catch (Exception^ e)
                 {
                     // This should never ever happen.
                     // If this occurs then someone has broken a .Net ThreadScheduler/Task invariant
                     // i.e. trying to run a task on the wrong scheduler, or some
                     // weird exception during task completion. 
-                    // TODO: We need to forward this exception somewhere...
+                    auto msg = String::Format(gcnew String(L"CefTaskWrapper caught an unexpected exception. This should never happen, please contact CefSharp for assistance: {0}"), e->ToString());
+                    LOG(ERROR) << StringUtils::ToNative(msg).ToString();
+                    // Throw the exception from a threadpool thread in hopes that
+                    // AppDomain::UnhandledException event handler will get called 
+                    // with the exception.
+                    ThreadPool::UnsafeQueueUserWorkItem(
+                        gcnew WaitCallback(&CefTaskWrapper::ReportUnhanledException),
+                        static_cast<Object^>(msg));
                 }
             };
 

--- a/CefSharp.Core/Internals/CefTaskWrapper.h
+++ b/CefSharp.Core/Internals/CefTaskWrapper.h
@@ -23,7 +23,7 @@ namespace CefSharp
         private:
             // Throw the exception, this method executes on the thread pool
             // in order to report a .net exception from a CEF thread.
-            static void ReportUnhanledException(Object ^state)
+            static void ReportUnhandledException(Object ^state)
             {
                 Exception ^e = dynamic_cast<Exception^>(state);
                 throw gcnew InvalidOperationException(gcnew String(L"CefTaskWrapper caught an unexpected exception. This should never happen, please contact CefSharp for assistance."), e);


### PR DESCRIPTION
Log an ERROR message via CEF logging, and throw an appropriate exception on thread pool thread.

The idea is that the AppDomain's UnhandledException or Application.ThreadException handler will get called.

This PR is for discussion, I'll be testing out the approach with a non-CEF sample app in a bit.