### PR TITLE
Fixed NullReferenceException on ControlExtensions.IsActiveControl call

### DIFF
--- a/CefSharp.WinForms/Internals/ControlExtensions.cs
+++ b/CefSharp.WinForms/Internals/ControlExtensions.cs
@@ -45,7 +45,13 @@ namespace CefSharp.WinForms.Internals
         /// <returns></returns>
         public static bool IsActiveControl(this Control control)
         {
-            Control activeControl = control.FindForm().ActiveControl;
+            Form form = control.FindForm();
+            if (form == null)
+            {
+                return false;
+            }
+
+            Control activeControl = form.ActiveControl;
             ContainerControl containerControl;
             while (activeControl != null
                     && (activeControl as ContainerControl != null)


### PR DESCRIPTION
Fixes NullReferenceException exception when browser control is removed from a form but not disposed as should be added back to the form at some point of time:

```
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException
Stack:
   at CefSharp.WinForms.Internals.ControlExtensions.IsActiveControl(System.Windows.Forms.Control)
   at CefSharp.WinForms.Internals.ParentFormMessageInterceptor.WndProc(System.Windows.Forms.Message ByRef)
   at System.Windows.Forms.NativeWindow.DebuggableCallback(IntPtr, Int32, IntPtr, IntPtr)
   at System.Windows.Forms.UnsafeNativeMethods.PeekMessage(MSG ByRef, System.Runtime.InteropServices.HandleRef, Int32, Int32, Int32)
   at System.Windows.Forms.Application+ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr, Int32, Int32)
   at System.Windows.Forms.Application+ThreadContext.RunMessageLoopInner(Int32, System.Windows.Forms.ApplicationContext)
   at System.Windows.Forms.Application+ThreadContext.RunMessageLoop(Int32, System.Windows.Forms.ApplicationContext)
   at System.Windows.Forms.Application.Run(System.Windows.Forms.Form)
   at Lombard.UserInterface.Shell.Program.Main()
```

Windows 7, x86
