### PR TITLE
OnGotFocus no longer calls SetFocus if browser not initialized.

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -324,7 +324,11 @@ namespace CefSharp.WinForms
 
         protected override void OnGotFocus(EventArgs e)
         {
-            SetFocus(true);
+            if (IsBrowserInitialized)
+            {
+                SetFocus(true);
+            }
+
             base.OnGotFocus(e);
         }
 


### PR DESCRIPTION
Fixes following crash:
```
Exception: System.Exception
Message: 'Browser Is Not yet initialized. Use the IsBrowserInitializedChanged event and checkthe IsBrowserInitialized property to determine when the browser has been intialized.'
Source: CefSharp
Stacktrace:
at CefSharp.WebBrowserExtensions.ThrowExceptionIfBrowserNotInitialized(IWebBrowser browser)
at CefSharp.WinForms.ChromiumWebBrowser.SetFocus(Boolean isFocused)
at CefSharp.WinForms.ChromiumWebBrowser.OnGotFocus(EventArgs e)
at System.Windows.Forms.Control.WmSetFocus(Message& m)
at System.Windows.Forms.Control.WndProc(Message& m)
at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```