### PR TITLE
Add Visual Studio 2015 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ CefSharp.BrowserSubprocess.lib
 Win32/Release
 x64/Release
 Win32/Release
+.vs/

--- a/CefSharp.props
+++ b/CefSharp.props
@@ -5,10 +5,14 @@
     <VisualStudioProductVersion>2010</VisualStudioProductVersion>
     <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='11.0'">2012</VisualStudioProductVersion>
     <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='12.0'">2013</VisualStudioProductVersion>
+    <!-- For Visual Studio 2015, use VS 2013 binaries -->
+    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='14.0'">2013</VisualStudioProductVersion>
 
     <PlatformToolset>v100</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='11.0'">v110</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <!-- For Visual Studio 2015, use VS 2013 tool set for now -->
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v120</PlatformToolset>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Redirect VS2015 to use VS2013 binaries and toolset in CefSharp.props.

Added .vs folder to .gitignore, as it contains the .suo files and
intellisense database used by VS2015. See
http://visualstudio.uservoice.com/forums/121579-visual-studio/suggestions/6079923-store-project-related-information-in-vs-folder-to
for more details.