### PR TITLE
Followup changes for js callback ipc

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -152,9 +152,10 @@ namespace CefSharp
                 if (frame.get())
                 {
                     auto context = frame->GetV8Context();
-                    try
+                    
+                    if (context.get() && context->Enter())
                     {
-                        if (context.get() && context->Enter())
+                        try
                         {
                             success = context->Eval(script, result, exception);
                             response = CefProcessMessage::Create(kEvaluateJavascriptResponse);
@@ -165,10 +166,14 @@ namespace CefSharp
                                 SerializeV8Object(result, argList, 2, browserWrapper->CallbackRegistry);
                             }
                         }
+                        finally
+                        {
+                            context->Exit();
+                        }
                     }
-                    finally
+                    else
                     {
-                        context->Exit();
+                        //TODO handle error
                     }
                 }
                 else
@@ -190,10 +195,10 @@ namespace CefSharp
                 auto callbackWrapper = callbackRegistry->FindWrapper(jsCallbackId);
                 auto context = callbackWrapper->GetContext();
                 auto value = callbackWrapper->GetValue();
-
-                try
+                
+                if (context.get() && context->Enter())
                 {
-                    if (context.get() && context->Enter())
+                    try
                     {
                         result = value->ExecuteFunction(nullptr, params);
                         success = result.get() != nullptr;
@@ -209,11 +214,16 @@ namespace CefSharp
                             exception = value->GetException();
                         }
                     }
+                    finally
+                    {
+                        context->Exit();
+                    }
                 }
-                finally
+                else
                 {
-                    context->Exit();
+                    //TODO handle error					
                 }
+                
             }
 
             if (response.get())

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -116,6 +116,8 @@ namespace CefSharp
             }
             else
             {
+                //TODO: Should be throw an exception here? It's likely that only a CefSharp developer would see this
+                // when they added a new message and havn't yet implemented the render process functionality.
                 throw gcnew Exception("Unsupported message type");
             }
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -256,7 +256,7 @@ namespace CefSharp
         }
         else if (name == kJavascriptCallbackDestroyRequest)
         {
-            auto jsCallbackId = GetInt64(argList, 1);
+            auto jsCallbackId = GetInt64(argList, 0);
             browserWrapper->CallbackRegistry->Deregister(jsCallbackId);
 
             handled = true;

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -148,6 +148,8 @@ namespace CefSharp
                 auto frameId = GetInt64(argList, 0);
                 auto script = argList->GetString(2);
 
+                response = CefProcessMessage::Create(kEvaluateJavascriptResponse);
+
                 auto frame = browser->GetFrame(frameId);
                 if (frame.get())
                 {
@@ -159,12 +161,12 @@ namespace CefSharp
                         {
                             CefRefPtr<CefV8Exception> exception;
                             success = context->Eval(script, result, exception);
-                            response = CefProcessMessage::Create(kEvaluateJavascriptResponse);
+                            
                             //we need to do this here to be able to store the v8context
                             if (success)
                             {
-                                auto argList = response->GetArgumentList();
-                                SerializeV8Object(result, argList, 2, browserWrapper->CallbackRegistry);
+                                auto responseArgList = response->GetArgumentList();
+                                SerializeV8Object(result, responseArgList, 2, browserWrapper->CallbackRegistry);
                             }
                             else
                             {
@@ -196,6 +198,8 @@ namespace CefSharp
                     params.push_back(DeserializeV8Object(parameterList, static_cast<int>(i)));
                 }
 
+                response = CefProcessMessage::Create(kJavascriptCallbackResponse);
+
                 auto callbackRegistry = browserWrapper->CallbackRegistry;
                 auto callbackWrapper = callbackRegistry->FindWrapper(jsCallbackId);
                 auto context = callbackWrapper->GetContext();
@@ -207,7 +211,7 @@ namespace CefSharp
                     {
                         result = value->ExecuteFunction(nullptr, params);
                         success = result.get() != nullptr;
-                        response = CefProcessMessage::Create(kJavascriptCallbackResponse);
+                        
                         //we need to do this here to be able to store the v8context
                         if (success)
                         {

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -93,15 +93,15 @@ namespace CefSharp
         auto name = message->GetName();
         auto argList = message->GetArgumentList();
 
-        auto browserId = browser->GetIdentifier();
-        auto browserWrapper = FindBrowserWrapper(browserId, false);
+        auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier(), false);
 
         //Error handling for missing/closed browser
         if (browserWrapper == nullptr)
         {
             if (name == kJavascriptCallbackDestroyRequest)
             {
-                //If we can't find the browser wrapper then we'll just ignore this
+                //If we can't find the browser wrapper then we'll just
+                //ignore this as it's likely already been disposed of
                 return true;
             }
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -23,7 +23,6 @@ namespace CefSharp
         gcroot<Action<CefBrowserWrapper^>^> _onBrowserDestroyed;
         gcroot<Dictionary<int, CefBrowserWrapper^>^> _browserWrappers;
     public:
-        
         CefAppUnmanagedWrapper(Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestoryed)
         {
             _onBrowserCreated = onBrowserCreated;

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.cpp
@@ -6,8 +6,6 @@
 #include "Stdafx.h"
 
 #include "CefAppWrapper.h"
-#include "CefBrowserWrapper.h"
-#include ".\..\CefSharp.Core\Internals\CefTaskScheduler.h"
 
 using namespace System;
 using namespace System::Diagnostics;
@@ -15,21 +13,6 @@ using namespace System::Collections::Generic;
 
 namespace CefSharp
 {
-    CefAppWrapper::CefAppWrapper()
-    {
-        auto onBrowserCreated = gcnew Action<CefBrowserWrapper^>(this, &CefAppWrapper::OnBrowserCreated);
-        auto onBrowserDestroyed = gcnew Action<CefBrowserWrapper^>(this, &CefAppWrapper::OnBrowserDestroyed);
-        _cefApp = new CefAppUnmanagedWrapper(onBrowserCreated, onBrowserDestroyed);
-
-        RenderThreadTaskFactory = gcnew TaskFactory(gcnew CefTaskScheduler(TID_RENDERER));
-    };
-
-    CefAppWrapper::~CefAppWrapper()
-    {
-        RenderThreadTaskFactory = nullptr;
-        _cefApp = nullptr;
-    }
-
     int CefAppWrapper::Run()
     {
         auto hInstance = Process::GetCurrentProcess()->Handle;

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
@@ -10,6 +10,7 @@
 
 #include "CefBrowserWrapper.h"
 #include "CefAppUnmanagedWrapper.h"
+#include ".\..\CefSharp.Core\Internals\CefTaskScheduler.h"
 
 using namespace System::Collections::Generic;
 
@@ -22,8 +23,25 @@ namespace CefSharp
         MCefRefPtr<CefAppUnmanagedWrapper> _cefApp;
         
     public:        
-        CefAppWrapper();
-        ~CefAppWrapper();
+        CefAppWrapper()
+        {
+            auto onBrowserCreated = gcnew Action<CefBrowserWrapper^>(this, &CefAppWrapper::OnBrowserCreated);
+            auto onBrowserDestroyed = gcnew Action<CefBrowserWrapper^>(this, &CefAppWrapper::OnBrowserDestroyed);
+            _cefApp = new CefAppUnmanagedWrapper(onBrowserCreated, onBrowserDestroyed);
+
+            RenderThreadTaskFactory = gcnew TaskFactory(gcnew CefTaskScheduler(TID_RENDERER));
+        };
+
+        !CefAppWrapper()
+        {
+            _cefApp = nullptr;
+        }
+
+        ~CefAppWrapper()
+        {
+            this->!CefAppWrapper();
+            RenderThreadTaskFactory = nullptr;
+        }
 
         int Run();
 

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.cpp
@@ -9,14 +9,6 @@
 
 namespace CefSharp
 {
-    CefBrowserWrapper::CefBrowserWrapper(CefRefPtr<CefBrowser> cefBrowser)
-    {
-        _cefBrowser = cefBrowser;
-        BrowserId = cefBrowser->GetIdentifier();
-        IsPopup = cefBrowser->IsPopup();
-        _callbackRegistry = gcnew JavascriptCallbackRegistry(BrowserId);
-    }
-
     JavascriptRootObjectWrapper^ CefBrowserWrapper::JavascriptRootObjectWrapper::get()
     {
         return _javascriptRootObjectWrapper;
@@ -34,20 +26,5 @@ namespace CefSharp
     JavascriptCallbackRegistry^ CefBrowserWrapper::CallbackRegistry::get()
     {
         return _callbackRegistry;
-    }
-
-    CefBrowserWrapper::!CefBrowserWrapper()
-    {
-        _cefBrowser = nullptr;
-    }
-
-    CefBrowserWrapper::~CefBrowserWrapper()
-    {
-        this->!CefBrowserWrapper();
-        if (_callbackRegistry != nullptr)
-        {
-            delete _callbackRegistry;
-            _callbackRegistry = nullptr;
-        }
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -24,7 +24,6 @@ namespace CefSharp
     // for ONE CefBrowser.
     public ref class CefBrowserWrapper
     {
-    
     private:
         MCefRefPtr<CefBrowser> _cefBrowser;
         JavascriptCallbackRegistry^ _callbackRegistry;
@@ -37,9 +36,28 @@ namespace CefSharp
         }
 
     public:
-        CefBrowserWrapper(CefRefPtr<CefBrowser> cefBrowser);
-        !CefBrowserWrapper();
-        ~CefBrowserWrapper();
+        CefBrowserWrapper(CefRefPtr<CefBrowser> cefBrowser)
+        {
+            _cefBrowser = cefBrowser;
+            BrowserId = cefBrowser->GetIdentifier();
+            IsPopup = cefBrowser->IsPopup();
+            _callbackRegistry = gcnew JavascriptCallbackRegistry(BrowserId);
+        }
+        
+        !CefBrowserWrapper()
+        {
+            _cefBrowser = nullptr;
+        }
+
+        ~CefBrowserWrapper()
+        {
+            this->!CefBrowserWrapper();
+            if (_callbackRegistry != nullptr)
+            {
+                delete _callbackRegistry;
+                _callbackRegistry = nullptr;
+            }
+        }
 
         property int BrowserId;
         property bool IsPopup;

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
@@ -11,19 +11,6 @@ namespace CefSharp
 {
     namespace Internals
     {
-        JavascriptCallbackRegistry::~JavascriptCallbackRegistry()
-        {
-            if (_callbacks != nullptr)
-            {
-                for each (JavascriptCallbackWrapper^ callback in _callbacks->Values)
-                {
-                    delete callback;
-                }
-                _callbacks->Clear();
-                _callbacks = nullptr;
-            }
-        }
-
         JavascriptCallback^ JavascriptCallbackRegistry::Register(CefRefPtr<CefV8Context> context, CefRefPtr<CefV8Value> value)
         {
             Int64 newId = Interlocked::Increment(_lastId);

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.h
@@ -27,7 +27,19 @@ namespace CefSharp
             {
                 _callbacks = gcnew ConcurrentDictionary<Int64, JavascriptCallbackWrapper^>();
             }
-            ~JavascriptCallbackRegistry();
+
+            ~JavascriptCallbackRegistry()
+            {
+                if (_callbacks != nullptr)
+                {
+                    for each (JavascriptCallbackWrapper^ callback in _callbacks->Values)
+                    {
+                        delete callback;
+                    }
+                    _callbacks->Clear();
+                    _callbacks = nullptr;
+                }
+            }
 
             JavascriptCallback^ Register(CefRefPtr<CefV8Context> context, CefRefPtr<CefV8Value> value);
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.cpp
@@ -13,17 +13,6 @@ namespace CefSharp
 {
     namespace Internals
     {
-        JavascriptCallbackWrapper::!JavascriptCallbackWrapper()
-        {
-            _value = nullptr;
-            _context = nullptr;
-        }
-
-        JavascriptCallbackWrapper::~JavascriptCallbackWrapper()
-        {
-            this->!JavascriptCallbackWrapper();
-        }
-
         CefRefPtr<CefV8Value> JavascriptCallbackWrapper::GetValue()
         {
             return _value.get();

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.cpp
@@ -15,8 +15,8 @@ namespace CefSharp
     {
         JavascriptCallbackWrapper::!JavascriptCallbackWrapper()
         {
-            value = nullptr;
-            context = nullptr;
+            _value = nullptr;
+            _context = nullptr;
         }
 
         JavascriptCallbackWrapper::~JavascriptCallbackWrapper()
@@ -26,12 +26,12 @@ namespace CefSharp
 
         CefRefPtr<CefV8Value> JavascriptCallbackWrapper::GetValue()
         {
-            return value.get();
+            return _value.get();
         }
 
         CefRefPtr<CefV8Context> JavascriptCallbackWrapper::GetContext()
         {
-            return context.get();
+            return _context.get();
         }
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include<include\cef_v8.h>
+#include "include\cef_v8.h"
 
 using namespace CefSharp::Internals;
 
@@ -28,8 +28,16 @@ namespace CefSharp
             {
             }
 
-            !JavascriptCallbackWrapper();
-            ~JavascriptCallbackWrapper();
+            !JavascriptCallbackWrapper()
+            {
+                _value = nullptr;
+                _context = nullptr;
+            }
+
+            ~JavascriptCallbackWrapper()
+            {
+                this->!JavascriptCallbackWrapper();
+            }
         };
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackWrapper.h
@@ -15,8 +15,8 @@ namespace CefSharp
         private ref class JavascriptCallbackWrapper
         {
         private:
-            MCefRefPtr<CefV8Value> value;
-            MCefRefPtr<CefV8Context> context;
+            MCefRefPtr<CefV8Value> _value;
+            MCefRefPtr<CefV8Context> _context;
 
         internal:
             CefRefPtr<CefV8Value> GetValue();
@@ -24,7 +24,7 @@ namespace CefSharp
 
         public:
             JavascriptCallbackWrapper(CefRefPtr<CefV8Value> value, CefRefPtr<CefV8Context> context)
-                : value(value), context(context) 
+                : _value(value), _context(context) 
             {
             }
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
@@ -10,18 +10,6 @@ using namespace CefSharp::Internals;
 
 namespace CefSharp
 {
-    JavascriptMethodHandler::JavascriptMethodHandler(Func<array<Object^>^, BrowserProcessResponse^>^ method, JavascriptCallbackRegistry^ callbackRegistry)
-    {
-        _method = method;
-        _callbackRegistry = callbackRegistry;
-    }
-
-    JavascriptMethodHandler::~JavascriptMethodHandler()
-    {
-        delete _method;
-        delete _callbackRegistry;
-    }
-
     bool JavascriptMethodHandler::Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8ValueList& arguments, CefRefPtr<CefV8Value>& retval, CefString& exception)
     {
         auto parameter = gcnew array<Object^>(arguments.size());

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
@@ -18,9 +18,17 @@ namespace CefSharp
         gcroot<JavascriptCallbackRegistry^> _callbackRegistry;
 
     public:
-        JavascriptMethodHandler(Func<array<Object^>^, BrowserProcessResponse^>^ method, JavascriptCallbackRegistry^ callbackRegistry);
+        JavascriptMethodHandler(Func<array<Object^>^, BrowserProcessResponse^>^ method, JavascriptCallbackRegistry^ callbackRegistry)
+        {
+            _method = method;
+            _callbackRegistry = callbackRegistry;
+        }
 
-        ~JavascriptMethodHandler();
+        ~JavascriptMethodHandler()
+        {
+            delete _method;
+            delete _callbackRegistry;
+        }
 
         virtual bool Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8ValueList& arguments, CefRefPtr<CefV8Value>& retval, CefString& exception);
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.cpp
@@ -9,28 +9,6 @@
 
 namespace CefSharp
 {
-    JavascriptRootObjectWrapper::JavascriptRootObjectWrapper(JavascriptRootObject^ rootObject, IBrowserProcess^ browserProcess)
-    {
-        _rootObject = rootObject;
-        _browserProcess = browserProcess;
-        _wrappedObjects = gcnew List<JavascriptObjectWrapper^>();
-    }
-
-    JavascriptRootObjectWrapper::!JavascriptRootObjectWrapper()
-    {
-        V8Value = nullptr;
-    }
-
-    JavascriptRootObjectWrapper::~JavascriptRootObjectWrapper()
-    {
-        this->!JavascriptRootObjectWrapper();
-        CallbackRegistry = nullptr;
-        for each (JavascriptObjectWrapper^ var in _wrappedObjects)
-        {
-            delete var;
-        }
-    }
-
     void JavascriptRootObjectWrapper::Bind()
     {
         auto memberObjects = _rootObject->MemberObjects;

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -37,10 +37,27 @@ namespace CefSharp
         JavascriptCallbackRegistry^ CallbackRegistry;
 
     public:
-        JavascriptRootObjectWrapper(JavascriptRootObject^ rootObject, IBrowserProcess^ browserProcess);
+        JavascriptRootObjectWrapper(JavascriptRootObject^ rootObject, IBrowserProcess^ browserProcess)
+        {
+            _rootObject = rootObject;
+            _browserProcess = browserProcess;
+            _wrappedObjects = gcnew List<JavascriptObjectWrapper^>();
+        }
 
-        !JavascriptRootObjectWrapper();
-        ~JavascriptRootObjectWrapper();
+        !JavascriptRootObjectWrapper()
+        {
+            V8Value = nullptr;
+        }
+
+        ~JavascriptRootObjectWrapper()
+        {
+            this->!JavascriptRootObjectWrapper();
+            CallbackRegistry = nullptr;
+            for each (JavascriptObjectWrapper^ var in _wrappedObjects)
+            {
+                delete var;
+            }
+        }
 
         void Bind();
     };

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -28,8 +28,6 @@ namespace CefSharp
         IBrowserProcess^ _browserProcess;
 
     internal:
-        // TODO: Is this member variable necessary?
-        // We only use it to call a static method on CefV8Value atm.
         MCefRefPtr<CefV8Value> V8Value;
 
         // The entire set of possible JavaScript functions to

--- a/CefSharp.Core/Internals/CefFrameWrapper.cpp
+++ b/CefSharp.Core/Internals/CefFrameWrapper.cpp
@@ -176,11 +176,12 @@ Task<JavascriptResponse^>^ CefFrameWrapper::EvaluateScriptAsync(String^ script, 
 {
     ThrowIfDisposed();
 
-    auto host = _frame->GetBrowser()->GetHost();
+    auto browser = _frame->GetBrowser();
+    auto host = browser->GetHost();
 
     auto client = static_cast<ClientAdapter*>(host->GetClient().get());
 
-    return client->EvaluateScriptAsync(_frame->GetBrowser()->GetIdentifier(), _frame->GetIdentifier(), script, timeout);
+    return client->EvaluateScriptAsync(browser->GetIdentifier(), browser->IsPopup(), _frame->GetIdentifier(), script, timeout);
 }
 
 ///

--- a/CefSharp.Core/Internals/CefSharpBrowserWrapper.cpp
+++ b/CefSharp.Core/Internals/CefSharpBrowserWrapper.cpp
@@ -252,3 +252,8 @@ MCefRefPtr<CefBrowser> CefSharpBrowserWrapper::Browser::get()
 {
     return _browser;
 }
+
+bool CefSharpBrowserWrapper::IsDisposed::get()
+{
+    return _disposed;
+}

--- a/CefSharp.Core/Internals/CefSharpBrowserWrapper.h
+++ b/CefSharp.Core/Internals/CefSharpBrowserWrapper.h
@@ -197,6 +197,11 @@ namespace CefSharp
             ///
             /*--cef()--*/
             virtual bool SendProcessMessage(CefProcessId targetProcess, CefRefPtr<CefProcessMessage> message);
+
+            property bool IsDisposed
+            {
+                bool get();
+            }
         };
     }
 }

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -850,19 +850,20 @@ namespace CefSharp
             return handled;
         }
 
-        Task<JavascriptResponse^>^ ClientAdapter::EvaluateScriptAsync(int browserId, int64 frameId, String^ script, Nullable<TimeSpan> timeout)
+        Task<JavascriptResponse^>^ ClientAdapter::EvaluateScriptAsync(int browserId, bool isBrowserPopup, int64 frameId, String^ script, Nullable<TimeSpan> timeout)
         {
             //create a new taskcompletionsource
             auto idAndComplectionSource = _pendingTaskRepository->CreatePendingTask(timeout);
 
             auto message = CefProcessMessage::Create(kEvaluateJavascriptRequest);
             auto argList = message->GetArgumentList();
-            argList->SetInt(0, browserId);
-            SetInt64(frameId, argList, 1);
-            SetInt64(idAndComplectionSource.Key, argList, 2);
-            argList->SetString(3, StringUtils::ToNative(script));
+            SetInt64(frameId, argList, 0);
+            SetInt64(idAndComplectionSource.Key, argList, 1);
+            argList->SetString(2, StringUtils::ToNative(script));
 
-            _cefBrowser->SendProcessMessage(CefProcessId::PID_RENDERER, message);
+            auto browserWrapper = static_cast<CefSharpBrowserWrapper^>(GetBrowserWrapper(browserId, isBrowserPopup));
+
+            browserWrapper->Browser->SendProcessMessage(CefProcessId::PID_RENDERER, message);
 
             return idAndComplectionSource.Value->Task;
         }

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -174,7 +174,7 @@ namespace CefSharp
                 CefRefPtr<CefDownloadItemCallback> callback) OVERRIDE;
 
             //sends out an eval script request to the render process
-            Task<JavascriptResponse^>^ EvaluateScriptAsync(int browserId, int64 frameId, String^ script, Nullable<TimeSpan> timeout);
+            Task<JavascriptResponse^>^ EvaluateScriptAsync(int browserId, bool isBrowserPopup, int64 frameId, String^ script, Nullable<TimeSpan> timeout);
 
             IMPLEMENT_REFCOUNTING(ClientAdapter);
         };

--- a/CefSharp.Core/Internals/JavascriptCallbackFactory.cpp
+++ b/CefSharp.Core/Internals/JavascriptCallbackFactory.cpp
@@ -11,14 +11,9 @@ namespace CefSharp
 {
     namespace Internals
     {
-        void JavascriptCallbackFactory::BrowserWrapper::set(WeakReference^ browserWrapper)
-        {
-            _browserWrapper = browserWrapper;
-        }
-
         IJavascriptCallback^ JavascriptCallbackFactory::Create(JavascriptCallback^ callback)
         {
-            return gcnew JavascriptCallbackProxy(callback, _pendingTasks, _browserWrapper);
+            return gcnew JavascriptCallbackProxy(callback, _pendingTasks, BrowserWrapper);
         }
     }
 }

--- a/CefSharp.Core/Internals/JavascriptCallbackFactory.h
+++ b/CefSharp.Core/Internals/JavascriptCallbackFactory.h
@@ -13,7 +13,6 @@ namespace CefSharp
         private ref class JavascriptCallbackFactory : public IJavascriptCallbackFactory
         {
         private:
-            WeakReference^ _browserWrapper;
             PendingTaskRepository<JavascriptResponse^>^ _pendingTasks;
         public:
             JavascriptCallbackFactory(PendingTaskRepository<JavascriptResponse^>^ pendingTasks)
@@ -21,10 +20,7 @@ namespace CefSharp
             {
             }
 
-            property WeakReference^ BrowserWrapper
-            {
-                void set(WeakReference^ browserWrapper);
-            };
+            property WeakReference^ BrowserWrapper;
 
             virtual IJavascriptCallback^ Create(JavascriptCallback^ callback);
         };

--- a/CefSharp.Core/Internals/JavascriptCallbackProxy.cpp
+++ b/CefSharp.Core/Internals/JavascriptCallbackProxy.cpp
@@ -20,18 +20,16 @@ namespace CefSharp
             DisposedGuard();
 
             auto browser = GetBrowser();
-            if (browser != nullptr)
-            {
-                auto doneCallback = _pendingTasks->CreatePendingTask(Nullable<TimeSpan>());
-                auto callbackMessage = CreateCallMessage(doneCallback.Key, parameters);
-                browser->SendProcessMessage(CefProcessId::PID_RENDERER, callbackMessage);
-
-                return doneCallback.Value->Task;
-            }
-            else
+            if (browser == nullptr)
             {
                 throw gcnew InvalidOperationException("Browser instance is null.");
             }
+
+            auto doneCallback = _pendingTasks->CreatePendingTask(Nullable<TimeSpan>());
+            auto callbackMessage = CreateCallMessage(doneCallback.Key, parameters);
+            browser->SendProcessMessage(CefProcessId::PID_RENDERER, callbackMessage);
+
+            return doneCallback.Value->Task;
         }
 
         CefRefPtr<CefProcessMessage> JavascriptCallbackProxy::CreateCallMessage(int64 doneCallbackId, array<Object^>^ parameters)

--- a/CefSharp.Core/Internals/JavascriptCallbackProxy.cpp
+++ b/CefSharp.Core/Internals/JavascriptCallbackProxy.cpp
@@ -37,16 +37,15 @@ namespace CefSharp
             auto result = CefProcessMessage::Create(kJavascriptCallbackRequest);
             auto browser = GetBrowser();
             auto argList = result->GetArgumentList();
-            argList->SetInt(0, browser->Identifier);
-            SetInt64(_callback->Id, argList, 1);
-            SetInt64(doneCallbackId, argList, 2);
+            SetInt64(_callback->Id, argList, 0);
+            SetInt64(doneCallbackId, argList, 1);
             auto paramList = CefListValue::Create();
             for (int i = 0; i < parameters->Length; i++)
             {
                 auto param = parameters[i];
                 SerializeV8Object(param, paramList, i);
             }
-            argList->SetList(3, paramList);
+            argList->SetList(2, paramList);
             return result;
         }
 

--- a/CefSharp.Core/Internals/JavascriptCallbackProxy.h
+++ b/CefSharp.Core/Internals/JavascriptCallbackProxy.h
@@ -37,7 +37,10 @@ namespace CefSharp
 
             virtual Task<JavascriptResponse^>^ ExecuteAsync(array<Object^>^ parameters);
 
-            ~JavascriptCallbackProxy() { this->!JavascriptCallbackProxy(); }
+            ~JavascriptCallbackProxy()
+            {
+                this->!JavascriptCallbackProxy();
+            }
 
             !JavascriptCallbackProxy()
             {

--- a/CefSharp.Core/Internals/JavascriptCallbackProxy.h
+++ b/CefSharp.Core/Internals/JavascriptCallbackProxy.h
@@ -45,7 +45,7 @@ namespace CefSharp
             !JavascriptCallbackProxy()
             {
                 auto browser = GetBrowser();
-                if (browser != nullptr)
+                if (browser != nullptr && !browser->IsDisposed)
                 {
                     browser->SendProcessMessage(CefProcessId::PID_RENDERER, CreateDestroyMessage());
                 }

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -122,6 +122,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Controls\CefSharpCommands.cs" />
     <Compile Include="Controls\NonReloadingTabControl.cs" />
     <Compile Include="Handlers\GeolocationHandler.cs" />
     <Compile Include="Handlers\MenuHandler.cs" />

--- a/CefSharp.Wpf.Example/Controls/CefSharpCommands.cs
+++ b/CefSharp.Wpf.Example/Controls/CefSharpCommands.cs
@@ -7,9 +7,9 @@ using System.Windows.Input;
 
 namespace CefSharp.Wpf.Example.Controls
 {
-	public static class CefSharpCommands
-	{
-		public static RoutedUICommand Exit = new RoutedUICommand("Exit", "Exit", typeof(CefSharpCommands));
-		public static RoutedUICommand OpenTabBindingTest = new RoutedUICommand("OpenTabBindingTest", "OpenTabBindingTest", typeof(CefSharpCommands));
-	}
+    public static class CefSharpCommands
+    {
+        public static RoutedUICommand Exit = new RoutedUICommand("Exit", "Exit", typeof(CefSharpCommands));
+        public static RoutedUICommand OpenTabBindingTest = new RoutedUICommand("OpenTabBindingTest", "OpenTabBindingTest", typeof(CefSharpCommands));
+    }
 }

--- a/CefSharp.Wpf.Example/Controls/CefSharpCommands.cs
+++ b/CefSharp.Wpf.Example/Controls/CefSharpCommands.cs
@@ -1,0 +1,15 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+
+using System.Windows.Input;
+
+namespace CefSharp.Wpf.Example.Controls
+{
+	public static class CefSharpCommands
+	{
+		public static RoutedUICommand Exit = new RoutedUICommand("Exit", "Exit", typeof(CefSharpCommands));
+		public static RoutedUICommand OpenTabBindingTest = new RoutedUICommand("OpenTabBindingTest", "OpenTabBindingTest", typeof(CefSharpCommands));
+	}
+}

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -8,7 +8,17 @@
         <KeyBinding Key="T" Modifiers="Control" Command="New"/>
         <KeyBinding Key="W" Modifiers="Control" Command="Close"/>
     </Window.InputBindings>
-    <Grid>
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_New Tab" Command="New"/>
+                <MenuItem Header="_Close Tab" Command="Close"/>
+                <MenuItem Header="_Exit" Command="controls:CefSharpCommands.Exit"/>
+            </MenuItem>
+            <MenuItem Header="_Tests">
+                <MenuItem Header="_Binding Test" Command="controls:CefSharpCommands.OpenTabBindingTest"/>
+            </MenuItem>
+        </Menu>
         <controls:NonReloadingTabControl x:Name="TabControl"
                                Margin="0,5,0,0"
                                ItemsSource="{Binding BrowserTabs, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
@@ -37,5 +47,5 @@
                 </DataTemplate>
             </TabControl.ContentTemplate>
         </controls:NonReloadingTabControl>
-    </Grid>
+    </DockPanel>
 </Window>

--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
 using CefSharp.Example;
+using CefSharp.Wpf.Example.Controls;
 using CefSharp.Wpf.Example.ViewModels;
 
 namespace CefSharp.Wpf.Example
@@ -26,6 +27,9 @@ namespace CefSharp.Wpf.Example
 
             CommandBindings.Add(new CommandBinding(ApplicationCommands.New, OpenNewTab));
             CommandBindings.Add(new CommandBinding(ApplicationCommands.Close, CloseTab));
+
+            CommandBindings.Add(new CommandBinding(CefSharpCommands.Exit, Exit));
+            CommandBindings.Add(new CommandBinding(CefSharpCommands.OpenTabBindingTest, OpenTabBindingTest));
 
             Loaded += MainWindowLoaded;
 
@@ -73,6 +77,18 @@ namespace CefSharp.Wpf.Example
         private void CreateNewTab(string url = DefaultUrlForAddedTabs, bool showSideBar = false)
         {
             BrowserTabs.Add(new BrowserTabViewModel(url) { ShowSidebar = showSideBar });
+        }
+
+        private void OpenTabBindingTest(object sender, ExecutedRoutedEventArgs e)
+        {
+            CreateNewTab(CefExample.BindingTestUrl, true);
+
+            TabControl.SelectedIndex = TabControl.Items.Count - 1;
+        }
+
+        private void Exit(object sender, ExecutedRoutedEventArgs e)
+        {
+            Close();
         }
     }
 }


### PR DESCRIPTION
- Added a menu to the WPF example so it's easy to access the Binding Test page (should probably add some more test pages in as well)
- Minor code consistency refactorings, going forward constructor/finalizer/descructor blocks will be in the header files (may even considering remove cpp files for classes of small enough size)
- Check if browser is disposed before sending ipc message
- Always create a response message so errors can be returned from `render process ipc`.