### PR TITLE
Rewrite OnJSDialog so now matches the Cef API

### DIFF
--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -253,6 +253,7 @@
     <ClInclude Include="Internals\CookieVisitor.h" />
     <ClInclude Include="Internals\CefSharpApp.h" />
     <ClInclude Include="Internals\CefRequestWrapper.h" />
+    <ClInclude Include="Internals\JsDialogCallback.h" />
     <ClInclude Include="Internals\MCefRefPtr.h" />
     <ClInclude Include="Internals\PluginVisitor.h" />
     <ClInclude Include="Internals\RenderClientAdapter.h" />

--- a/CefSharp.Core/CefSharp.Core.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.vcxproj.filters
@@ -151,6 +151,9 @@
     <ClInclude Include="Internals\CefFrameWrapper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Internals\JsDialogCallback.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -10,6 +10,7 @@
 #include "ClientAdapter.h"
 #include "DownloadAdapter.h"
 #include "StreamAdapter.h"
+#include "JsDialogCallback.h"
 #include "Internals/TypeConversion.h"
 #include "include/wrapper/cef_stream_resource_handler.h"
 #include "include/internal/cef_types.h"
@@ -490,42 +491,17 @@ namespace CefSharp
             JSDialogType dialog_type, const CefString& message_text, const CefString& default_prompt_text,
             CefRefPtr<CefJSDialogCallback> callback, bool& suppress_message)
         {
-            IJsDialogHandler^ handler = _browserControl->JsDialogHandler;
+            auto handler = _browserControl->JsDialogHandler;
 
             if (handler == nullptr)
             {
                 return false;
             }
 
-            bool result;
-            bool handled = false;
+            auto dialogCallback = gcnew JsDialogCallback(callback);
 
-            switch (dialog_type)
-            {
-            case JSDIALOGTYPE_ALERT:
-                handled = handler->OnJSAlert(_browserControl, StringUtils::ToClr(origin_url), StringUtils::ToClr(message_text));
-                break;
-
-            case JSDIALOGTYPE_CONFIRM:
-                handled = handler->OnJSConfirm(_browserControl, StringUtils::ToClr(origin_url), StringUtils::ToClr(message_text), result);
-                if(handled)
-                {
-                    callback->Continue(result, CefString());
-                }
-                break;
-
-            case JSDIALOGTYPE_PROMPT:
-                String^ resultString = nullptr;
-                handled = handler->OnJSPrompt(_browserControl, StringUtils::ToClr(origin_url), StringUtils::ToClr(message_text),
-                    StringUtils::ToClr(default_prompt_text), result, resultString);
-                if(handled)
-                {
-                    callback->Continue(result, StringUtils::ToNative(resultString));
-                }
-                break;
-            }
-
-            return handled;
+            return handler->OnJSDialog(_browserControl, StringUtils::ToClr(origin_url), StringUtils::ToClr(accept_lang), (CefJsDialogType)dialog_type, 
+                                        StringUtils::ToClr(message_text), StringUtils::ToClr(default_prompt_text), dialogCallback, suppress_message);
         }
 
         bool ClientAdapter::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser, const CefString& message_text, bool is_reload, CefRefPtr<CefJSDialogCallback> callback)

--- a/CefSharp.Core/Internals/JsDialogCallback.h
+++ b/CefSharp.Core/Internals/JsDialogCallback.h
@@ -1,0 +1,36 @@
+﻿// Copyright � 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+#include "MCefRefPtr.h"
+
+using namespace CefSharp;
+
+namespace CefSharp
+{
+    namespace Internals
+    {
+        public ref class JsDialogCallback : public IJsDialogCallback
+        {
+            MCefRefPtr<CefJSDialogCallback> _callback;
+        internal:
+            JsDialogCallback(CefRefPtr<CefJSDialogCallback> callback) : _callback(callback)
+            {
+            }
+
+            ~JsDialogCallback()
+            {
+                _callback = NULL;
+            }
+
+        public:
+            virtual void Continue(bool success, String^ userInput)
+            {
+                _callback->Continue(success, StringUtils::ToNative(userInput));
+            }
+        };
+    }
+}

--- a/CefSharp.Example/JsDialogHandler.cs
+++ b/CefSharp.Example/JsDialogHandler.cs
@@ -2,23 +2,8 @@
 {
     public class JsDialogHandler : IJsDialogHandler
     {
-        public bool OnJSAlert(IWebBrowser browser, string url, string message)
+        public bool OnJSDialog(IWebBrowser browser, string originUrl, string acceptLang, CefJsDialogType dialogType, string messageText, string defaultPromptText, IJsDialogCallback callback, ref bool suppressMessage)
         {
-            return false;
-        }
-
-        public bool OnJSConfirm(IWebBrowser browser, string url, string message, out bool retval)
-        {
-            retval = false;
-
-            return false;
-        }
-
-        public bool OnJSPrompt(IWebBrowser browser, string url, string message, string defaultValue, out bool retval, out string result)
-        {
-            retval = false;
-            result = null;
-
             return false;
         }
 

--- a/CefSharp/CefJsDialogType.cs
+++ b/CefSharp/CefJsDialogType.cs
@@ -4,10 +4,10 @@
 
 namespace CefSharp
 {
-	public enum CefJsDialogType
-	{
-		Alert = 0,
-		Confirm,
-		Prompt
-	}
+    public enum CefJsDialogType
+    {
+        Alert = 0,
+        Confirm,
+        Prompt
+    }
 }

--- a/CefSharp/CefJsDialogType.cs
+++ b/CefSharp/CefJsDialogType.cs
@@ -1,0 +1,13 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+	public enum CefJsDialogType
+	{
+		Alert = 0,
+		Confirm,
+		Prompt
+	}
+}

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -90,12 +90,14 @@
   <ItemGroup>
     <Compile Include="CefDirtyRect.cs" />
     <Compile Include="CefFileDialogMode.cs" />
+    <Compile Include="CefJsDialogType.cs" />
     <Compile Include="CefReturnValue.cs" />
     <Compile Include="CefThreadIds.cs" />
     <Compile Include="DefaultResourceHandlerFactory.cs" />
     <Compile Include="DependencyChecker.cs" />
     <Compile Include="IFrame.cs" />
     <Compile Include="IJavascriptCallback.cs" />
+    <Compile Include="IJsDialogCallback.cs" />
     <Compile Include="Internals\IBrowserAdapter.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/CefSharp/IJsDialogCallback.cs
+++ b/CefSharp/IJsDialogCallback.cs
@@ -1,0 +1,16 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+    public interface IJsDialogCallback
+    {
+        /// <summary>
+        /// Continue the Javascript dialog request.
+        /// </summary>
+        /// <param name="success">Set to true if the OK button was pressed.</param>
+        /// <param name="userInput">value should be specified for prompt dialogs.</param>
+        void Continue(bool success, string userInput);
+    }
+}

--- a/CefSharp/IJsDialogHandler.cs
+++ b/CefSharp/IJsDialogHandler.cs
@@ -6,9 +6,19 @@ namespace CefSharp
 {
     public interface IJsDialogHandler
     {
-        bool OnJSAlert(IWebBrowser browser, string url, string message);
-        bool OnJSConfirm(IWebBrowser browser, string url, string message, out bool retval);
-        bool OnJSPrompt(IWebBrowser browser, string url, string message, string defaultValue, out bool retval, out string result);
+        /// <summary>
+        /// Called to run a JavaScript dialog.
+        /// </summary>
+        /// <param name="browser">the browser object</param>
+        /// <param name="originUrl">originating url</param>
+        /// <param name="acceptLang">language</param>
+        /// <param name="dialogType">Dialog Type</param>
+        /// <param name="messageText">Message Text</param>
+        /// <param name="defaultPromptText">value will be specified for prompt dialogs only</param>
+        /// <param name="callback">Callback can be executed inline or in an async fashion</param>
+        /// <param name="suppressMessage">Set |suppress_message| to true and return false to suppress the message (suppressing messages is preferable to immediately executing the callback as this is used to detect presumably malicious behavior like spamming alert messages in onbeforeunload). Set |suppress_message| to false and return false to use the default implementation (the default implementation will show one modal dialog at a time and suppress any additional dialog requests until the displayed dialog is dismissed).</param>
+        /// <returns>Return true if the application will use a custom dialog or if the callback has been executed immediately. Custom dialogs may be either modal or modeless. If a custom dialog is used the application must execute |callback| once the custom dialog is dismissed.</returns>
+        bool OnJSDialog(IWebBrowser browser, string originUrl, string acceptLang, CefJsDialogType dialogType, string messageText, string defaultPromptText, IJsDialogCallback callback, ref bool suppressMessage);
         
         /// <summary>
         /// When leaving the page a Javascript dialog is displayed asking for user confirmation.


### PR DESCRIPTION
Whilst I understand that the ideal of having the types split into different methods was nice from a user point of view, I think we kept functionality from users that was exposed.

So the callback wrapper has been added so can now be executed async. SuppressMessage is now possible.

Fixes #999

Breaking changes 

- `IJsDialogHandler.OnJSAlert` Removed
- `IJsDialogHandler.OnJSConfirm` Removed
- `IJsDialogHandler.OnJSPrompt` Removed
- `IJsDialogHandler.OnJSDialog ` Added


