### PR TITLE
Create a Cookie class to represent the CefCookie

### DIFF
--- a/CefSharp.Core/Internals/CookieVisitor.cpp
+++ b/CefSharp.Core/Internals/CookieVisitor.cpp
@@ -5,13 +5,11 @@
 #include "Stdafx.h"
 #include "CookieVisitor.h"
 
-using namespace System::Net;
-
 namespace CefSharp
 {
     bool CookieVisitor::Visit(const CefCookie& cefCookie, int count, int total, bool& deleteCookie)
     {
-        Cookie^ cookie = gcnew Cookie();
+        auto cookie = gcnew Cookie();
         String^ cookieName = StringUtils::ToClr(cefCookie.name);
 
         if (!String::IsNullOrEmpty(cookieName))
@@ -35,6 +33,27 @@ namespace CefSharp
                     cefCookie.expires.millisecond
                 );
             }
+
+            //TODO: There is a method in TypeUtils that's in BrowserSubProcess that convers CefTime, need to make it accessible.
+            cookie->Creation = DateTime(
+                cefCookie.creation.year,
+                cefCookie.creation.month,
+                cefCookie.creation.day_of_month,
+                cefCookie.creation.hour,
+                cefCookie.creation.minute,
+                cefCookie.creation.second,
+                cefCookie.creation.millisecond
+                );
+
+            cookie->LastAccess = DateTime(
+                cefCookie.last_access.year,
+                cefCookie.last_access.month,
+                cefCookie.last_access.day_of_month,
+                cefCookie.last_access.hour,
+                cefCookie.last_access.minute,
+                cefCookie.last_access.second,
+                cefCookie.last_access.millisecond
+                );
         }
 
         return _visitor->Visit(cookie, count, total, deleteCookie);

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -93,6 +93,7 @@
     <Compile Include="CefJsDialogType.cs" />
     <Compile Include="CefReturnValue.cs" />
     <Compile Include="CefThreadIds.cs" />
+    <Compile Include="Cookie.cs" />
     <Compile Include="DefaultResourceHandlerFactory.cs" />
     <Compile Include="DependencyChecker.cs" />
     <Compile Include="IBrowser.cs" />

--- a/CefSharp/Cookie.cs
+++ b/CefSharp/Cookie.cs
@@ -9,12 +9,12 @@ namespace CefSharp
     public class Cookie
     {
         public string Name { get; set; }
-        public string Value  { get; set; }
-        public string Domain  { get; set; }
-        public string Path  { get; set; }
-        public bool Secure  { get; set; }
-        public bool HttpOnly  { get; set; }
-        public DateTime? Expires  { get; set; }
+        public string Value { get; set; }
+        public string Domain { get; set; }
+        public string Path { get; set; }
+        public bool Secure { get; set; }
+        public bool HttpOnly { get; set; }
+        public DateTime? Expires { get; set; }
         public DateTime Creation { get; set; }
         public DateTime LastAccess { get; set; }
     }

--- a/CefSharp/Cookie.cs
+++ b/CefSharp/Cookie.cs
@@ -1,0 +1,21 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+
+namespace CefSharp
+{
+    public class Cookie
+    {
+        public string Name { get; set; }
+        public string Value  { get; set; }
+        public string Domain  { get; set; }
+        public string Path  { get; set; }
+        public bool Secure  { get; set; }
+        public bool HttpOnly  { get; set; }
+        public DateTime? Expires  { get; set; }
+        public DateTime Creation { get; set; }
+        public DateTime LastAccess { get; set; }
+    }
+}

--- a/CefSharp/ICookieVisitor.cs
+++ b/CefSharp/ICookieVisitor.cs
@@ -2,8 +2,6 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
-using System.Net;
-
 namespace CefSharp
 {
     public interface ICookieVisitor


### PR DESCRIPTION
`CefCookie` doesn't quite map to `System.Net.Cookie`, so create a special class to represent.

Resolve #338

Breaking change (Though shouldn't be a problem as the type is still called cookie, would only be if explicitly identified using namespace).