### PR TITLE
Honour the Background property for the ChromiumWebBrowser

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -904,7 +905,10 @@ namespace CefSharp.Wpf
             base.OnApplyTemplate();
 
             // Create main window
-            Content = image = CreateImage();
+            Border outerBorder = new Border() { Child = image = CreateImage() };
+            Binding b = new Binding("Background") { Source = this };
+            outerBorder.SetBinding(Border.BackgroundProperty, b);
+            Content = outerBorder;
 
             popup = CreatePopup();
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -905,10 +905,10 @@ namespace CefSharp.Wpf
             base.OnApplyTemplate();
 
             // Create main window
-            Border outerBorder = new Border() { Child = image = CreateImage() };
-            Binding b = new Binding("Background") { Source = this };
-            outerBorder.SetBinding(Border.BackgroundProperty, b);
-            Content = outerBorder;
+            Border border = new Border() { Child = image = CreateImage() };
+            Binding binding = new Binding("Background") { Source = this };
+            border.SetBinding(Border.BackgroundProperty, binding);
+            Content = border;
 
             popup = CreatePopup();
         }


### PR DESCRIPTION
Currently, if you set the Background DependencyProperty on the ChromiumWebBrowser control, it is ignored.

This pull request fixes that.