### PR TITLE
NullReferenceException when Address is set before OnApplyTemplate

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -905,6 +905,12 @@ namespace CefSharp.Wpf
             Content = image = CreateImage();
 
             popup = CreatePopup();
+
+            // If Address was previously set, only now can we actually do the load
+            if (!string.IsNullOrEmpty(Address))
+            {
+                Load(Address);
+            }
         }
 
         private Image CreateImage()
@@ -1243,8 +1249,9 @@ namespace CefSharp.Wpf
 
         public void Load(string url)
         {
-            //Added null check -> binding-triggered changes of Address will lead to a nullref after Dispose has been called.
-            if (managedCefBrowserAdapter != null)
+            // Added null check -> binding-triggered changes of Address will lead to a nullref after Dispose has been called
+            // or before OnApplyTemplate has been called
+            if (managedCefBrowserAdapter != null && GetMainFrame() != null)
             {
                 if (tooltipTimer != null)
                 {

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1251,7 +1251,8 @@ namespace CefSharp.Wpf
         {
             // Added null check -> binding-triggered changes of Address will lead to a nullref after Dispose has been called
             // or before OnApplyTemplate has been called
-            if (managedCefBrowserAdapter != null && GetMainFrame() != null)
+            IFrame mainFrame = GetMainFrame();
+            if (mainFrame != null)
             {
                 if (tooltipTimer != null)
                 {
@@ -1266,7 +1267,7 @@ namespace CefSharp.Wpf
                     Dispatcher
                     );
 
-                GetMainFrame().LoadUrl(url);
+                mainFrame.LoadUrl(url);
             }
         }
 


### PR DESCRIPTION
Fix NullReferenceException in WPF ChromiumWebBrowser when Address is set before OnApplyTemplate is called

See #1110

