### PR TITLE
Auto-close blank popups when download is complete

### DIFF
--- a/CefSharp.Core/Internals/DownloadAdapter.cpp
+++ b/CefSharp.Core/Internals/DownloadAdapter.cpp
@@ -38,6 +38,11 @@ namespace CefSharp
         void DownloadAdapter::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDownloadItem> download_item,
             CefRefPtr<CefDownloadItemCallback> callback) 
         {
+            if (!download_item->IsInProgress() && browser->IsPopup() && !browser->HasDocument())
+            {
+                browser->GetHost()->CloseBrowser(false);
+            }
+
             if (_handler->OnDownloadUpdated(TypeConversion::FromNative(download_item)))
             {
                 callback->Cancel();

--- a/CefSharp.Core/Internals/DownloadAdapter.cpp
+++ b/CefSharp.Core/Internals/DownloadAdapter.cpp
@@ -38,6 +38,7 @@ namespace CefSharp
         void DownloadAdapter::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDownloadItem> download_item,
             CefRefPtr<CefDownloadItemCallback> callback) 
         {
+
             if (!download_item->IsInProgress() && browser->IsPopup() && !browser->HasDocument())
             {
                 browser->GetHost()->CloseBrowser(false);

--- a/CefSharp.Core/Internals/DownloadAdapter.cpp
+++ b/CefSharp.Core/Internals/DownloadAdapter.cpp
@@ -38,7 +38,6 @@ namespace CefSharp
         void DownloadAdapter::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDownloadItem> download_item,
             CefRefPtr<CefDownloadItemCallback> callback) 
         {
-
             if (!download_item->IsInProgress() && browser->IsPopup() && !browser->HasDocument())
             {
                 browser->GetHost()->CloseBrowser(false);


### PR DESCRIPTION
Fix for issue #1031

Automatically close blank popups that appear when downloads are started in a separate window, once the download is done (complete, failed or cancelled).

Test the fix here:
https://jsfiddle.net/yLk7d3z8/
