### PR TITLE
Automatically detect Windows XP.

### DIFF
--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -79,10 +79,6 @@ namespace CefSharp.Example
                 Cef.SetCookiePath("cookies", true);
             };
 
-            //Cef will check if all dependencies are present
-            //For special case when Checking Windows Xp Dependencies
-            //DependencyChecker.IsWindowsXp = true;
-
             if (!Cef.Initialize(settings, shutdownOnProcessExit: true, performDependencyCheck: !DebuggingSubProcess))
             {
                 throw new Exception("Unable to Initialize Cef");

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -21,7 +21,14 @@ namespace CefSharp
         /// <summary>
         /// IsWindowsXp - Special case for legacy XP support
         /// </summary>
-        public static bool IsWindowsXp { get; set; }
+        public static bool IsWindowsXp
+        {
+            get
+            {
+                var osVersion = Environment.OSVersion;
+                return osVersion.Platform == PlatformID.Win32NT && osVersion.Version.Major < 6;
+            }
+        }
 
         /// <summary>
         /// List of Cef Dependencies


### PR DESCRIPTION
As requested in https://github.com/cefsharp/CefSharp/issues/1007, here is a pull request containing only the change to automatically detect Windows XP:

Previously, it was the main program's responsibility to set `IsWindowsXp` if necessary, but that was problematic because it wasn't possible to set it before its value was used. But it's easy enough to detect automatically anyway, so it's probably nicer to just do that.