### PR TITLE
Display Release Mode Message Box In Examples

### DIFF
--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -39,6 +39,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants>DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>

--- a/CefSharp.WinForms.Example/Program.cs
+++ b/CefSharp.WinForms.Example/Program.cs
@@ -9,11 +9,19 @@ using CefSharp.WinForms.Example.Minimal;
 
 namespace CefSharp.WinForms.Example
 {
-    class Program
+    public class Program
     {
         [STAThread]
-        static void Main()
+        public static void Main()
         {
+#if DEBUG
+            if (!System.Diagnostics.Debugger.IsAttached)
+            {
+                MessageBox.Show("When running this Example outside of Visual Studio" +
+                                "please make sure you compile in `Release` mode.", "Warning");
+            }
+#endif
+
             CefExample.Init();
 
             var browser = new BrowserForm();

--- a/CefSharp.Wpf.Example/App.xaml.cs
+++ b/CefSharp.Wpf.Example/App.xaml.cs
@@ -11,6 +11,13 @@ namespace CefSharp.Wpf.Example
     {
         private App()
         {
+#if DEBUG
+            if (!System.Diagnostics.Debugger.IsAttached)
+            {
+                MessageBox.Show("When running this Example outside of Visual Studio" +
+                                "please make sure you compile in `Release` mode.", "Warning");
+            }
+#endif
             CefExample.Init();
         }
     }


### PR DESCRIPTION
Add Message Box into WinForms and WPF examples to alert users they need to compile in Release mode when running outside of Visual Studio