### PR TITLE
Offscreen browser is not created for wpf control when it has parent

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -788,7 +788,8 @@ namespace CefSharp.Wpf
 
         private void CreateOffscreenBrowserWhenActualSizeChanged()
         {
-            if (browserCreated || System.ComponentModel.DesignerProperties.GetIsInDesignMode(this))
+            var webBrowserInternal = this as IWebBrowserInternal;
+            if (browserCreated || System.ComponentModel.DesignerProperties.GetIsInDesignMode(this) || webBrowserInternal.HasParent)
             {
                 return;
             }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -788,13 +788,16 @@ namespace CefSharp.Wpf
 
         private void CreateOffscreenBrowserWhenActualSizeChanged()
         {
-            var webBrowserInternal = this as IWebBrowserInternal;
-            if (browserCreated || System.ComponentModel.DesignerProperties.GetIsInDesignMode(this) || webBrowserInternal.HasParent)
+            if (browserCreated || System.ComponentModel.DesignerProperties.GetIsInDesignMode(this))
             {
                 return;
             }
 
-            managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, RequestContext, Address);
+            var webBrowserInternal = this as IWebBrowserInternal;
+            if (!webBrowserInternal.HasParent)
+            {
+                managedCefBrowserAdapter.CreateOffscreenBrowser(source == null ? IntPtr.Zero : source.Handle, BrowserSettings, RequestContext, Address);
+            }
             browserCreated = true;
         }
 


### PR DESCRIPTION
I believe the new offscreen popup feature had a little problem, namely that the offscreen browser is created for the wpf control even if it had a parent. This is just a minimal fix for that, maybe it shouldn't even be a PR :smile:.