### PR TITLE
Make SourceHook virtual for Wpf ChromiumWebBrowser

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -939,7 +939,7 @@ namespace CefSharp.Wpf
             return newPopup;
         }
 
-        private IntPtr SourceHook(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam, ref bool handled)
+        protected virtual IntPtr SourceHook(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
             if (handled)
             {


### PR DESCRIPTION
Related to #583

Mark ChromiumWebBrowser.SourceHook as protected virtual so inherited controls can override the default SourceHook handling of messages.