### PR TITLE
Allow app to disable transparent background in windowless mode

### DIFF
--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -73,6 +73,8 @@ namespace CefSharp
     {
     private:
         bool _isFinalized;
+        Nullable<bool>^ _offscreenTransparentBackground;
+
     internal:
         CefBrowserSettings* _browserSettings;
 
@@ -272,6 +274,12 @@ namespace CefSharp
         {
             Nullable<bool>^ get() { return CefStateToDisabledSetting(_browserSettings->webgl); }
             void set(Nullable<bool>^ value) { _browserSettings->webgl = CefStateFromDisabledSetting(value); }
+        }
+
+        property Nullable<bool>^ OffscreenTransparentBackground
+        {
+            Nullable<bool>^ get() { return _offscreenTransparentBackground; }
+            void set(Nullable<bool>^ value) { _offscreenTransparentBackground = value; }
         }
 
     };

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -72,14 +72,10 @@ namespace CefSharp
 
         void CreateOffscreenBrowser(IntPtr windowHandle, BrowserSettings^ browserSettings, String^ address)
         {
-            CreateOffscreenBrowser(windowHandle, browserSettings, address, FALSE);
-        }
-
-        void CreateOffscreenBrowser(IntPtr windowHandle, BrowserSettings^ browserSettings, String^ address, bool transparent)
-        {
             auto hwnd = static_cast<HWND>(windowHandle.ToPointer());
 
             CefWindowInfo window;
+            bool transparent = !(browserSettings->OffscreenTransparentBackground->HasValue) || browserSettings->OffscreenTransparentBackground->Value;
             window.SetAsWindowless(hwnd, transparent);
             CefString addressNative = StringUtils::ToNative(address);
 

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -72,10 +72,15 @@ namespace CefSharp
 
         void CreateOffscreenBrowser(IntPtr windowHandle, BrowserSettings^ browserSettings, String^ address)
         {
+            CreateOffscreenBrowser(windowHandle, browserSettings, address, FALSE);
+        }
+
+        void CreateOffscreenBrowser(IntPtr windowHandle, BrowserSettings^ browserSettings, String^ address, bool transparent)
+        {
             auto hwnd = static_cast<HWND>(windowHandle.ToPointer());
 
             CefWindowInfo window;
-            window.SetAsWindowless(hwnd, TRUE);
+            window.SetAsWindowless(hwnd, transparent);
             CefString addressNative = StringUtils::ToNative(address);
 
             if (!CefBrowserHost::CreateBrowser(window, _clientAdapter.get(), addressNative,

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -50,7 +50,6 @@ namespace CefSharp.Wpf
         public IResourceHandlerFactory ResourceHandlerFactory { get; set; }
         public IGeolocationHandler GeolocationHandler { get; set; }
         public IBitmapFactory BitmapFactory { get; set; }
-        public bool TransparentBackground { get; set; }
 
         public event EventHandler<ConsoleMessageEventArgs> ConsoleMessage;
         public event EventHandler<StatusMessageEventArgs> StatusMessage;
@@ -151,7 +150,6 @@ namespace CefSharp.Wpf
 
             ResourceHandlerFactory = new DefaultResourceHandlerFactory();
             BrowserSettings = new BrowserSettings();
-            TransparentBackground = true;
 
             PresentationSource.AddSourceChangedHandler(this, PresentationSourceChangedHandler);
         }
@@ -859,7 +857,7 @@ namespace CefSharp.Wpf
                 return;
             }
 
-            managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, Address, TransparentBackground);
+            managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, Address);
             browserCreated = true;
         }
 

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -904,7 +905,10 @@ namespace CefSharp.Wpf
             base.OnApplyTemplate();
 
             // Create main window
-            Content = image = CreateImage();
+            Border outerBorder = new Border() { Child = image = CreateImage() };
+            Binding b = new Binding("Background") { Source = this };
+            outerBorder.SetBinding(Border.BackgroundProperty, b);
+            Content = outerBorder;
 
             popup = CreatePopup();
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -51,6 +50,7 @@ namespace CefSharp.Wpf
         public IResourceHandlerFactory ResourceHandlerFactory { get; set; }
         public IGeolocationHandler GeolocationHandler { get; set; }
         public IBitmapFactory BitmapFactory { get; set; }
+        public bool TransparentBackground { get; set; }
 
         public event EventHandler<ConsoleMessageEventArgs> ConsoleMessage;
         public event EventHandler<StatusMessageEventArgs> StatusMessage;
@@ -151,6 +151,7 @@ namespace CefSharp.Wpf
 
             ResourceHandlerFactory = new DefaultResourceHandlerFactory();
             BrowserSettings = new BrowserSettings();
+            TransparentBackground = true;
 
             PresentationSource.AddSourceChangedHandler(this, PresentationSourceChangedHandler);
         }
@@ -858,7 +859,7 @@ namespace CefSharp.Wpf
                 return;
             }
 
-            managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, Address);
+            managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, Address, TransparentBackground);
             browserCreated = true;
         }
 
@@ -905,10 +906,7 @@ namespace CefSharp.Wpf
             base.OnApplyTemplate();
 
             // Create main window
-            Border border = new Border() { Child = image = CreateImage() };
-            Binding binding = new Binding("Background") { Source = this };
-            border.SetBinding(Border.BackgroundProperty, binding);
-            Content = border;
+            Content = image = CreateImage();
 
             popup = CreatePopup();
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -905,10 +905,10 @@ namespace CefSharp.Wpf
             base.OnApplyTemplate();
 
             // Create main window
-            Border outerBorder = new Border() { Child = image = CreateImage() };
-            Binding b = new Binding("Background") { Source = this };
-            outerBorder.SetBinding(Border.BackgroundProperty, b);
-            Content = outerBorder;
+            Border border = new Border() { Child = image = CreateImage() };
+            Binding binding = new Binding("Background") { Source = this };
+            border.SetBinding(Border.BackgroundProperty, binding);
+            Content = border;
 
             popup = CreatePopup();
         }


### PR DESCRIPTION
Currently, ManagedCefBrowserAdapter always sets transparent to TRUE when setting windowless mode.

Transparency isn't always desired, and attempting to place the browser control in a painted outer control can have ugly side-effects when resizing the app, if its colour is different from the containing window.

This PR lets the ChromiumWebBrowser specify whether transparency should be set.