### PR TITLE
WPF - Handle case where Bitmap in WpfBitmapInfo is null

### DIFF
--- a/CefSharp.Wpf/Rendering/InteropBitmapInfo.cs
+++ b/CefSharp.Wpf/Rendering/InteropBitmapInfo.cs
@@ -42,13 +42,13 @@ namespace CefSharp.Wpf.Rendering
         {
             var stride = Width * BytesPerPixel;
 
-            if (FileMappingHandle != IntPtr.Zero)
+            if (FileMappingHandle == IntPtr.Zero)
             {
-                Bitmap = (InteropBitmap)Imaging.CreateBitmapSourceFromMemorySection(FileMappingHandle, Width, Height, PixelFormat, stride, 0);
+                ClearBitmap();
             }
             else
             {
-                ClearBitmap();
+                Bitmap = (InteropBitmap)Imaging.CreateBitmapSourceFromMemorySection(FileMappingHandle, Width, Height, PixelFormat, stride, 0);
             }
 
             return Bitmap;

--- a/CefSharp.Wpf/Rendering/InteropBitmapInfo.cs
+++ b/CefSharp.Wpf/Rendering/InteropBitmapInfo.cs
@@ -42,9 +42,10 @@ namespace CefSharp.Wpf.Rendering
         {
             var stride = Width * BytesPerPixel;
 
+            // Unable to create bitmap without valid File Handle (Most likely control is being disposed)
             if (FileMappingHandle == IntPtr.Zero)
             {
-                ClearBitmap();
+                return null;
             }
             else
             {

--- a/CefSharp.Wpf/Rendering/InteropBitmapInfo.cs
+++ b/CefSharp.Wpf/Rendering/InteropBitmapInfo.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -31,14 +32,24 @@ namespace CefSharp.Wpf.Rendering
 
         public override void Invalidate()
         {
-            Bitmap.Invalidate();
+            if (Bitmap != null)
+            {
+                Bitmap.Invalidate();
+            }
         }
 
         public override BitmapSource CreateBitmap()
         {
             var stride = Width * BytesPerPixel;
 
-            Bitmap = (InteropBitmap)Imaging.CreateBitmapSourceFromMemorySection(FileMappingHandle, Width, Height, PixelFormat, stride, 0);
+            if (FileMappingHandle != IntPtr.Zero)
+            {
+                Bitmap = (InteropBitmap)Imaging.CreateBitmapSourceFromMemorySection(FileMappingHandle, Width, Height, PixelFormat, stride, 0);
+            }
+            else
+            {
+                ClearBitmap();
+            }
 
             return Bitmap;
         }


### PR DESCRIPTION
The OnPaint call arrives on a thread other than the UI thread. This means it is possible that the InvokeRenderAsync method, which is dispatched back to the UI thread, will get called after the Dispose method. In this case, a NullReferenceException is thrown, because FileMappingHandle is no longer set.
