### PR TITLE
Ignore callback usage after dispose

### DIFF
--- a/CefSharp.Core/Internals/CefCallbackWrapper.h
+++ b/CefSharp.Core/Internals/CefCallbackWrapper.h
@@ -33,6 +33,11 @@ namespace CefSharp
 
         virtual void Cancel()
         {
+            if (this == nullptr)
+            {
+                return;
+            }
+
             _callback->Cancel();
 
             delete this;
@@ -40,6 +45,11 @@ namespace CefSharp
 
         virtual void Continue()
         {
+            if (this == nullptr)
+            {
+                return;
+            }
+
             _callback->Continue();
 
             delete this;

--- a/CefSharp.Core/Internals/CefCallbackWrapper.h
+++ b/CefSharp.Core/Internals/CefCallbackWrapper.h
@@ -33,26 +33,22 @@ namespace CefSharp
 
         virtual void Cancel()
         {
-            if (_callback.get() == nullptr)
+            if (_callback.get())
             {
-                return;
+                _callback->Cancel();
+
+                delete this;
             }
-
-            _callback->Cancel();
-
-            delete this;
         }
 
         virtual void Continue()
         {
-            if (_callback.get() == nullptr)
+            if (_callback.get())
             {
-                return;
+                _callback->Continue();
+
+                delete this;
             }
-
-            _callback->Continue();
-
-            delete this;
         }
     };
 }

--- a/CefSharp.Core/Internals/CefCallbackWrapper.h
+++ b/CefSharp.Core/Internals/CefCallbackWrapper.h
@@ -33,7 +33,7 @@ namespace CefSharp
 
         virtual void Cancel()
         {
-            if (this == nullptr)
+            if (_callback.get() == nullptr)
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace CefSharp
 
         virtual void Continue()
         {
-            if (this == nullptr)
+            if (_callback.get() == nullptr)
             {
                 return;
             }


### PR DESCRIPTION
Users have no way to determine whether a callback has been disposed, resulting in the following crash if the callback is fired after disposal.  This change silently ignores the method calls.  Another approach would have been to add an `IsDisposed` flag that users must check but that seems more error-prone.

Because callbacks are typically executed asynchronously there is a good chance that they fire after the callback and/or the browser control has been disposed.  This happens occasionally in my app, and adding a `if (!browser.IsDisposed)` check prior to the callback being fired was not adequate to protect against the `NullReferenceException`.

I'm re-running my tests now to make sure this fixes it.

```
Exception: System.NullReferenceException
Message: 'Object reference not set to an instance of an object.'
Source: CefSharp.Core
Stacktrace:
at CefSharp.CefCallbackWrapper.Continue()
at ...
```