### PR TITLE
ManagedCefBrowserAdapter can now be disposed before initialization

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -75,12 +75,15 @@ namespace CefSharp
             // Release the MCefRefPtr<ClientAdapter> reference
             // before calling _browserWrapper->CloseBrowser(true)
             this->!ManagedCefBrowserAdapter();
-            _browserWrapper->CloseBrowser(true);
+            if (_browserWrapper != nullptr)
+            {
+                _browserWrapper->CloseBrowser(true);
 
-            delete _browserWrapper;
-            _browserWrapper = nullptr;
+                delete _browserWrapper;
+                _browserWrapper = nullptr;
+            }
 
-            if (CefSharpSettings::WcfEnabled)
+            if (CefSharpSettings::WcfEnabled && _browserProcessServiceHost != nullptr)
             {
                 _browserProcessServiceHost->Close();
                 _browserProcessServiceHost = nullptr;


### PR DESCRIPTION
This fixes a NullReferenceException when disposing a ChromiumWebBrowser prior to initialization.

To reproduce the bug, modify `CefSharp.WinForms.Example\BrowserTabUserControl.cs` to the following:

```
line 21
            browserPanel.Controls.Add(browser);
+           browserPanel.Visible = false;
```

Then start the `CefSharp.WinForms.Example` application and close the main window.  Because the `_browserWrapper` was never initialized, a `NullReferenceException` would occur on the line `_browserWrapper->CloseBrowser(true);`.