### PR TITLE
Revise Event Handlers, Add ILoadHandler, IDisplayHandler and remove IPopupHandler

### DIFF
--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -137,7 +137,10 @@ namespace CefSharp
             }
         }
 
-        /// <summary>Initializes CefSharp with the default settings.</summary>
+        /// <summary>
+        /// Initializes CefSharp with the default settings.
+        /// This function should be called on the main application thread to initialize the CEF browser process.
+        /// </summary>
         /// <return>true if successful; otherwise, false.</return>
         static bool Initialize()
         {
@@ -145,7 +148,10 @@ namespace CefSharp
             return Initialize(cefSettings);
         }
 
-        /// <summary>Initializes CefSharp with user-provided settings.</summary>
+        /// <summary>
+        /// Initializes CefSharp with user-provided settings.
+        /// This function should be called on the main application thread to initialize the CEF browser process.
+        /// </summary>
         /// <param name="cefSettings">CefSharp configuration settings.</param>
         /// <return>true if successful; otherwise, false.</return>
         static bool Initialize(CefSettings^ cefSettings)
@@ -153,7 +159,10 @@ namespace CefSharp
             return Initialize(cefSettings, true, false);
         }
 
-        /// <summary>Initializes CefSharp with user-provided settings.</summary>
+        /// <summary>
+        /// Initializes CefSharp with user-provided settings.
+        /// This function should be called on the main application thread to initialize the CEF browser process.
+        /// </summary>
         /// <param name="cefSettings">CefSharp configuration settings.</param>
         /// <param name="shutdownOnProcessExit">When the Current AppDomain (relative to the thread called on)
         /// Exits(ProcessExit event) then Shudown will be called.</param>
@@ -302,8 +311,10 @@ namespace CefSharp
             return gcnew CookieManager(cookieManager);
         }
 
-        /// <summary>Shuts down CefSharp and the underlying CEF infrastructure. This method is safe to call multiple times; it will only
+        /// <summary>
+        /// Shuts down CefSharp and the underlying CEF infrastructure. This method is safe to call multiple times; it will only
         /// shut down CEF on the first call (all subsequent calls will be ignored).
+        /// This function should be called on the main application thread to shut down the CEF browser process before the application exits. 
         /// </summary>
         static void Shutdown()
         {

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -266,6 +266,7 @@
     <ClInclude Include="Internals\CefPostDataWrapper.h" />
     <ClInclude Include="Internals\CefResponseWrapper.h" />
     <ClInclude Include="Internals\CefSharpBrowserWrapper.h" />
+    <ClInclude Include="Internals\CefSslInfoWrapper.h" />
     <ClInclude Include="Internals\CefTaskScheduler.h" />
     <ClInclude Include="Internals\CefTaskWrapper.h" />
     <ClInclude Include="WindowInfo.h" />

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -261,6 +261,7 @@
     <ClInclude Include="Internals\CefFileDialogCallbackWrapper.h" />
     <ClInclude Include="Internals\CefFrameWrapper.h" />
     <ClInclude Include="Internals\CefGeolocationCallbackWrapper.h" />
+    <ClInclude Include="Internals\CefMenuModelWrapper.h" />
     <ClInclude Include="Internals\CefPostDataElementWrapper.h" />
     <ClInclude Include="Internals\CefPostDataWrapper.h" />
     <ClInclude Include="Internals\CefResponseWrapper.h" />

--- a/CefSharp.Core/CefSharp.Core.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.vcxproj.filters
@@ -238,6 +238,9 @@
     <ClInclude Include="WindowInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Internals\CefMenuModelWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Internals\CefSharpBrowserWrapper.h">

--- a/CefSharp.Core/CefSharp.Core.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.vcxproj.filters
@@ -241,6 +241,9 @@
     <ClInclude Include="Internals\CefMenuModelWrapper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Internals\CefSslInfoWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Internals\CefSharpBrowserWrapper.h">

--- a/CefSharp.Core/Internals/CefMenuModelWrapper.h
+++ b/CefSharp.Core/Internals/CefMenuModelWrapper.h
@@ -1,0 +1,39 @@
+// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+
+#include "include\cef_menu_model.h"
+
+namespace CefSharp
+{
+    public ref class CefMenuModelWrapper : public IMenuModel
+    {
+    private:
+        MCefRefPtr<CefMenuModel> _menu;
+
+    public:
+        CefMenuModelWrapper(CefRefPtr<CefMenuModel> &menu) : _menu(menu)
+        {
+            
+        }
+
+        !CefMenuModelWrapper()
+        {
+            _menu = NULL;
+        }
+
+        ~CefMenuModelWrapper()
+        {
+            this->!CefMenuModelWrapper();
+        }
+
+        virtual bool Clear()
+        {
+            return _menu->Clear();
+        }
+    };
+}

--- a/CefSharp.Core/Internals/CefSslInfoWrapper.h
+++ b/CefSharp.Core/Internals/CefSslInfoWrapper.h
@@ -1,0 +1,171 @@
+// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+#include "TypeConversion.h"
+
+#include "include\cef_ssl_info.h"
+
+namespace CefSharp
+{
+    public ref class CefSslInfoWrapper : ISslInfo
+    {
+    private:
+        MCefRefPtr<CefSSLInfo> _sslInfo;
+
+    public:
+        CefSslInfoWrapper(CefRefPtr<CefSSLInfo> &sslInfo)
+            : _sslInfo(sslInfo)
+        {
+            
+        }
+
+        !CefSslInfoWrapper()
+        {
+            _sslInfo = NULL;
+        }
+
+        ~CefSslInfoWrapper()
+        {
+            this->!CefSslInfoWrapper();
+        }
+
+        public:
+            /*virtual property SslCertPrincipal^ Subject
+            {
+                SslCertPrincipal^ get()
+                {
+                    auto certPrincipal = gcnew SslCertPrincipal();
+
+                    auto _sslInfo->GetSubject();
+
+                    auto elementCount = _postData->GetElementCount();
+                    if (elementCount == 0)
+                    {
+                        return gcnew ReadOnlyCollection<IPostDataElement^>(elements);
+                    }
+                    CefPostData::ElementVector ev;
+
+                    _postData->GetElements(ev);
+
+                    for (CefPostData::ElementVector::iterator it = ev.begin(); it != ev.end(); ++it)
+                    {
+                        CefPostDataElement *el = it->get();
+
+                        elements->Add(gcnew CefPostDataElementWrapper(el));
+                    }
+
+                    return gcnew ReadOnlyCollection<IPostDataElement^>(elements);;
+                }
+            }*/
+
+            /// <summary>
+            /// Returns the subject of the X.509 certificate. For HTTPS server
+            /// certificates this represents the web server.  The common name of the
+            /// subject should match the host name of the web server.
+            /// </summary>
+            /*SslCertPrincipal Subject { get; }*/
+
+            /// <summary>
+            /// Returns the issuer of the X.509 certificate.
+            /// </summary>
+            /*SslCertPrincipal Issuer { get; }*/
+
+            /// <summary>
+            /// Returns the DER encoded serial number for the X.509 certificate. The value
+            /// possibly includes a leading 00 byte.
+            /// </summary>
+            virtual property array<Byte>^ SerialNumber
+            {
+                array<Byte>^ get()
+                {
+                    auto serialNumber = _sslInfo->GetSerialNumber();
+                    auto byteCount = serialNumber->GetSize();
+                    if (byteCount == 0)
+                    {
+                        return nullptr;
+                    }
+
+                    auto bytes = gcnew array<Byte>(byteCount);
+                    pin_ptr<Byte> src = &bytes[0]; // pin pointer to first element in arr
+
+                    serialNumber->GetData(static_cast<void*>(src), byteCount, 0);
+
+                    return bytes;
+                }
+            }
+  
+            /// <summary>
+            /// Returns the date before which the X.509 certificate is invalid.
+            /// will return null if no date was specified.
+            /// </summary>
+            virtual property Nullable<DateTime> ValidStart
+            {
+                Nullable<DateTime> get()
+                {
+                    return TypeConversion::FromNative(_sslInfo->GetValidStart());
+                }
+            }
+
+            /// <summary>
+            /// Returns the date after which the X.509 certificate is invalid.
+            /// will return null if no date was specified.
+            /// </summary>
+            virtual property Nullable<DateTime> ValidExpiry
+            {
+                Nullable<DateTime> get()
+                {
+                    return TypeConversion::FromNative(_sslInfo->GetValidExpiry());
+                }
+            }
+
+            /// <summary>
+            /// Returns the DER encoded data for the X.509 certificate.
+            /// </summary>
+            virtual property array<Byte>^ DerEncoded
+            {
+                array<Byte>^ get()
+                {
+                    auto serialNumber = _sslInfo->GetDEREncoded();
+                    auto byteCount = serialNumber->GetSize();
+                    if (byteCount == 0)
+                    {
+                        return nullptr;
+                    }
+
+                    auto bytes = gcnew array<Byte>(byteCount);
+                    pin_ptr<Byte> src = &bytes[0]; // pin pointer to first element in arr
+
+                    serialNumber->GetData(static_cast<void*>(src), byteCount, 0);
+
+                    return bytes;
+                }
+            }
+
+            /// <summary>
+            /// Returns the PEM encoded data for the X.509 certificate.
+            /// </summary>
+            virtual property array<Byte>^ PemEncoded
+            {
+                array<Byte>^ get()
+                {
+                    auto serialNumber = _sslInfo->GetPEMEncoded();
+                    auto byteCount = serialNumber->GetSize();
+                    if (byteCount == 0)
+                    {
+                        return nullptr;
+                    }
+
+                    auto bytes = gcnew array<Byte>(byteCount);
+                    pin_ptr<Byte> src = &bytes[0]; // pin pointer to first element in arr
+
+                    serialNumber->GetData(static_cast<void*>(src), byteCount, 0);
+
+                    return bytes;
+                }
+            }
+    };
+}

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -8,6 +8,7 @@
 #include "ClientAdapter.h"
 #include "CefRequestWrapper.h"
 #include "CefContextMenuParamsWrapper.h"
+#include "CefMenuModelWrapper.h"
 #include "CefDragDataWrapper.h"
 #include "TypeConversion.h"
 #include "CefSharpBrowserWrapper.h"
@@ -623,19 +624,15 @@ namespace CefSharp
         {
             auto handler = _browserControl->MenuHandler;
             
-            if (handler == nullptr)
+            if (handler != nullptr)
             {
-                return;
-            }
-
-            CefFrameWrapper frameWrapper(frame);
-            CefContextMenuParamsWrapper contextMenuParamsWrapper(params);
-            
-            auto result = handler->OnBeforeContextMenu(_browserControl, %frameWrapper, %contextMenuParamsWrapper);
-            if (!result)
-            {
-                model->Clear();
-            }
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                CefFrameWrapper frameWrapper(frame);
+                CefContextMenuParamsWrapper contextMenuParamsWrapper(params);
+                CefMenuModelWrapper menuModelWrapper(model);
+                
+                handler->OnBeforeContextMenu(_browserControl, browserWrapper, %frameWrapper, %contextMenuParamsWrapper, %menuModelWrapper);
+            }            
         }
 
         void ClientAdapter::OnGotFocus(CefRefPtr<CefBrowser> browser)

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -725,6 +725,30 @@ namespace CefSharp
             return handler->OnJSBeforeUnload(_browserControl, browserWrapper, StringUtils::ToClr(message_text), is_reload, callbackWrapper);
         }
 
+        void ClientAdapter::OnResetDialogState(CefRefPtr<CefBrowser> browser)
+        {
+            auto handler = _browserControl->JsDialogHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnResetDialogState(_browserControl, browserWrapper);
+            }
+        }
+
+        void ClientAdapter::OnDialogClosed(CefRefPtr<CefBrowser> browser)
+        {
+            auto handler = _browserControl->JsDialogHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnDialogClosed(_browserControl, browserWrapper);
+            }
+        }
+
         bool ClientAdapter::OnFileDialog(CefRefPtr<CefBrowser> browser, FileDialogMode mode, const CefString& title,
                 const CefString& default_file_path, const std::vector<CefString>& accept_filters, int selected_accept_filter,
                 CefRefPtr<CefFileDialogCallback> callback)

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -139,7 +139,7 @@ namespace CefSharp
                 // Add to the list of popup browsers.
                 _popupBrowsers->Add(browser->GetIdentifier(), browserWrapper);
 
-                auto handler = _browserControl->PopupHandler;
+                auto handler = _browserControl->DisplayHandler;
 
                 if (handler != nullptr)
                 {
@@ -185,7 +185,7 @@ namespace CefSharp
                 // Remove from the browser popup list.
                 auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
 
-                auto handler = _browserControl->PopupHandler;
+                auto handler = _browserControl->DisplayHandler;
 
                 if (handler != nullptr)
                 {
@@ -220,7 +220,7 @@ namespace CefSharp
 
             if (browser->IsPopup())
             {
-                auto handler = _browserControl->PopupHandler;
+                auto handler = _browserControl->DisplayHandler;
 
                 if (handler != nullptr)
                 {
@@ -240,7 +240,7 @@ namespace CefSharp
 
             if (browser->IsPopup())
             {
-                auto handler = _browserControl->PopupHandler;
+                auto handler = _browserControl->DisplayHandler;
 
                 if (handler != nullptr)
                 {
@@ -314,7 +314,7 @@ namespace CefSharp
 
             if (browser->IsPopup())
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto popupHandler = _browserControl->DisplayHandler;
                 if (popupHandler != nullptr)
                 {
                     popupHandler->OnStatusMessage(_browserControl, args);
@@ -362,7 +362,7 @@ namespace CefSharp
         {
             if (browser->IsPopup())
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto popupHandler = _browserControl->DisplayHandler;
                 if (popupHandler != nullptr)
                 {
                     auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
@@ -382,7 +382,7 @@ namespace CefSharp
         {
             if (browser->IsPopup())
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto popupHandler = _browserControl->DisplayHandler;
 
                 if (popupHandler != nullptr)
                 {
@@ -404,7 +404,7 @@ namespace CefSharp
         {
             if (browser->IsPopup())
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto popupHandler = _browserControl->DisplayHandler;
 
                 if (popupHandler != nullptr)
                 {

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -138,14 +138,6 @@ namespace CefSharp
                 auto browserWrapper = gcnew CefSharpBrowserWrapper(browser);
                 // Add to the list of popup browsers.
                 _popupBrowsers->Add(browser->GetIdentifier(), browserWrapper);
-
-                auto handler = _browserControl->DisplayHandler;
-
-                if (handler != nullptr)
-                {
-                    throw gcnew NotImplementedException();
-                    //handler->OnAfterCreated(_browserControl, browserWrapper);
-                }
             }
             else
             {
@@ -166,15 +158,15 @@ namespace CefSharp
                     SerializeJsObject(_browserAdapter->JavascriptObjectRepository->RootObject, argList, 1);
                     browser->SendProcessMessage(CefProcessId::PID_RENDERER, jsRootObjectMessage);
                 }
+            }
 
-                auto handler = _browserControl->LifeSpanHandler;
+            auto handler = _browserControl->LifeSpanHandler;
 
-                if (handler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
 
-                    handler->OnAfterCreated(_browserControl, browserWrapper);
-                }
+                handler->OnAfterCreated(_browserControl, browserWrapper);
             }
         }
 
@@ -184,15 +176,6 @@ namespace CefSharp
             {
                 // Remove from the browser popup list.
                 auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
-
-                auto handler = _browserControl->DisplayHandler;
-
-                if (handler != nullptr)
-                {
-                    //handler->OnBeforeClose(_browserControl, browserWrapper);
-                    throw gcnew NotImplementedException();
-                }
-
                 _popupBrowsers->Remove(browser->GetIdentifier());
                 // Dispose the CefSharpBrowserWrapper
                 delete browserWrapper;
@@ -201,15 +184,16 @@ namespace CefSharp
             //the handles don't match up (at least in WPF), need to investigate further.
             else if (_browserHwnd == browser->GetHost()->GetWindowHandle() || _browserControl->HasParent)
             {
-                auto handler = _browserControl->LifeSpanHandler;
-
-                if (handler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
-
-                    handler->OnBeforeClose(_browserControl, browserWrapper);
-                }
                 _cefBrowser = NULL;
+            }
+
+            auto handler = _browserControl->LifeSpanHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnBeforeClose(_browserControl, browserWrapper);
             }
         }
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -425,31 +425,15 @@ namespace CefSharp
 
         bool ClientAdapter::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool isRedirect)
         {
-            if (browser->IsPopup())
+            auto handler = _browserControl->RequestHandler;
+
+            if (handler != nullptr)
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                CefFrameWrapper frameWrapper(frame);
+                CefRequestWrapper requestWrapper(request);
 
-                if (popupHandler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
-                    CefFrameWrapper frameWrapper(frame);
-                    CefRequestWrapper requestWrapper(request);
-
-                    return popupHandler->OnBeforeBrowse(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, isRedirect);
-                }
-            }
-            else
-            {
-                auto handler = _browserControl->RequestHandler;
-
-                if (handler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
-                    CefFrameWrapper frameWrapper(frame);
-                    CefRequestWrapper requestWrapper(request);
-
-                    return handler->OnBeforeBrowse(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, isRedirect);
-                }
+                return handler->OnBeforeBrowse(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, isRedirect);
             }
 
             return false;
@@ -533,37 +517,18 @@ namespace CefSharp
 
         void ClientAdapter::OnResourceRedirect(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefString& newUrl)
         {
-            if (browser->IsPopup())
+            auto handler = _browserControl->RequestHandler;
+
+            if (handler != nullptr)
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto managedNewUrl = StringUtils::ToClr(newUrl);
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());;
+                CefFrameWrapper frameWrapper(frame);
+                CefRequestWrapper requestWrapper(request);
 
-                if (popupHandler != nullptr)
-                {
-                    auto managedNewUrl = StringUtils::ToClr(newUrl);
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);;
-                    CefFrameWrapper frameWrapper(frame);
-                    CefRequestWrapper requestWrapper(request);
+                handler->OnResourceRedirect(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, managedNewUrl);
 
-                    popupHandler->OnResourceRedirect(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, managedNewUrl);
-
-                    newUrl = StringUtils::ToNative(managedNewUrl);
-                }
-            }
-            else
-            {
-                auto handler = _browserControl->RequestHandler;
-
-                if (handler != nullptr)
-                {
-                    auto managedNewUrl = StringUtils::ToClr(newUrl);
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);;
-                    CefFrameWrapper frameWrapper(frame);
-                    CefRequestWrapper requestWrapper(request);
-
-                    handler->OnResourceRedirect(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, managedNewUrl);
-
-                    newUrl = StringUtils::ToNative(managedNewUrl);
-                }
+                newUrl = StringUtils::ToNative(managedNewUrl);
             }
         }
 
@@ -624,34 +589,18 @@ namespace CefSharp
 
         cef_return_value_t ClientAdapter::OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefRefPtr<CefRequestCallback> callback)
         {
-            if (browser->IsPopup())
+            auto handler = _browserControl->RequestHandler;
+
+            if (handler != nullptr)
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto frameWrapper = gcnew CefFrameWrapper(frame);
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                auto requestWrapper = gcnew CefRequestWrapper(request);
+                auto requestCallback = gcnew CefRequestCallbackWrapper(callback, frameWrapper, requestWrapper);
 
-                if (popupHandler != nullptr)
-                {
-                    auto frameWrapper = gcnew CefFrameWrapper(frame);
-                    auto requestWrapper = gcnew CefRequestWrapper(request);
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
-                    auto requestCallback = gcnew CefRequestCallbackWrapper(callback, frameWrapper, requestWrapper);
-
-                    return (cef_return_value_t)popupHandler->OnBeforeResourceLoad(_browserControl, browserWrapper, frameWrapper, requestWrapper, requestCallback);
-                }
+                return (cef_return_value_t)handler->OnBeforeResourceLoad(_browserControl, browserWrapper, frameWrapper, requestWrapper, requestCallback);
             }
-            else
-            {
-                auto handler = _browserControl->RequestHandler;
 
-                if (handler != nullptr)
-                {
-                    auto frameWrapper = gcnew CefFrameWrapper(frame);
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
-                    auto requestWrapper = gcnew CefRequestWrapper(request);
-                    auto requestCallback = gcnew CefRequestCallbackWrapper(callback, frameWrapper, requestWrapper);
-
-                    return (cef_return_value_t)handler->OnBeforeResourceLoad(_browserControl, browserWrapper, frameWrapper, requestWrapper, requestCallback);
-                }
-            }
             return cef_return_value_t::RV_CONTINUE;
         }
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -632,7 +632,36 @@ namespace CefSharp
                 CefMenuModelWrapper menuModelWrapper(model);
                 
                 handler->OnBeforeContextMenu(_browserControl, browserWrapper, %frameWrapper, %contextMenuParamsWrapper, %menuModelWrapper);
-            }            
+            }           
+        }
+
+        bool ClientAdapter::OnContextMenuCommand(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                CefRefPtr<CefContextMenuParams> params, int commandId, EventFlags eventFlags)
+        {
+            auto handler = _browserControl->MenuHandler;
+            
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                CefFrameWrapper frameWrapper(frame);
+                CefContextMenuParamsWrapper contextMenuParamsWrapper(params);
+                
+                return handler->OnContextMenuCommand(_browserControl, browserWrapper, %frameWrapper, %contextMenuParamsWrapper,
+                    commandId, (CefEventFlags)eventFlags);
+            }
+        }
+        
+        void ClientAdapter::OnContextMenuDismissed(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame)
+        {
+            auto handler = _browserControl->MenuHandler;
+            
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                CefFrameWrapper frameWrapper(frame);
+                
+                handler->OnContextMenuDismissed(_browserControl, browserWrapper, %frameWrapper);
+            }
         }
 
         void ClientAdapter::OnGotFocus(CefRefPtr<CefBrowser> browser)

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -143,7 +143,8 @@ namespace CefSharp
 
                 if (handler != nullptr)
                 {
-                    handler->OnAfterCreated(_browserControl, browserWrapper);
+                    throw gcnew NotImplementedException();
+                    //handler->OnAfterCreated(_browserControl, browserWrapper);
                 }
             }
             else
@@ -188,7 +189,8 @@ namespace CefSharp
 
                 if (handler != nullptr)
                 {
-                    handler->OnBeforeClose(_browserControl, browserWrapper);
+                    //handler->OnBeforeClose(_browserControl, browserWrapper);
+                    throw gcnew NotImplementedException();
                 }
 
                 _popupBrowsers->Remove(browser->GetIdentifier());

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -303,12 +303,12 @@ namespace CefSharp
             }
 
             auto handler = _browserControl->DisplayHandler;
-            if (handler != nullptr)
+            if (handler == nullptr)
             {
-                return handler->OnConsoleMessage(_browserControl, args);
+                return false;
             }
 
-            return true;
+            return handler->OnConsoleMessage(_browserControl, args);
         }
 
         void ClientAdapter::OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefString& value)

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -512,6 +512,18 @@ namespace CefSharp
             }
         }
 
+        void ClientAdapter::OnRenderViewReady(CefRefPtr<CefBrowser> browser)
+        {
+            auto handler = _browserControl->RequestHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnRenderViewReady(_browserControl, browserWrapper);
+            }
+        }
+
         void ClientAdapter::OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status)
         {
             auto handler = _browserControl->RequestHandler;

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -452,7 +452,7 @@ namespace CefSharp
             auto requestCallback = callback == NULL ? nullptr : gcnew CefRequestCallbackWrapper(callback);
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
 
-            return handler->OnCertificateError(_browserControl, browserWrapper, (CefErrorCode)cert_error, StringUtils::ToClr(request_url), requestCallback);
+            return handler->OnCertificateError(_browserControl, browserWrapper, (CefErrorCode)cert_error, StringUtils::ToClr(request_url), nullptr, requestCallback);
         }
 
         bool ClientAdapter::OnQuotaRequest(CefRefPtr<CefBrowser> browser, const CefString& originUrl, int64 newSize, CefRefPtr<CefRequestCallback> callback)

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -270,27 +270,13 @@ namespace CefSharp
 
         void ClientAdapter::OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std::vector<CefString>& iconUrls)
         {
-            if (browser->IsPopup())
+            auto handler = _browserControl->RequestHandler;
+
+            if (handler != nullptr)
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
 
-                if (popupHandler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
-
-                    popupHandler->OnFaviconUrlChange(_browserControl, browserWrapper, StringUtils::ToClr(iconUrls));
-                }
-            }
-            else
-            {
-                auto handler = _browserControl->RequestHandler;
-
-                if (handler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
-
-                    handler->OnFaviconUrlChange(_browserControl, browserWrapper, StringUtils::ToClr(iconUrls));
-                }
+                handler->OnFaviconUrlChange(_browserControl, browserWrapper, StringUtils::ToClr(iconUrls));
             }
         }
 
@@ -329,8 +315,6 @@ namespace CefSharp
                 auto popupHandler = _browserControl->PopupHandler;
                 if (popupHandler != nullptr)
                 {
-                    
-
                     popupHandler->OnStatusMessage(_browserControl, args);
                 }
             }

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -342,63 +342,32 @@ namespace CefSharp
 
         bool ClientAdapter::OnKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEvent& event, CefEventHandle os_event)
         {
-            if (browser->IsPopup())
+            auto handler = _browserControl->KeyboardHandler;
+
+            if (handler != nullptr)
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
 
-                if (popupHandler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
-
-                    return popupHandler->OnKeyEvent(
-                        _browserControl, browserWrapper, (KeyType)event.type, 
-                        event.windows_key_code, event.native_key_code, 
-                        (CefEventFlags)event.modifiers, event.is_system_key == 1);
-                }
-            }
-            else
-            {
-                auto handler = _browserControl->KeyboardHandler;
-
-                if (handler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
-
-                    return handler->OnKeyEvent(
-                        _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code, 
-                        event.native_key_code,
-                        (CefEventFlags)event.modifiers, event.is_system_key == 1);
-                }                
+                return handler->OnKeyEvent(
+                    _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code, 
+                    event.native_key_code,
+                    (CefEventFlags)event.modifiers, event.is_system_key == 1);
             }
             return false;
         }
 
         bool ClientAdapter::OnPreKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEvent& event, CefEventHandle os_event, bool* is_keyboard_shortcut)
         {
-            if (browser->IsPopup())
+            auto handler = _browserControl->KeyboardHandler;
+
+            if (handler != nullptr)
             {
-                auto popupHandler = _browserControl->PopupHandler;
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
 
-                if (popupHandler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), true);
-
-                    popupHandler->OnPreKeyEvent(_browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code, event.native_key_code, (CefEventFlags)event.modifiers, event.is_system_key == 1, *is_keyboard_shortcut);
-                }
-            }
-            else
-            {
-                auto handler = _browserControl->KeyboardHandler;
-
-                if (handler != nullptr)
-                {
-                    auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), false);
-
-                    return handler->OnPreKeyEvent(
-                        _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code,
-                        event.native_key_code, (CefEventFlags)event.modifiers, event.is_system_key == 1,
-                        *is_keyboard_shortcut);
-                }
+                return handler->OnPreKeyEvent(
+                    _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code,
+                    event.native_key_code, (CefEventFlags)event.modifiers, event.is_system_key == 1,
+                    *is_keyboard_shortcut);
             }
             return false;
         }

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -332,32 +332,34 @@ namespace CefSharp
         {
             auto handler = _browserControl->KeyboardHandler;
 
-            if (handler != nullptr)
+            if (handler == nullptr)
             {
-                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
-
-                return handler->OnKeyEvent(
-                    _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code, 
-                    event.native_key_code,
-                    (CefEventFlags)event.modifiers, event.is_system_key == 1);
+                return false;
             }
-            return false;
+            
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+            return handler->OnKeyEvent(
+                _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code, 
+                event.native_key_code,
+                (CefEventFlags)event.modifiers, event.is_system_key == 1);            
         }
 
         bool ClientAdapter::OnPreKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEvent& event, CefEventHandle os_event, bool* is_keyboard_shortcut)
         {
             auto handler = _browserControl->KeyboardHandler;
 
-            if (handler != nullptr)
+            if (handler == nullptr)
             {
-                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                return false;
+            }            
 
-                return handler->OnPreKeyEvent(
-                    _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code,
-                    event.native_key_code, (CefEventFlags)event.modifiers, event.is_system_key == 1,
-                    *is_keyboard_shortcut);
-            }
-            return false;
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+            return handler->OnPreKeyEvent(
+                _browserControl, browserWrapper, (KeyType)event.type, event.windows_key_code,
+                event.native_key_code, (CefEventFlags)event.modifiers, event.is_system_key == 1,
+                *is_keyboard_shortcut);
         }
 
         void ClientAdapter::OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame)
@@ -419,16 +421,16 @@ namespace CefSharp
         {
             auto handler = _browserControl->RequestHandler;
 
-            if (handler != nullptr)
+            if (handler == nullptr)
             {
-                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
-                CefFrameWrapper frameWrapper(frame);
-                CefRequestWrapper requestWrapper(request);
+                return false;
+            }           
 
-                return handler->OnBeforeBrowse(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, isRedirect);
-            }
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+            CefFrameWrapper frameWrapper(frame);
+            CefRequestWrapper requestWrapper(request);
 
-            return false;
+            return handler->OnBeforeBrowse(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, isRedirect);
         }
 
         bool ClientAdapter::OnCertificateError(CefRefPtr<CefBrowser> browser, cef_errorcode_t cert_error, const CefString& request_url, CefRefPtr<CefSSLInfo> ssl_info, CefRefPtr<CefRequestCallback> callback)
@@ -583,17 +585,17 @@ namespace CefSharp
         {
             auto handler = _browserControl->RequestHandler;
 
-            if (handler != nullptr)
+            if (handler == nullptr)
             {
-                auto frameWrapper = gcnew CefFrameWrapper(frame);
-                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
-                auto requestWrapper = gcnew CefRequestWrapper(request);
-                auto requestCallback = gcnew CefRequestCallbackWrapper(callback, frameWrapper, requestWrapper);
+                return cef_return_value_t::RV_CONTINUE;
+            }            
 
-                return (cef_return_value_t)handler->OnBeforeResourceLoad(_browserControl, browserWrapper, frameWrapper, requestWrapper, requestCallback);
-            }
+            auto frameWrapper = gcnew CefFrameWrapper(frame);
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+            auto requestWrapper = gcnew CefRequestWrapper(request);
+            auto requestCallback = gcnew CefRequestCallbackWrapper(callback, frameWrapper, requestWrapper);
 
-            return cef_return_value_t::RV_CONTINUE;
+            return (cef_return_value_t)handler->OnBeforeResourceLoad(_browserControl, browserWrapper, frameWrapper, requestWrapper, requestCallback);
         }
 
         bool ClientAdapter::GetAuthCredentials(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, bool isProxy,

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -274,6 +274,7 @@ namespace CefSharp
             bool hasChanged = tooltip != _tooltip;
 
             //NOTE: Only called if tooltip changed otherwise called many times
+            // also only appears to be called with OSR rendering at the moment
             if(hasChanged)
             {
                 if (!browser->IsPopup())
@@ -289,7 +290,6 @@ namespace CefSharp
                 }
             }
 
-            //TODO: Should this be true for WinForms?
             return true;
         }
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -177,11 +177,6 @@ namespace CefSharp
 
         void ClientAdapter::OnBeforeClose(CefRefPtr<CefBrowser> browser)
         {
-            if(_javascriptCallbackFactories->ContainsKey(browser->GetIdentifier()))
-            {
-                _javascriptCallbackFactories->Remove(browser->GetIdentifier());
-            }
-
             if (browser->IsPopup() && !_browserControl->HasParent)
             {
                 // Remove from the browser popup list.
@@ -511,10 +506,6 @@ namespace CefSharp
         {
             if (!Object::ReferenceEquals(_browserAdapter, nullptr))
             {
-                //save callback factory for this browser
-                //it's only going to be present after browseradapter is initialized
-                _javascriptCallbackFactories->Add(browser->GetIdentifier(), _browserAdapter->JavascriptCallbackFactory);
-
                 auto objectRepository = _browserAdapter->JavascriptObjectRepository;
                 //transmit async bound objects
                 auto jsRootObjectMessage = CefProcessMessage::Create(kJavascriptRootObjectRequest);
@@ -906,8 +897,7 @@ namespace CefSharp
             auto handled = false;
             auto name = message->GetName();
             auto argList = message->GetArgumentList();
-            IJavascriptCallbackFactory^ callbackFactory;
-            _javascriptCallbackFactories->TryGetValue(browser->GetIdentifier(), callbackFactory);
+            IJavascriptCallbackFactory^ callbackFactory = _browserAdapter->JavascriptCallbackFactory;
 
             if (name == kEvaluateJavascriptResponse || name == kJavascriptCallbackResponse)
             {

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -171,6 +171,20 @@ namespace CefSharp
             }
         }
 
+        bool ClientAdapter::DoClose(CefRefPtr<CefBrowser> browser)
+        {
+            auto handler = _browserControl->LifeSpanHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                return handler->DoClose(_browserControl, browserWrapper);
+            }
+
+            return false;
+        }
+
         void ClientAdapter::OnBeforeClose(CefRefPtr<CefBrowser> browser)
         {
             if (browser->IsPopup() && !_browserControl->HasParent)

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -234,7 +234,7 @@ namespace CefSharp
         void ClientAdapter::OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& address)
         {
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
-            auto args = gcnew AddressChangedEventArgs(StringUtils::ToClr(address));
+            auto args = gcnew AddressChangedEventArgs(browserWrapper, StringUtils::ToClr(address));
 
             if (browser->IsPopup())
             {

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -42,8 +42,6 @@ namespace CefSharp
             //contains in-progress eval script tasks
             gcroot<PendingTaskRepository<JavascriptResponse^>^> _pendingTaskRepository;
             //contains js callback factories for each browser
-            //TODO: This this required now?
-            gcroot<Dictionary<int, IJavascriptCallbackFactory^>^> _javascriptCallbackFactories;
 
             void ThrowUnknownPopupBrowser(String^ context)
             {
@@ -57,7 +55,6 @@ namespace CefSharp
                 _browserControl(browserControl), 
                 _popupBrowsers(gcnew Dictionary<int, IBrowser^>()),
                 _pendingTaskRepository(gcnew PendingTaskRepository<JavascriptResponse^>()),
-                _javascriptCallbackFactories(gcnew Dictionary<int, IJavascriptCallbackFactory^>()),
                 _browserAdapter(browserAdapter)
             {
                 

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -140,6 +140,9 @@ namespace CefSharp
             // CefContextMenuHandler
             virtual DECL void OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
                 CefRefPtr<CefContextMenuParams> params, CefRefPtr<CefMenuModel> model) OVERRIDE;
+            virtual DECL bool OnContextMenuCommand(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                CefRefPtr<CefContextMenuParams> params, int commandId, EventFlags eventFlags) OVERRIDE;
+            virtual DECL void OnContextMenuDismissed(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame) OVERRIDE;
 
             // CefFocusHandler
             virtual DECL void OnGotFocus(CefRefPtr<CefBrowser> browser) OVERRIDE;

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -42,6 +42,7 @@ namespace CefSharp
             //contains in-progress eval script tasks
             gcroot<PendingTaskRepository<JavascriptResponse^>^> _pendingTaskRepository;
             //contains js callback factories for each browser
+            //TODO: This this required now?
             gcroot<Dictionary<int, IJavascriptCallbackFactory^>^> _javascriptCallbackFactories;
 
             void ThrowUnknownPopupBrowser(String^ context)

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -124,9 +124,9 @@ namespace CefSharp
             virtual DECL bool OnQuotaRequest(CefRefPtr<CefBrowser> browser, const CefString& originUrl, int64 newSize, CefRefPtr<CefRequestCallback> callback) OVERRIDE;
             virtual DECL void OnResourceRedirect(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefString& newUrl) OVERRIDE;
             virtual DECL void OnProtocolExecution(CefRefPtr<CefBrowser> browser, const CefString& url, bool& allowOSExecution) OVERRIDE;
-
             virtual DECL bool OnBeforePluginLoad( CefRefPtr< CefBrowser > browser, const CefString& url, const CefString& policy_url, CefRefPtr< CefWebPluginInfo > info ) OVERRIDE;
             virtual DECL void OnPluginCrashed(CefRefPtr<CefBrowser> browser, const CefString& plugin_path) OVERRIDE;
+            virtual DECL void OnRenderViewReady(CefRefPtr<CefBrowser> browser) OVERRIDE;
             virtual DECL void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status) OVERRIDE;
 
             // CefDisplayHandler

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -156,6 +156,8 @@ namespace CefSharp
                 CefRefPtr<CefJSDialogCallback> callback, bool& suppress_message) OVERRIDE;
             virtual DECL bool OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser, const CefString& message_text, bool is_reload,
                 CefRefPtr<CefJSDialogCallback> callback) OVERRIDE;
+            virtual DECL void OnResetDialogState(CefRefPtr<CefBrowser> browser) OVERRIDE;
+            virtual DECL void OnDialogClosed(CefRefPtr<CefBrowser> browser) OVERRIDE;
 
             // CefDialogHandler
             virtual DECL bool OnFileDialog(CefRefPtr<CefBrowser> browser, FileDialogMode mode, const CefString& title,

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -106,6 +106,7 @@ namespace CefSharp
                 const CefPopupFeatures& popupFeatures,
                 CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, bool* no_javascript_access) OVERRIDE;
             virtual DECL void OnAfterCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
+            virtual DECL bool DoClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
             virtual DECL void OnBeforeClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
 
             // CefLoadHandler

--- a/CefSharp.Example/JsDialogHandler.cs
+++ b/CefSharp.Example/JsDialogHandler.cs
@@ -19,5 +19,15 @@ namespace CefSharp.Example
             //NOTE: Returning false will trigger the default behaviour, you need to return true to handle yourself.
             return false;
         }
+
+        public void OnResetDialogState(IWebBrowser browserControl, IBrowser browser)
+        {
+            
+        }
+
+        public void OnDialogClosed(IWebBrowser browserControl, IBrowser browser)
+        {
+            
+        }
     }
 }

--- a/CefSharp.Example/RequestHandler.cs
+++ b/CefSharp.Example/RequestHandler.cs
@@ -21,7 +21,7 @@ namespace CefSharp.Example
             return false;
         }
 
-        bool IRequestHandler.OnCertificateError(IWebBrowser browserControl, IBrowser browser, CefErrorCode errorCode, string requestUrl, IRequestCallback callback)
+        bool IRequestHandler.OnCertificateError(IWebBrowser browserControl, IBrowser browser, CefErrorCode errorCode, string requestUrl, ISslInfo sslInfo, IRequestCallback callback)
         {
             try
             {

--- a/CefSharp.Example/RequestHandler.cs
+++ b/CefSharp.Example/RequestHandler.cs
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace CefSharp.Example
 {
@@ -14,6 +12,11 @@ namespace CefSharp.Example
             Cef.ChromiumVersion, Cef.CefVersion, Cef.CefSharpVersion);
 
         bool IRequestHandler.OnBeforeBrowse(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, bool isRedirect)
+        {
+            return false;
+        }
+
+        bool IRequestHandler.OnOpenUrlFromTab(IWebBrowser browserControl, IBrowser browser, IFrame frame, string targetUrl, WindowOpenDisposition targetDisposition, bool userGesture)
         {
             return false;
         }
@@ -97,7 +100,7 @@ namespace CefSharp.Example
             // TODO: Add your own code here for handling scenarios where the Render Process terminated for one reason or another.
         }
 
-        public bool OnQuotaRequest(IWebBrowser browserControl, IBrowser browser, string originUrl, long newSize, IRequestCallback callback)
+        bool IRequestHandler.OnQuotaRequest(IWebBrowser browserControl, IBrowser browser, string originUrl, long newSize, IRequestCallback callback)
         {
             try
             {
@@ -113,7 +116,7 @@ namespace CefSharp.Example
             }
         }
 
-        public void OnResourceRedirect(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, ref string newUrl)
+        void IRequestHandler.OnResourceRedirect(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, ref string newUrl)
         {
             //Example of how to redirect - need to check `newUrl` in the second pass
             //if (string.Equals(frame.GetUrl(), "https://www.google.com/", StringComparison.OrdinalIgnoreCase) && !newUrl.Contains("github"))
@@ -122,14 +125,14 @@ namespace CefSharp.Example
             //}
         }
 
-        public bool OnProtocolExecution(IWebBrowser browserControl, IBrowser browser, string url)
+        bool IRequestHandler.OnProtocolExecution(IWebBrowser browserControl, IBrowser browser, string url)
         {
             return url.StartsWith("mailto");
         }
 
-        public void OnFaviconUrlChange(IWebBrowser browserControl, IBrowser browser, IList<string> urls)
+        void IRequestHandler.OnRenderViewReady(IWebBrowser browserControl, IBrowser browser)
         {
-            var url = urls[0];
+            
         }
     }
 }

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -66,6 +66,7 @@ namespace CefSharp.OffScreen
         public event EventHandler<StatusMessageEventArgs> StatusMessage;
         public event EventHandler<LoadingStateChangedEventArgs> LoadingStateChanged;
         public event EventHandler<AddressChangedEventArgs> AddressChanged;
+        public event EventHandler<TitleChangedEventArgs> TitleChanged;
 
         /// <summary>
         /// Fired by a separate thread when Chrome has re-rendered.
@@ -330,12 +331,12 @@ namespace CefSharp.OffScreen
         {
         }
 
-        void IWebBrowserInternal.OnConsoleMessage(string message, string source, int line)
+        void IWebBrowserInternal.OnConsoleMessage(ConsoleMessageEventArgs args)
         {
             var handler = ConsoleMessage;
             if (handler != null)
             {
-                handler(this, new ConsoleMessageEventArgs(message, source, line));
+                handler(this, args);
             }
         }
 
@@ -368,12 +369,12 @@ namespace CefSharp.OffScreen
             }
         }
 
-        void IWebBrowserInternal.OnLoadError(IFrame frame, CefErrorCode errorCode, string errorText, string failedUrl)
+        void IWebBrowserInternal.OnLoadError(LoadErrorEventArgs args)
         {
             var handler = LoadError;
             if (handler != null)
             {
-                handler(this, new LoadErrorEventArgs(frame, errorCode, errorText, failedUrl));
+                handler(this, args);
             }
         }
 
@@ -389,43 +390,47 @@ namespace CefSharp.OffScreen
             get { return IntPtr.Zero; }
         }
 
-        void IWebBrowserInternal.OnStatusMessage(string value)
+        void IWebBrowserInternal.OnStatusMessage(StatusMessageEventArgs args)
         {
             var handler = StatusMessage;
             if (handler != null)
             {
-                handler(this, new StatusMessageEventArgs(value));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.SetAddress(string address)
+        void IWebBrowserInternal.SetAddress(AddressChangedEventArgs args)
         {
-            Address = address;
+            Address = args.Address;
 
             var handler = AddressChanged;
             if (handler != null)
             {
-                handler(this, new AddressChangedEventArgs(address));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.SetLoadingStateChange(bool canGoBack, bool canGoForward, bool isLoading)
+        void IWebBrowserInternal.SetLoadingStateChange(LoadingStateChangedEventArgs args)
         {
-            CanGoBack = canGoBack;
-            CanGoForward = canGoForward;
-            CanReload = !isLoading;
-            IsLoading = isLoading;
+            CanGoBack = args.CanGoBack;
+            CanGoForward = args.CanGoForward;
+            CanReload = !args.IsLoading;
+            IsLoading = args.IsLoading;
 
             var handler = LoadingStateChanged;
             if (handler != null)
             {
-                handler(this, new LoadingStateChangedEventArgs(canGoBack, canGoForward, isLoading));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.SetTitle(string title)
+        void IWebBrowserInternal.SetTitle(TitleChangedEventArgs args)
         {
-            Title = title;
+            var handler = TitleChanged;
+            if (handler != null)
+            {
+                handler(this, args);
+            }
         }
 
         void IWebBrowserInternal.SetTooltipText(string tooltipText)

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -37,7 +37,6 @@ namespace CefSharp.OffScreen
 
         public bool IsBrowserInitialized { get; private set; }
         public bool IsLoading { get; set; }
-        public string Title { get; set; }
         public string TooltipText { get; set; }
         public bool CanReload { get; private set; }
         public string Address { get; private set; }

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -38,6 +38,7 @@ namespace CefSharp.OffScreen
         public bool IsBrowserInitialized { get; private set; }
         public bool IsLoading { get; set; }
         public string TooltipText { get; set; }
+        [Obsolete("Use IsLoading instead (inverse of this property)")]
         public bool CanReload { get; private set; }
         public string Address { get; private set; }
         public bool CanGoBack { get; private set; }

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -52,7 +52,7 @@ namespace CefSharp.OffScreen
         public ILoadHandler LoadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IDisplayHandler DisplayHandler { get; set; }
-        public IMenuHandler MenuHandler { get; set; }
+        public IContextMenuHandler MenuHandler { get; set; }
         public IFocusHandler FocusHandler { get; set; }
         public IRequestHandler RequestHandler { get; set; }
         public IDragHandler DragHandler { get; set; }

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -50,7 +50,7 @@ namespace CefSharp.OffScreen
         public IDownloadHandler DownloadHandler { get; set; }
         public IKeyboardHandler KeyboardHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
-        public IPopupHandler PopupHandler { get; set; }
+        public IDisplayHandler DisplayHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }
         public IFocusHandler FocusHandler { get; set; }
         public IRequestHandler RequestHandler { get; set; }

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -49,6 +49,7 @@ namespace CefSharp.OffScreen
         public IDialogHandler DialogHandler { get; set; }
         public IDownloadHandler DownloadHandler { get; set; }
         public IKeyboardHandler KeyboardHandler { get; set; }
+        public ILoadHandler LoadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IDisplayHandler DisplayHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }

--- a/CefSharp.WinForms.Example/Handlers/LifeSpanHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/LifeSpanHandler.cs
@@ -56,6 +56,11 @@ namespace CefSharp.WinForms.Example.Handlers
 			
 		}
 
+		bool ILifeSpanHandler.DoClose(IWebBrowser browserControl, IBrowser browser)
+		{
+			return false;
+		}
+
 		public void OnBeforeClose(IWebBrowser browserControl, IBrowser browser)
 		{
 			

--- a/CefSharp.WinForms.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/MenuHandler.cs
@@ -6,10 +6,20 @@ namespace CefSharp.WinForms.Example.Handlers
 {
     internal class MenuHandler : IMenuHandler
     {
-        public bool OnBeforeContextMenu(IWebBrowser browser, IFrame frame, IContextMenuParams parameters)
+        void IMenuHandler.OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
         {
-            // Return false if you want to disable the context menu.
-            return true;
+            //To disable the menu then call clear
+            // model.Clear();
+        }
+
+        bool IMenuHandler.OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, int commandId, CefEventFlags eventFlags)
+        {
+            return false;
+        }
+
+        void IMenuHandler.OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
+        {
+            
         }
     }
 }

--- a/CefSharp.WinForms.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/MenuHandler.cs
@@ -4,20 +4,20 @@
 
 namespace CefSharp.WinForms.Example.Handlers
 {
-    internal class MenuHandler : IMenuHandler
+    internal class MenuHandler : IContextMenuHandler
     {
-        void IMenuHandler.OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
+        void IContextMenuHandler.OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
         {
             //To disable the menu then call clear
             // model.Clear();
         }
 
-        bool IMenuHandler.OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, int commandId, CefEventFlags eventFlags)
+        bool IContextMenuHandler.OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, int commandId, CefEventFlags eventFlags)
         {
             return false;
         }
 
-        void IMenuHandler.OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
+        void IContextMenuHandler.OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
         {
             
         }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -35,7 +35,7 @@ namespace CefSharp.WinForms
         public ILoadHandler LoadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IDisplayHandler DisplayHandler { get; set; }
-        public IMenuHandler MenuHandler { get; set; }
+        public IContextMenuHandler MenuHandler { get; set; }
 
         /// <summary>
         /// The <see cref="IFocusHandler"/> for this ChromiumWebBrowser.

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -63,6 +63,7 @@ namespace CefSharp.WinForms
 
         public bool CanGoForward { get; private set; }
         public bool CanGoBack { get; private set; }
+        [Obsolete("Use IsLoading instead (inverse of this property)")]
         public bool CanReload { get; private set; }
         public bool IsBrowserInitialized { get; private set; }
 

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -206,39 +206,39 @@ namespace CefSharp.WinForms
             }
         }
 
-        void IWebBrowserInternal.SetAddress(string address)
+        void IWebBrowserInternal.SetAddress(AddressChangedEventArgs args)
         {
-            Address = address;
+            Address = args.Address;
 
             var handler = AddressChanged;
             if (handler != null)
             {
-                handler(this, new AddressChangedEventArgs(address));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.SetLoadingStateChange(bool canGoBack, bool canGoForward, bool isLoading)
+        void IWebBrowserInternal.SetLoadingStateChange(LoadingStateChangedEventArgs args)
         {
-            CanGoBack = canGoBack;
-            CanGoForward = canGoForward;
-            CanReload = !isLoading;
-            IsLoading = isLoading;
+            CanGoBack = args.CanGoBack;
+            CanGoForward = args.CanGoForward;
+            CanReload = !args.IsLoading;
+            IsLoading = args.IsLoading;
 
             var handler = LoadingStateChanged;
             if (handler != null)
             {
-                handler(this, new LoadingStateChangedEventArgs(canGoBack, canGoForward, isLoading));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.SetTitle(string title)
+        void IWebBrowserInternal.SetTitle(TitleChangedEventArgs args)
         {
-            Title = title;
+            Title = args.Title;
 
             var handler = TitleChanged;
             if (handler != null)
             {
-                handler(this, new TitleChangedEventArgs(title));
+                handler(this, args);
             }
         }
 
@@ -265,30 +265,30 @@ namespace CefSharp.WinForms
             }
         }
 
-        void IWebBrowserInternal.OnConsoleMessage(string message, string source, int line)
+        void IWebBrowserInternal.OnConsoleMessage(ConsoleMessageEventArgs args)
         {
             var handler = ConsoleMessage;
             if (handler != null)
             {
-                handler(this, new ConsoleMessageEventArgs(message, source, line));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.OnStatusMessage(string value)
+        void IWebBrowserInternal.OnStatusMessage(StatusMessageEventArgs args)
         {
             var handler = StatusMessage;
             if (handler != null)
             {
-                handler(this, new StatusMessageEventArgs(value));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.OnLoadError(IFrame frame, CefErrorCode errorCode, string errorText, string failedUrl)
+        void IWebBrowserInternal.OnLoadError(LoadErrorEventArgs args)
         {
             var handler = LoadError;
             if (handler != null)
             {
-                handler(this, new LoadErrorEventArgs(frame, errorCode, errorText, failedUrl));
+                handler(this, args);
             }
         }
 

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -33,7 +33,7 @@ namespace CefSharp.WinForms
         public IRequestHandler RequestHandler { get; set; }
         public IDownloadHandler DownloadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
-        public IPopupHandler PopupHandler { get; set; }
+        public IDisplayHandler DisplayHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }
 
         /// <summary>

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -32,6 +32,7 @@ namespace CefSharp.WinForms
         public IKeyboardHandler KeyboardHandler { get; set; }
         public IRequestHandler RequestHandler { get; set; }
         public IDownloadHandler DownloadHandler { get; set; }
+        public ILoadHandler LoadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IDisplayHandler DisplayHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -23,7 +23,6 @@ namespace CefSharp.WinForms
 
         public BrowserSettings BrowserSettings { get; set; }
         public RequestContext RequestContext { get; set; }
-        public string Title { get; set; }
         public bool IsLoading { get; private set; }
         public string TooltipText { get; private set; }
         public string Address { get; private set; }
@@ -233,8 +232,6 @@ namespace CefSharp.WinForms
 
         void IWebBrowserInternal.SetTitle(TitleChangedEventArgs args)
         {
-            Title = args.Title;
-
             var handler = TitleChanged;
             if (handler != null)
             {

--- a/CefSharp.Wpf.Example/Handlers/LifespanHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/LifespanHandler.cs
@@ -71,7 +71,12 @@ namespace CefSharp.Wpf.Example.Handlers
             });
         }
 
-        public void OnBeforeClose(IWebBrowser browserControl, IBrowser browser)
+        bool ILifeSpanHandler.DoClose(IWebBrowser browserControl, IBrowser browser)
+        {
+            return false;
+        }
+
+        void ILifeSpanHandler.OnBeforeClose(IWebBrowser browserControl, IBrowser browser)
         {
             var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
 

--- a/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
@@ -8,12 +8,23 @@ namespace CefSharp.Wpf.Example.Handlers
 {
     public class MenuHandler : IMenuHandler
     {
-        public bool OnBeforeContextMenu(IWebBrowser browser, IFrame frame, IContextMenuParams parameters)
+        void IMenuHandler.OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
         {
             Console.WriteLine("Context menu opened");
             Console.WriteLine(parameters.MisspelledWord);
 
-            return true;
+            //To disable context mode then clear
+            // model.Clear();
+        }
+
+        bool IMenuHandler.OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, int commandId, CefEventFlags eventFlags)
+        {
+            return false;
+        }
+
+        void IMenuHandler.OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
+        {
+            
         }
     }
 }

--- a/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
@@ -6,9 +6,9 @@ using System;
 
 namespace CefSharp.Wpf.Example.Handlers
 {
-    public class MenuHandler : IMenuHandler
+    public class MenuHandler : IContextMenuHandler
     {
-        void IMenuHandler.OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
+        void IContextMenuHandler.OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
         {
             Console.WriteLine("Context menu opened");
             Console.WriteLine(parameters.MisspelledWord);
@@ -17,12 +17,12 @@ namespace CefSharp.Wpf.Example.Handlers
             // model.Clear();
         }
 
-        bool IMenuHandler.OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, int commandId, CefEventFlags eventFlags)
+        bool IContextMenuHandler.OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, int commandId, CefEventFlags eventFlags)
         {
             return false;
         }
 
-        void IMenuHandler.OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
+        void IContextMenuHandler.OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
         {
             
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -45,7 +45,7 @@ namespace CefSharp.Wpf
         public IRequestHandler RequestHandler { get; set; }
         public IDownloadHandler DownloadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
-        public IPopupHandler PopupHandler { get; set; }
+        public IDisplayHandler DisplayHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }
         public IFocusHandler FocusHandler { get; set; }
         public IDragHandler DragHandler { get; set; }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -47,7 +47,7 @@ namespace CefSharp.Wpf
         public ILoadHandler LoadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IDisplayHandler DisplayHandler { get; set; }
-        public IMenuHandler MenuHandler { get; set; }
+        public IContextMenuHandler MenuHandler { get; set; }
         public IFocusHandler FocusHandler { get; set; }
         public IDragHandler DragHandler { get; set; }
         public IResourceHandlerFactory ResourceHandlerFactory { get; set; }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -295,12 +295,12 @@ namespace CefSharp.Wpf
             });
         }
 
-        void IWebBrowserInternal.SetAddress(string address)
+        void IWebBrowserInternal.SetAddress(AddressChangedEventArgs args)
         {
             UiThreadRunAsync(() =>
             {
                 ignoreUriChange = true;
-                SetCurrentValue(AddressProperty, address);
+                SetCurrentValue(AddressProperty, args.Address);
                 ignoreUriChange = false;
 
                 // The tooltip should obviously also be reset (and hidden) when the address changes.
@@ -308,14 +308,14 @@ namespace CefSharp.Wpf
             });
         }
 
-        void IWebBrowserInternal.SetLoadingStateChange(bool canGoBack, bool canGoForward, bool isLoading)
+        void IWebBrowserInternal.SetLoadingStateChange(LoadingStateChangedEventArgs args)
         {
             UiThreadRunAsync(() =>
             {
-                SetCurrentValue(CanGoBackProperty, canGoBack);
-                SetCurrentValue(CanGoForwardProperty, canGoForward);
-                SetCurrentValue(CanReloadProperty, !isLoading);
-                SetCurrentValue(IsLoadingProperty, isLoading);
+                SetCurrentValue(CanGoBackProperty, args.CanGoBack);
+                SetCurrentValue(CanGoForwardProperty, args.CanGoForward);
+                SetCurrentValue(CanReloadProperty, !args.IsLoading);
+                SetCurrentValue(IsLoadingProperty, args.IsLoading);
 
                 ((DelegateCommand)BackCommand).RaiseCanExecuteChanged();
                 ((DelegateCommand)ForwardCommand).RaiseCanExecuteChanged();
@@ -325,13 +325,13 @@ namespace CefSharp.Wpf
             var handler = LoadingStateChanged;
             if (handler != null)
             {
-                handler(this, new LoadingStateChangedEventArgs(canGoBack, canGoForward, isLoading));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.SetTitle(string title)
+        void IWebBrowserInternal.SetTitle(TitleChangedEventArgs args)
         {
-            UiThreadRunAsync(() => SetCurrentValue(TitleProperty, title));
+            UiThreadRunAsync(() => SetCurrentValue(TitleProperty, args.Title));
         }
 
         void IWebBrowserInternal.SetTooltipText(string tooltipText)
@@ -358,30 +358,30 @@ namespace CefSharp.Wpf
             }
         }
 
-        void IWebBrowserInternal.OnConsoleMessage(string message, string source, int line)
+        void IWebBrowserInternal.OnConsoleMessage(ConsoleMessageEventArgs args)
         {
             var handler = ConsoleMessage;
             if (handler != null)
             {
-                handler(this, new ConsoleMessageEventArgs(message, source, line));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.OnStatusMessage(string value)
+        void IWebBrowserInternal.OnStatusMessage(StatusMessageEventArgs args)
         {
             var handler = StatusMessage;
             if (handler != null)
             {
-                handler(this, new StatusMessageEventArgs(value));
+                handler(this, args);
             }
         }
 
-        void IWebBrowserInternal.OnLoadError(IFrame frame, CefErrorCode errorCode, string errorText, string failedUrl)
+        void IWebBrowserInternal.OnLoadError(LoadErrorEventArgs args)
         {
             var handler = LoadError;
             if (handler != null)
             {
-                handler(this, new LoadErrorEventArgs(frame, errorCode, errorText, failedUrl));
+                handler(this, args);
             }
         }
 

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -44,6 +44,7 @@ namespace CefSharp.Wpf
         public IKeyboardHandler KeyboardHandler { get; set; }
         public IRequestHandler RequestHandler { get; set; }
         public IDownloadHandler DownloadHandler { get; set; }
+        public ILoadHandler LoadHandler { get; set; }
         public ILifeSpanHandler LifeSpanHandler { get; set; }
         public IDisplayHandler DisplayHandler { get; set; }
         public IMenuHandler MenuHandler { get; set; }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -128,7 +128,7 @@ namespace CefSharp.Wpf
 
             BackCommand = new DelegateCommand(this.Back, () => CanGoBack);
             ForwardCommand = new DelegateCommand(this.Forward, () => CanGoForward);
-            ReloadCommand = new DelegateCommand(this.Reload, () => CanReload);
+            ReloadCommand = new DelegateCommand(this.Reload, () => !IsLoading);
             PrintCommand = new DelegateCommand(this.Print);
             ZoomInCommand = new DelegateCommand(ZoomIn);
             ZoomOutCommand = new DelegateCommand(ZoomOut);
@@ -437,6 +437,7 @@ namespace CefSharp.Wpf
 
         #region CanReload dependency property
 
+        [Obsolete("Use IsLoading instead (inverse of this property)")]
         public bool CanReload
         {
             get { return (bool)GetValue(CanReloadProperty); }

--- a/CefSharp.Wpf/IWpfWebBrowser.cs
+++ b/CefSharp.Wpf/IWpfWebBrowser.cs
@@ -107,5 +107,11 @@ namespace CefSharp.Wpf
         /// The increment at which the <see cref="ZoomLevel"/> property will be incremented/decremented.
         /// </summary>
         double ZoomLevelIncrement { get; set; }
+
+        /// <summary>
+        /// The title of the web page being currently displayed.
+        /// </summary>
+        /// <remarks>This property is implemented as a Dependency Property and fully supports data binding.</remarks>
+        string Title { get; }
     }
 }

--- a/CefSharp/AddressChangedEventArgs.cs
+++ b/CefSharp/AddressChangedEventArgs.cs
@@ -11,10 +11,12 @@ namespace CefSharp
     /// </summary>
     public class AddressChangedEventArgs : EventArgs
     {
+        public IBrowser Browser { get; set; }
         public string Address { get; private set; }
 
-        public AddressChangedEventArgs(string address)
+        public AddressChangedEventArgs(IBrowser browser, string address)
         {
+            Browser = browser;
             Address = address;
         }
     }

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -132,7 +132,7 @@
     <Compile Include="Internals\JavascriptCallbackSurrogate.cs" />
     <Compile Include="Internals\PendingTaskRepository.cs" />
     <Compile Include="Internals\ReflectionUtils.cs" />
-    <Compile Include="IPopupHandler.cs" />
+    <Compile Include="IDisplayHandler.cs" />
     <Compile Include="IRequestCallback.cs" />
     <Compile Include="IResourceHandler.cs" />
     <Compile Include="IResourceHandlerFactory.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -93,6 +93,7 @@
     <Compile Include="CefFileDialogMode.cs" />
     <Compile Include="CefJsDialogType.cs" />
     <Compile Include="ICookieManager.cs" />
+    <Compile Include="ILoadHandler.cs" />
     <Compile Include="KeyEvent.cs" />
     <Compile Include="KeyEventType.cs" />
     <Compile Include="IPostData.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -193,7 +193,7 @@
     <Compile Include="IJsDialogHandler.cs" />
     <Compile Include="IKeyboardHandler.cs" />
     <Compile Include="ILifeSpanHandler.cs" />
-    <Compile Include="IMenuHandler.cs" />
+    <Compile Include="IContextMenuHandler.cs" />
     <Compile Include="Internals\IRenderWebBrowser.cs" />
     <Compile Include="InternalWebBrowserExtensions.cs" />
     <Compile Include="WebBrowserExtensions.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -94,6 +94,7 @@
     <Compile Include="CefJsDialogType.cs" />
     <Compile Include="ICookieManager.cs" />
     <Compile Include="ILoadHandler.cs" />
+    <Compile Include="IMenuModel.cs" />
     <Compile Include="KeyEvent.cs" />
     <Compile Include="KeyEventType.cs" />
     <Compile Include="IPostData.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -95,6 +95,7 @@
     <Compile Include="ICookieManager.cs" />
     <Compile Include="ILoadHandler.cs" />
     <Compile Include="IMenuModel.cs" />
+    <Compile Include="ISslInfo.cs" />
     <Compile Include="KeyEvent.cs" />
     <Compile Include="KeyEventType.cs" />
     <Compile Include="IPostData.cs" />

--- a/CefSharp/FrameLoadStartEventArgs.cs
+++ b/CefSharp/FrameLoadStartEventArgs.cs
@@ -19,7 +19,11 @@ namespace CefSharp
             IsMainFrame = frame.IsMain;
         }
 
+        /// <summary>
+        /// The browser object
+        /// </summary>
         public IBrowser Browser { get; private set;}
+
         /// <summary>
         /// The frame that just started loading.
         /// </summary>

--- a/CefSharp/IContextMenuHandler.cs
+++ b/CefSharp/IContextMenuHandler.cs
@@ -4,7 +4,7 @@
 
 namespace CefSharp
 {
-    public interface IMenuHandler
+    public interface IContextMenuHandler
     {
         /// <summary>
         /// Called before a context menu is displayed. |params| provides information

--- a/CefSharp/IDisplayHandler.cs
+++ b/CefSharp/IDisplayHandler.cs
@@ -5,9 +5,9 @@
 namespace CefSharp
 {
     /// <summary>
-    /// Handler methods that get called AFTER the Popup is created.
+    /// Handle events related to browser display state.
     /// </summary>
-    public interface IPopupHandler
+    public interface IDisplayHandler
     {
         /// <summary>
         /// Called when a frame's address has changed. 

--- a/CefSharp/IDisplayHandler.cs
+++ b/CefSharp/IDisplayHandler.cs
@@ -43,7 +43,7 @@ namespace CefSharp
         /// </summary>
         /// <param name="browserControl">The ChromiumWebBrowser control</param>
         /// <param name="text"></param>
-        void OnTooltip(IWebBrowser browserControl, string text);
+        bool OnTooltipChanged(IWebBrowser browserControl, string text);
 
         /// <summary>
         /// Called when the browser receives a status message.
@@ -57,49 +57,7 @@ namespace CefSharp
         /// being output to the console.
         /// </summary>
         /// <param name="browserControl">The ChromiumWebBrowser control</param>
-        /// <param name="consoleMessageArgs"></param>
-        void OnConsoleMessage(IWebBrowser browserControl, ConsoleMessageEventArgs consoleMessageArgs);
-
-        /// <summary>
-        /// Called when the loading state has changed. This callback will be executed twice
-        /// once when loading is initiated either programmatically or by user action,
-        /// and once when loading is terminated due to completion, cancellation of failure. 
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="loadingStateChangedArgs">args</param>
-        void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
-
-        /// <summary>
-        /// Called when the browser begins loading a frame.
-        /// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
-        /// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
-        /// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
-        /// This method may not be called for a particular frame if the load request for that frame fails.
-        /// For notification of overall browser load status use <see cref="OnLoadingStateChange"/> instead. 
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="frameLoadStartArgs">args</param>
-        void OnFrameLoadStart(IWebBrowser browserControl, FrameLoadStartEventArgs frameLoadStartArgs);
-
-        /// <summary>
-        /// Called when the browser is done loading a frame.
-        /// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
-        /// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
-        /// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
-        /// This method will always be called for all frames irrespective of whether the request completes successfully. 
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="frameLoadEndArgs">args</param>
-        void OnFrameLoadEnd(IWebBrowser browserControl, FrameLoadEndEventArgs frameLoadEndArgs);
-
-        /// <summary>
-        /// Called when the resource load for a navigation fails or is canceled.
-        /// |errorCode| is the error code number, |errorText| is the error text and
-        /// |failedUrl| is the URL that failed to load. See net\base\net_error_list.h
-        /// for complete descriptions of the error codes.
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="loadErrorArgs">args</param>
-        void OnLoadError(IWebBrowser browserControl, LoadErrorEventArgs loadErrorArgs);
+        /// <param name="consoleMessageArgs">args</param>
+        bool OnConsoleMessage(IWebBrowser browserControl, ConsoleMessageEventArgs consoleMessageArgs);
     }
 }

--- a/CefSharp/IDisplayHandler.cs
+++ b/CefSharp/IDisplayHandler.cs
@@ -2,6 +2,8 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System.Collections.Generic;
+
 namespace CefSharp
 {
     /// <summary>
@@ -17,13 +19,31 @@ namespace CefSharp
         void OnAddressChanged(IWebBrowser browserControl, AddressChangedEventArgs addressChangedArgs);
 
         /// <summary>
-        /// Called when the loading state has changed. This callback will be executed twice
-        /// once when loading is initiated either programmatically or by user action,
-        /// and once when loading is terminated due to completion, cancellation of failure. 
+        /// Called when the page title changes.
         /// </summary>
         /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="loadingStateChangedArgs">args</param>
-        void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
+        /// <param name="titleChangedArgs">args</param>
+        void OnTitleChanged(IWebBrowser browserControl, TitleChangedEventArgs titleChangedArgs);
+
+        /// <summary>
+        /// Called when the page icon changes.
+        /// </summary>
+        /// <param name="browserControl">The ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="urls">list of urls where the favicons can be downloaded</param>
+        void OnFaviconUrlChange(IWebBrowser browserControl, IBrowser browser, IList<string> urls);
+
+        /// <summary>
+        /// Called when the browser is about to display a tooltip. |text| contains the
+        /// text that will be displayed in the tooltip. To handle the display of the
+        /// tooltip yourself return true. Otherwise, you can optionally modify |text|
+        /// and then return false to allow the browser to display the tooltip.
+        /// When window rendering is disabled the application is responsible for
+        /// drawing tooltips and the return value is ignored.
+        /// </summary>
+        /// <param name="browserControl">The ChromiumWebBrowser control</param>
+        /// <param name="text"></param>
+        void OnTooltip(IWebBrowser browserControl, string text);
 
         /// <summary>
         /// Called when the browser receives a status message.
@@ -31,6 +51,23 @@ namespace CefSharp
         /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="statusMessageArgs">args</param>
         void OnStatusMessage(IWebBrowser browserControl, StatusMessageEventArgs statusMessageArgs);
+
+        /// <summary>
+        /// Called to display a console message. Return true to stop the message from
+        /// being output to the console.
+        /// </summary>
+        /// <param name="browserControl">The ChromiumWebBrowser control</param>
+        /// <param name="consoleMessageArgs"></param>
+        void OnConsoleMessage(IWebBrowser browserControl, ConsoleMessageEventArgs consoleMessageArgs);
+
+        /// <summary>
+        /// Called when the loading state has changed. This callback will be executed twice
+        /// once when loading is initiated either programmatically or by user action,
+        /// and once when loading is terminated due to completion, cancellation of failure. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="loadingStateChangedArgs">args</param>
+        void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
 
         /// <summary>
         /// Called when the browser begins loading a frame.

--- a/CefSharp/IDragHandler.cs
+++ b/CefSharp/IDragHandler.cs
@@ -3,9 +3,9 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 namespace CefSharp
+{
+    public interface IDragHandler
     {
-        public interface IDragHandler
-        {
-            bool OnDragEnter(IWebBrowser browserControl, IBrowser browser, IDragData dragData, DragOperationsMask mask);
-        }
+        bool OnDragEnter(IWebBrowser browserControl, IBrowser browser, IDragData dragData, DragOperationsMask mask);
     }
+}

--- a/CefSharp/IJsDialogHandler.cs
+++ b/CefSharp/IJsDialogHandler.cs
@@ -33,5 +33,21 @@ namespace CefSharp
         /// <param name="callback">Callback can be executed inline or in an async fashion</param>
         /// <returns>Return false to use the default dialog implementation otherwise return true to handle</returns>
         bool OnJSBeforeUnload(IWebBrowser browserControl, IBrowser browser, string message, bool isReload, IJsDialogCallback callback);
+
+        /// <summary>
+        /// Called to cancel any pending dialogs and reset any saved dialog state. Will
+        /// be called due to events like page navigation irregardless of whether any
+        /// dialogs are currently pending.
+        /// </summary>
+        /// <param name="browserControl">the browser control</param>
+        /// <param name="browser">the browser object</param>
+        void OnResetDialogState(IWebBrowser browserControl, IBrowser browser);
+
+        /// <summary>
+        /// Called when the default implementation dialog is closed.
+        /// </summary>
+        /// <param name="browserControl">the browser control</param>
+        /// <param name="browser">the browser object</param>
+        void OnDialogClosed(IWebBrowser browserControl, IBrowser browser);
     }
 }

--- a/CefSharp/ILifeSpanHandler.cs
+++ b/CefSharp/ILifeSpanHandler.cs
@@ -48,6 +48,67 @@ namespace CefSharp
         void OnAfterCreated(IWebBrowser browserControl, IBrowser browser);
 
         /// <summary>
+        /// Called when a browser has recieved a request to close. This may result
+        /// directly from a call to CefBrowserHost::CloseBrowser() or indirectly if the
+        /// browser is a top-level OS window created by CEF and the user attempts to
+        /// close the window. This method will be called after the JavaScript
+        /// 'onunload' event has been fired. It will not be called for browsers after
+        /// the associated OS window has been destroyed (for those browsers it is no
+        /// longer possible to cancel the close).
+        ///
+        /// If CEF created an OS window for the browser returning false will send an OS
+        /// close notification to the browser window's top-level owner (e.g. WM_CLOSE
+        /// on Windows, performClose: on OS-X and "delete_event" on Linux). If no OS
+        /// window exists (window rendering disabled) returning false will cause the
+        /// browser object to be destroyed immediately. Return true if the browser is
+        /// parented to another window and that other window needs to receive close
+        /// notification via some non-standard technique.
+        ///
+        /// If an application provides its own top-level window it should handle OS
+        /// close notifications by calling CefBrowserHost::CloseBrowser(false) instead
+        /// of immediately closing (see the example below). This gives CEF an
+        /// opportunity to process the 'onbeforeunload' event and optionally cancel the
+        /// close before DoClose() is called.
+        ///
+        /// The CefLifeSpanHandler::OnBeforeClose() method will be called immediately
+        /// before the browser object is destroyed. The application should only exit
+        /// after OnBeforeClose() has been called for all existing browsers.
+        ///
+        /// If the browser represents a modal window and a custom modal loop
+        /// implementation was provided in CefLifeSpanHandler::RunModal() this callback
+        /// should be used to restore the opener window to a usable state.
+        ///
+        /// By way of example consider what should happen during window close when the
+        /// browser is parented to an application-provided top-level OS window.
+        /// 1.  User clicks the window close button which sends an OS close
+        ///     notification (e.g. WM_CLOSE on Windows, performClose: on OS-X and
+        ///     "delete_event" on Linux).
+        /// 2.  Application's top-level window receives the close notification and:
+        ///     A. Calls CefBrowserHost::CloseBrowser(false).
+        ///     B. Cancels the window close.
+        /// 3.  JavaScript 'onbeforeunload' handler executes and shows the close
+        ///     confirmation dialog (which can be overridden via
+        ///     CefJSDialogHandler::OnBeforeUnloadDialog()).
+        /// 4.  User approves the close.
+        /// 5.  JavaScript 'onunload' handler executes.
+        /// 6.  Application's DoClose() handler is called. Application will:
+        ///     A. Set a flag to indicate that the next close attempt will be allowed.
+        ///     B. Return false.
+        /// 7.  CEF sends an OS close notification.
+        /// 8.  Application's top-level window receives the OS close notification and
+        ///     allows the window to close based on the flag from #6B.
+        /// 9.  Browser OS window is destroyed.
+        /// 10. Application's CefLifeSpanHandler::OnBeforeClose() handler is called and
+        ///     the browser object is destroyed.
+        /// 11. Application exits by calling CefQuitMessageLoop() if no other browsers
+        ///     exist.
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control that is realted to the window is closing.</param>
+        /// <param name="browser">The browser instance</param>
+        /// <returns>For default behaviour return false</returns>
+        bool DoClose(IWebBrowser browserControl, IBrowser browser);
+
+        /// <summary>
         /// Called before a CefBrowser window (either the main browser for <see cref="IWebBrowser"/>, 
         /// or one of its children)
         /// </summary>

--- a/CefSharp/ILoadHandler.cs
+++ b/CefSharp/ILoadHandler.cs
@@ -1,0 +1,51 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+	public interface ILoadHandler
+	{
+		/// <summary>
+		/// Called when the loading state has changed. This callback will be executed twice
+		/// once when loading is initiated either programmatically or by user action,
+		/// and once when loading is terminated due to completion, cancellation of failure. 
+		/// </summary>
+		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+		/// <param name="loadingStateChangedArgs">args</param>
+		void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
+
+		/// <summary>
+		/// Called when the browser begins loading a frame.
+		/// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
+		/// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
+		/// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
+		/// This method may not be called for a particular frame if the load request for that frame fails.
+		/// For notification of overall browser load status use <see cref="OnLoadingStateChange"/> instead. 
+		/// </summary>
+		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+		/// <param name="frameLoadStartArgs">args</param>
+		void OnFrameLoadStart(IWebBrowser browserControl, FrameLoadStartEventArgs frameLoadStartArgs);
+
+		/// <summary>
+		/// Called when the browser is done loading a frame.
+		/// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
+		/// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
+		/// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
+		/// This method will always be called for all frames irrespective of whether the request completes successfully. 
+		/// </summary>
+		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+		/// <param name="frameLoadEndArgs">args</param>
+		void OnFrameLoadEnd(IWebBrowser browserControl, FrameLoadEndEventArgs frameLoadEndArgs);
+
+		/// <summary>
+		/// Called when the resource load for a navigation fails or is canceled.
+		/// |errorCode| is the error code number, |errorText| is the error text and
+		/// |failedUrl| is the URL that failed to load. See net\base\net_error_list.h
+		/// for complete descriptions of the error codes.
+		/// </summary>
+		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+		/// <param name="loadErrorArgs">args</param>
+		void OnLoadError(IWebBrowser browserControl, LoadErrorEventArgs loadErrorArgs);
+	}
+}

--- a/CefSharp/ILoadHandler.cs
+++ b/CefSharp/ILoadHandler.cs
@@ -4,48 +4,48 @@
 
 namespace CefSharp
 {
-	public interface ILoadHandler
-	{
-		/// <summary>
-		/// Called when the loading state has changed. This callback will be executed twice
-		/// once when loading is initiated either programmatically or by user action,
-		/// and once when loading is terminated due to completion, cancellation of failure. 
-		/// </summary>
-		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-		/// <param name="loadingStateChangedArgs">args</param>
-		void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
+    public interface ILoadHandler
+    {
+        /// <summary>
+        /// Called when the loading state has changed. This callback will be executed twice
+        /// once when loading is initiated either programmatically or by user action,
+        /// and once when loading is terminated due to completion, cancellation of failure. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="loadingStateChangedArgs">args</param>
+        void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
 
-		/// <summary>
-		/// Called when the browser begins loading a frame.
-		/// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
-		/// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
-		/// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
-		/// This method may not be called for a particular frame if the load request for that frame fails.
-		/// For notification of overall browser load status use <see cref="OnLoadingStateChange"/> instead. 
-		/// </summary>
-		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-		/// <param name="frameLoadStartArgs">args</param>
-		void OnFrameLoadStart(IWebBrowser browserControl, FrameLoadStartEventArgs frameLoadStartArgs);
+        /// <summary>
+        /// Called when the browser begins loading a frame.
+        /// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
+        /// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
+        /// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
+        /// This method may not be called for a particular frame if the load request for that frame fails.
+        /// For notification of overall browser load status use <see cref="OnLoadingStateChange"/> instead. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="frameLoadStartArgs">args</param>
+        void OnFrameLoadStart(IWebBrowser browserControl, FrameLoadStartEventArgs frameLoadStartArgs);
 
-		/// <summary>
-		/// Called when the browser is done loading a frame.
-		/// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
-		/// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
-		/// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
-		/// This method will always be called for all frames irrespective of whether the request completes successfully. 
-		/// </summary>
-		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-		/// <param name="frameLoadEndArgs">args</param>
-		void OnFrameLoadEnd(IWebBrowser browserControl, FrameLoadEndEventArgs frameLoadEndArgs);
+        /// <summary>
+        /// Called when the browser is done loading a frame.
+        /// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
+        /// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
+        /// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
+        /// This method will always be called for all frames irrespective of whether the request completes successfully. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="frameLoadEndArgs">args</param>
+        void OnFrameLoadEnd(IWebBrowser browserControl, FrameLoadEndEventArgs frameLoadEndArgs);
 
-		/// <summary>
-		/// Called when the resource load for a navigation fails or is canceled.
-		/// |errorCode| is the error code number, |errorText| is the error text and
-		/// |failedUrl| is the URL that failed to load. See net\base\net_error_list.h
-		/// for complete descriptions of the error codes.
-		/// </summary>
-		/// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-		/// <param name="loadErrorArgs">args</param>
-		void OnLoadError(IWebBrowser browserControl, LoadErrorEventArgs loadErrorArgs);
-	}
+        /// <summary>
+        /// Called when the resource load for a navigation fails or is canceled.
+        /// |errorCode| is the error code number, |errorText| is the error text and
+        /// |failedUrl| is the URL that failed to load. See net\base\net_error_list.h
+        /// for complete descriptions of the error codes.
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="loadErrorArgs">args</param>
+        void OnLoadError(IWebBrowser browserControl, LoadErrorEventArgs loadErrorArgs);
+    }
 }

--- a/CefSharp/IMenuHandler.cs
+++ b/CefSharp/IMenuHandler.cs
@@ -10,8 +10,7 @@ namespace CefSharp
         /// Called before a context menu is displayed. |params| provides information
         /// about the context menu state. |model| initially contains the default
         /// context menu. The |model| can be cleared to show no context menu or
-        /// modified to show a custom menu. Do not keep references to |params| or
-        /// |model| outside of this callback.
+        /// modified to show a custom menu.
         /// </summary>
         /// <param name="browserControl">the ChromiumWebBrowser control</param>
         /// <param name="browser">the browser object</param>
@@ -28,8 +27,7 @@ namespace CefSharp
         /// cef_menu_id_t for the command ids that have default implementations. All
         /// user-defined command ids should be between MENU_ID_USER_FIRST and
         /// MENU_ID_USER_LAST. |params| will have the same values as what was passed to
-        /// OnBeforeContextMenu(). Do not keep a reference to |params| outside of this
-        /// callback.
+        /// OnBeforeContextMenu().
         /// </summary>
         /// <param name="browserControl">the ChromiumWebBrowser control</param>
         /// <param name="browser">the browser object</param>

--- a/CefSharp/IMenuHandler.cs
+++ b/CefSharp/IMenuHandler.cs
@@ -6,6 +6,48 @@ namespace CefSharp
 {
     public interface IMenuHandler
     {
-        bool OnBeforeContextMenu(IWebBrowser browser, IFrame frame, IContextMenuParams parameters);
+        /// <summary>
+        /// Called before a context menu is displayed. |params| provides information
+        /// about the context menu state. |model| initially contains the default
+        /// context menu. The |model| can be cleared to show no context menu or
+        /// modified to show a custom menu. Do not keep references to |params| or
+        /// |model| outside of this callback.
+        /// </summary>
+        /// <param name="browserControl">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="frame">The frame the request is coming from</param>
+        /// <param name="parameters"></param>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        void OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters,
+                                IMenuModel model);
+
+        /// <summary>
+        /// Called to execute a command selected from the context menu. Return true if
+        /// the command was handled or false for the default implementation. See
+        /// cef_menu_id_t for the command ids that have default implementations. All
+        /// user-defined command ids should be between MENU_ID_USER_FIRST and
+        /// MENU_ID_USER_LAST. |params| will have the same values as what was passed to
+        /// OnBeforeContextMenu(). Do not keep a reference to |params| outside of this
+        /// callback.
+        /// </summary>
+        /// <param name="browserControl">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="frame">The frame the request is coming from</param>
+        /// <param name="parameters"></param>
+        /// <param name="commandId"></param>
+        /// <param name="eventFlags"></param>
+        /// <returns></returns>
+        bool OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters,
+                                  int commandId, CefEventFlags eventFlags);
+
+        /// <summary>
+        /// Called when the context menu is dismissed irregardless of whether the menu
+        /// was empty or a command was selected.
+        /// </summary>
+        /// <param name="browserControl">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="frame">The frame the request is coming from</param>
+        void OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame);
     }
 }

--- a/CefSharp/IMenuModel.cs
+++ b/CefSharp/IMenuModel.cs
@@ -1,0 +1,11 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+	public interface IMenuModel
+	{
+		bool Clear();
+	}
+}

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 namespace CefSharp
 {

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -10,18 +10,18 @@ namespace CefSharp
     public interface IPopupHandler
     {
         /// <summary>
-        /// Called before the passed popup window (browser) is closed.
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">The popup window instance that is closing.</param>
-        void OnBeforeClose(IWebBrowser browserControl, IBrowser browser);
-
-        /// <summary>
         /// Called after the paased popup window (browser) is created.
         /// </summary>
         /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="browser">The popup window instance that was just created.</param>
         void OnAfterCreated(IWebBrowser browserControl, IBrowser browser);
+
+        /// <summary>
+        /// Called before the passed popup window (browser) is closed.
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="browser">The popup window instance that is closing.</param>
+        void OnBeforeClose(IWebBrowser browserControl, IBrowser browser);
 
         /// <summary>
         /// Called when a frame's address has changed. 

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -22,14 +22,6 @@ namespace CefSharp
         void OnAfterCreated(IWebBrowser browserControl, IBrowser browser);
 
         /// <summary>
-        /// Called when the page icon changes.
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">The browser object</param>
-        /// <param name="iconUrls">List of Favicon urls</param>
-        void OnFaviconUrlChange(IWebBrowser browserControl, IBrowser browser, List<string> iconUrls);
-
-        /// <summary>
         /// Called when a frame's address has changed. 
         /// </summary>
         /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -10,20 +10,6 @@ namespace CefSharp
     public interface IPopupHandler
     {
         /// <summary>
-        /// Called after the paased popup window (browser) is created.
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">The popup window instance that was just created.</param>
-        void OnAfterCreated(IWebBrowser browserControl, IBrowser browser);
-
-        /// <summary>
-        /// Called before the passed popup window (browser) is closed.
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">The popup window instance that is closing.</param>
-        void OnBeforeClose(IWebBrowser browserControl, IBrowser browser);
-
-        /// <summary>
         /// Called when a frame's address has changed. 
         /// </summary>
         /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -5,7 +5,7 @@ namespace CefSharp
     /// <summary>
     /// Handler methods that get called AFTER the Popup is created.
     /// </summary>
-    public interface IPopupHandler : IKeyboardHandler
+    public interface IPopupHandler
     {
         /// <summary>
         /// Called before the passed popup window (browser) is closed.

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -10,25 +10,69 @@ namespace CefSharp
         /// <summary>
         /// Called before the passed popup window (browser) is closed.
         /// </summary>
-        /// <param name="browserControl">The IWebBrowser control this popup is related to.</param>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="browser">The popup window instance that is closing.</param>
         void OnBeforeClose(IWebBrowser browserControl, IBrowser browser);
 
         /// <summary>
         /// Called after the paased popup window (browser) is created.
         /// </summary>
-        /// <param name="browserControl">The IWebBrowser control this popup is related to.</param>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="browser">The popup window instance that was just created.</param>
         void OnAfterCreated(IWebBrowser browserControl, IBrowser browser);
 
+        /// <summary>
+        /// Called when the page icon changes.
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="browser">The browser object</param>
+        /// <param name="iconUrls">List of Favicon urls</param>
         void OnFaviconUrlChange(IWebBrowser browserControl, IBrowser browser, List<string> iconUrls);
 
-        void OnLoadingStateChange(IWebBrowser browserControl, IBrowser browser, bool isLoading, bool canGoBack, bool canGoForward);
+        /// <summary>
+        /// Called when a frame's address has changed. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="addressChangedArgs">args</param>
+        void OnAddressChanged(IWebBrowser browserControl, AddressChangedEventArgs addressChangedArgs);
 
-        void OnStatusMessage(IWebBrowser browserControl, IBrowser browser, string message);
+        /// <summary>
+        /// Called when the loading state has changed. This callback will be executed twice
+        /// once when loading is initiated either programmatically or by user action,
+        /// and once when loading is terminated due to completion, cancellation of failure. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="loadingStateChangedArgs">args</param>
+        void OnLoadingStateChange(IWebBrowser browserControl, LoadingStateChangedEventArgs loadingStateChangedArgs);
 
+        /// <summary>
+        /// Called when the browser receives a status message.
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="statusMessageArgs">args</param>
+        void OnStatusMessage(IWebBrowser browserControl, StatusMessageEventArgs statusMessageArgs);
+
+        /// <summary>
+        /// Called when the browser begins loading a frame.
+        /// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
+        /// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
+        /// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
+        /// This method may not be called for a particular frame if the load request for that frame fails.
+        /// For notification of overall browser load status use <see cref="OnLoadingStateChange"/> instead. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="frameLoadStartArgs">args</param>
         void OnFrameLoadStart(IWebBrowser browserControl, FrameLoadStartEventArgs frameLoadStartArgs);
 
+        /// <summary>
+        /// Called when the browser is done loading a frame.
+        /// The |<see cref="FrameLoadEndEventArgs.Frame"/> value will never be empty
+        /// Check the <see cref="IFrame.IsMain"/> method to see if this frame is the main frame.
+        /// Multiple frames may be loading at the same time. Sub-frames may start or continue loading after the main frame load has ended.
+        /// This method will always be called for all frames irrespective of whether the request completes successfully. 
+        /// </summary>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="frameLoadEndArgs">args</param>
         void OnFrameLoadEnd(IWebBrowser browserControl, FrameLoadEndEventArgs frameLoadEndArgs);
 
         /// <summary>
@@ -37,7 +81,9 @@ namespace CefSharp
         /// |failedUrl| is the URL that failed to load. See net\base\net_error_list.h
         /// for complete descriptions of the error codes.
         /// </summary>
-        void OnLoadError(IWebBrowser browserControl, IBrowser browser, LoadErrorEventArgs loadErrorArgs);
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
+        /// <param name="loadErrorArgs">args</param>
+        void OnLoadError(IWebBrowser browserControl, LoadErrorEventArgs loadErrorArgs);
 
         /// <summary>
         /// Called before browser navigation.
@@ -45,19 +91,19 @@ namespace CefSharp
         /// will be called. If the navigation is canceled <see cref="IWebBrowser.LoadError"/> will be called with an ErrorCode
         /// value of <see cref="CefErrorCode.Aborted"/>. 
         /// </summary>
-        /// <param name="browserControl">the browser control</param>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="browser">the browser object</param>
         /// <param name="request">the request object - cannot be modified in this callback</param>
-        /// <param name="isRedirect">has the request been redirected</param>
         /// <param name="frame">The frame the request is coming from</param>
+        /// <param name="isRedirect">has the request been redirected</param>
         /// <returns>Return true to cancel the navigation or false to allow the navigation to proceed.</returns>
-        bool OnBeforeBrowse(IWebBrowser browserControl, IBrowser browser, IRequest request, bool isRedirect, IFrame frame);
+        bool OnBeforeBrowse(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, bool isRedirect);
 
         /// <summary>
         /// Called on the IO thread when a resource load is redirected. The <see cref="IRequest.Url"/>
         /// parameter will contain the old URL and other request-related information.
         /// </summary>
-        /// <param name="browserControl">The browser control</param>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="browser">the browser object</param>
         /// <param name="frame">The frame that is being redirected.</param>
         /// <param name="request">the request object - cannot be modified in this callback</param>
@@ -68,7 +114,7 @@ namespace CefSharp
         /// Called before a resource request is loaded. For async processing return <see cref="CefReturnValue.ContinueAsync"/> 
         /// and execute <see cref="IRequestCallback.Continue"/> or <see cref="IRequestCallback.Cancel"/>
         /// </summary>
-        /// <param name="browserControl">The browser control</param>
+        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="browser">the browser object</param>
         /// <param name="request">the request object - can be modified in this callback.</param>
         /// <param name="frame">The frame object</param>

--- a/CefSharp/IPopupHandler.cs
+++ b/CefSharp/IPopupHandler.cs
@@ -78,44 +78,5 @@ namespace CefSharp
         /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
         /// <param name="loadErrorArgs">args</param>
         void OnLoadError(IWebBrowser browserControl, LoadErrorEventArgs loadErrorArgs);
-
-        /// <summary>
-        /// Called before browser navigation.
-        /// If the navigation is allowed <see cref="IWebBrowser.FrameLoadStart"/> and <see cref="IWebBrowser.FrameLoadEnd"/>
-        /// will be called. If the navigation is canceled <see cref="IWebBrowser.LoadError"/> will be called with an ErrorCode
-        /// value of <see cref="CefErrorCode.Aborted"/>. 
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="request">the request object - cannot be modified in this callback</param>
-        /// <param name="frame">The frame the request is coming from</param>
-        /// <param name="isRedirect">has the request been redirected</param>
-        /// <returns>Return true to cancel the navigation or false to allow the navigation to proceed.</returns>
-        bool OnBeforeBrowse(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, bool isRedirect);
-
-        /// <summary>
-        /// Called on the IO thread when a resource load is redirected. The <see cref="IRequest.Url"/>
-        /// parameter will contain the old URL and other request-related information.
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="frame">The frame that is being redirected.</param>
-        /// <param name="request">the request object - cannot be modified in this callback</param>
-        /// <param name="newUrl">the new URL and can be changed if desired</param>
-        void OnResourceRedirect(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, ref string newUrl);
-
-        /// <summary>
-        /// Called before a resource request is loaded. For async processing return <see cref="CefReturnValue.ContinueAsync"/> 
-        /// and execute <see cref="IRequestCallback.Continue"/> or <see cref="IRequestCallback.Cancel"/>
-        /// </summary>
-        /// <param name="browserControl">The <see cref="IWebBrowser"/> control this popup is related to.</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="request">the request object - can be modified in this callback.</param>
-        /// <param name="frame">The frame object</param>
-        /// <param name="callback">Callback interface used for asynchronous continuation of url requests.</param>
-        /// <returns>To cancel loading of the resource return <see cref="CefReturnValue.Cancel"/>
-        /// or <see cref="CefReturnValue.Continue"/> to allow the resource to load normally. For async
-        /// return <see cref="CefReturnValue.ContinueAsync"/></returns>
-        CefReturnValue OnBeforeResourceLoad(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, IRequestCallback callback);
     }
 }

--- a/CefSharp/IRequestHandler.cs
+++ b/CefSharp/IRequestHandler.cs
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
-using System.Collections.Generic;
 
 namespace CefSharp
 {
@@ -131,13 +130,5 @@ namespace CefSharp
         /// <param name="url">the request url</param>
         /// <returns>return to true to attempt execution via the registered OS protocol handler, if any. Otherwise return false.</returns>
         bool OnProtocolExecution(IWebBrowser browserControl, IBrowser browser, string url);
-
-        /// <summary>
-        /// Called when the page icon changes.
-        /// </summary>
-        /// <param name="browserControl">The ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="urls">list of urls where the favicons can be downloaded</param>
-        void OnFaviconUrlChange(IWebBrowser browserControl, IBrowser browser, IList<string> urls);
     }
 }

--- a/CefSharp/IRequestHandler.cs
+++ b/CefSharp/IRequestHandler.cs
@@ -23,6 +23,29 @@ namespace CefSharp
         bool OnBeforeBrowse(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, bool isRedirect);
 
         /// <summary>
+        /// Called on the UI thread before OnBeforeBrowse in certain limited cases
+        /// where navigating a new or different browser might be desirable. This
+        /// includes user-initiated navigation that might open in a special way (e.g.
+        /// links clicked via middle-click or ctrl + left-click) and certain types of
+        /// cross-origin navigation initiated from the renderer process (e.g.
+        /// navigating the top-level frame to/from a file URL).
+        /// </summary>
+        /// <param name="browserControl">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="frame">The frame object</param>
+        /// <param name="targetUrl">target url</param>
+        /// <param name="targetDisposition">The value indicates where the user intended to navigate the browser based
+        /// on standard Chromium behaviors (e.g. current tab, new tab, etc). </param>
+        /// <param name="userGesture">The value will be true if the browser navigated via explicit user gesture
+        /// (e.g. clicking a link) or false if it navigated automatically (e.g. via the DomContentLoaded event).</param>
+        /// <returns>Return true to cancel the navigation or false to allow the navigation
+        /// to proceed in the source browser's top-level frame.</returns>
+        bool OnOpenUrlFromTab(IWebBrowser browserControl, IBrowser browser, IFrame frame,
+                              string targetUrl,
+                              WindowOpenDisposition targetDisposition,
+                              bool userGesture);
+
+        /// <summary>
         /// Called to handle requests for URLs with an invalid SSL certificate.
         /// Return true and call <see cref="IRequestCallback.Continue"/> either
         /// in this method or at a later time to continue or cancel the request.  
@@ -53,8 +76,8 @@ namespace CefSharp
         /// </summary>
         /// <param name="browserControl">The ChromiumWebBrowser control</param>
         /// <param name="browser">the browser object</param>
-        /// <param name="request">the request object - can be modified in this callback.</param>
         /// <param name="frame">The frame object</param>
+        /// <param name="request">the request object - can be modified in this callback.</param>
         /// <param name="callback">Callback interface used for asynchronous continuation of url requests.</param>
         /// <returns>To cancel loading of the resource return <see cref="CefReturnValue.Cancel"/>
         /// or <see cref="CefReturnValue.Continue"/> to allow the resource to load normally. For async
@@ -130,5 +153,14 @@ namespace CefSharp
         /// <param name="url">the request url</param>
         /// <returns>return to true to attempt execution via the registered OS protocol handler, if any. Otherwise return false.</returns>
         bool OnProtocolExecution(IWebBrowser browserControl, IBrowser browser, string url);
+
+        /// <summary>
+        /// Called on the browser process UI thread when the render view associated
+        /// with |browser| is ready to receive/handle IPC messages in the render
+        /// process.
+        /// </summary>
+        /// <param name="browserControl">The ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        void OnRenderViewReady(IWebBrowser browserControl, IBrowser browser);
     }
 }

--- a/CefSharp/IRequestHandler.cs
+++ b/CefSharp/IRequestHandler.cs
@@ -56,11 +56,12 @@ namespace CefSharp
         /// <param name="browser">the browser object</param>
         /// <param name="errorCode">the error code for this invalid certificate</param>
         /// <param name="requestUrl">the url of the request for the invalid certificate</param>
+        /// <param name="sslInfo">ssl certificate information</param>
         /// <param name="callback">Callback interface used for asynchronous continuation of url requests.
         /// If empty the error cannot be recovered from and the request will be canceled automatically.</param>
         /// <returns>Return false to cancel the request immediately. Return true and use <see cref="IRequestCallback"/> to
         /// execute in an async fashion.</returns>
-        bool OnCertificateError(IWebBrowser browserControl, IBrowser browser, CefErrorCode errorCode, string requestUrl, IRequestCallback callback);
+        bool OnCertificateError(IWebBrowser browserControl, IBrowser browser, CefErrorCode errorCode, string requestUrl, ISslInfo sslInfo, IRequestCallback callback);
 
         /// <summary>
         /// Called when a plugin has crashed

--- a/CefSharp/ISslInfo.cs
+++ b/CefSharp/ISslInfo.cs
@@ -6,46 +6,46 @@ using System;
 
 namespace CefSharp
 {
-	public interface ISslInfo
-	{
-		/// <summary>
-		/// Returns the subject of the X.509 certificate. For HTTPS server
-		/// certificates this represents the web server.  The common name of the
-		/// subject should match the host name of the web server.
-		/// </summary>
-		//ISslCertPrincipal Subject { get; }
+    public interface ISslInfo
+    {
+        /// <summary>
+        /// Returns the subject of the X.509 certificate. For HTTPS server
+        /// certificates this represents the web server.  The common name of the
+        /// subject should match the host name of the web server.
+        /// </summary>
+        //ISslCertPrincipal Subject { get; }
 
-		/// <summary>
-		/// Returns the issuer of the X.509 certificate.
-		/// </summary>
-		//ISslCertPrincipal Issuer { get; }
+        /// <summary>
+        /// Returns the issuer of the X.509 certificate.
+        /// </summary>
+        //ISslCertPrincipal Issuer { get; }
 
-		/// <summary>
-		/// Returns the DER encoded serial number for the X.509 certificate. The value
-		/// possibly includes a leading 00 byte.
-		/// </summary>
-		byte[] SerialNumber { get; }
+        /// <summary>
+        /// Returns the DER encoded serial number for the X.509 certificate. The value
+        /// possibly includes a leading 00 byte.
+        /// </summary>
+        byte[] SerialNumber { get; }
   
-		/// <summary>
-		/// Returns the date before which the X.509 certificate is invalid.
-		/// will return null if no date was specified.
-		/// </summary>
-		DateTime? ValidStart { get; }
+        /// <summary>
+        /// Returns the date before which the X.509 certificate is invalid.
+        /// will return null if no date was specified.
+        /// </summary>
+        DateTime? ValidStart { get; }
 
-		/// <summary>
-		/// Returns the date after which the X.509 certificate is invalid.
-		/// will return null if no date was specified.
-		/// </summary>
-		DateTime? ValidExpiry { get; }
+        /// <summary>
+        /// Returns the date after which the X.509 certificate is invalid.
+        /// will return null if no date was specified.
+        /// </summary>
+        DateTime? ValidExpiry { get; }
 
-		/// <summary>
-		/// Returns the DER encoded data for the X.509 certificate.
-		/// </summary>
-		byte[] DerEncoded { get; }
+        /// <summary>
+        /// Returns the DER encoded data for the X.509 certificate.
+        /// </summary>
+        byte[] DerEncoded { get; }
 
-		/// <summary>
-		/// Returns the PEM encoded data for the X.509 certificate.
-		/// </summary>
-		byte[] PemEncoded { get; }
-	}
+        /// <summary>
+        /// Returns the PEM encoded data for the X.509 certificate.
+        /// </summary>
+        byte[] PemEncoded { get; }
+    }
 }

--- a/CefSharp/ISslInfo.cs
+++ b/CefSharp/ISslInfo.cs
@@ -1,0 +1,51 @@
+﻿// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+
+namespace CefSharp
+{
+	public interface ISslInfo
+	{
+		/// <summary>
+		/// Returns the subject of the X.509 certificate. For HTTPS server
+		/// certificates this represents the web server.  The common name of the
+		/// subject should match the host name of the web server.
+		/// </summary>
+		//ISslCertPrincipal Subject { get; }
+
+		/// <summary>
+		/// Returns the issuer of the X.509 certificate.
+		/// </summary>
+		//ISslCertPrincipal Issuer { get; }
+
+		/// <summary>
+		/// Returns the DER encoded serial number for the X.509 certificate. The value
+		/// possibly includes a leading 00 byte.
+		/// </summary>
+		byte[] SerialNumber { get; }
+  
+		/// <summary>
+		/// Returns the date before which the X.509 certificate is invalid.
+		/// will return null if no date was specified.
+		/// </summary>
+		DateTime? ValidStart { get; }
+
+		/// <summary>
+		/// Returns the date after which the X.509 certificate is invalid.
+		/// will return null if no date was specified.
+		/// </summary>
+		DateTime? ValidExpiry { get; }
+
+		/// <summary>
+		/// Returns the DER encoded data for the X.509 certificate.
+		/// </summary>
+		byte[] DerEncoded { get; }
+
+		/// <summary>
+		/// Returns the PEM encoded data for the X.509 certificate.
+		/// </summary>
+		byte[] PemEncoded { get; }
+	}
+}

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -176,13 +176,6 @@ namespace CefSharp
         string Address { get; }
 
         /// <summary>
-        /// The title of the web page being currently displayed.
-        /// </summary>
-        /// <remarks>In the WPF control, this property is implemented as a Dependency Property and fully supports data
-        /// binding.</remarks>
-        string Title { get; }
-
-        /// <summary>
         /// The text that will be displayed as a ToolTip
         /// </summary>
         string TooltipText { get; }

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -165,6 +165,7 @@ namespace CefSharp
         /// </summary>
         /// <remarks>In the WPF control, this property is implemented as a Dependency Property and fully supports data
         /// binding.</remarks>
+        [Obsolete("Use IsLoading instead (inverse of this property)")]
         bool CanReload { get; }
 
         /// <summary>

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -88,6 +88,11 @@ namespace CefSharp
         IDisplayHandler DisplayHandler { get; set; }
 
         /// <summary>
+        /// Implement <see cref="ILoadHandler"/> and assign to handle events related to browser load status.
+        /// </summary>
+        ILoadHandler LoadHandler { get; set; }
+
+        /// <summary>
         /// Implement <see cref="ILifeSpanHandler"/> and assign to handle events related to popups.
         /// </summary>
         ILifeSpanHandler LifeSpanHandler { get; set; }

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -83,9 +83,9 @@ namespace CefSharp
         IRequestHandler RequestHandler { get; set; }
 
         /// <summary>
-        /// Implement <see cref="IPopupHandler"/> and assign to handle events related to popup window events.
+        /// Implement <see cref="IDisplayHandler"/> and assign to handle events related to browser display state.
         /// </summary>
-        IPopupHandler PopupHandler { get; set; }
+        IDisplayHandler DisplayHandler { get; set; }
 
         /// <summary>
         /// Implement <see cref="ILifeSpanHandler"/> and assign to handle events related to popups.

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -118,9 +118,9 @@ namespace CefSharp
         IDownloadHandler DownloadHandler { get; set; }
 
         /// <summary>
-        /// Implement <see cref="IMenuHandler"/> and assign to handle events related to the browser context menu
+        /// Implement <see cref="IContextMenuHandler"/> and assign to handle events related to the browser context menu
         /// </summary>
-        IMenuHandler MenuHandler { get; set; }
+        IContextMenuHandler MenuHandler { get; set; }
 
         /// <summary>
         /// Implement <see cref="IFocusHandler"/> and assign to handle events related to the browser component's focus

--- a/CefSharp/Internals/IWebBrowserInternal.cs
+++ b/CefSharp/Internals/IWebBrowserInternal.cs
@@ -14,16 +14,16 @@ namespace CefSharp.Internals
     {
         void OnAfterBrowserCreated();
 
-        void SetAddress(string address);
-        void SetLoadingStateChange(bool canGoBack, bool canGoForward, bool isLoading);
-        void SetTitle(string title);
+        void SetAddress(AddressChangedEventArgs args);
+        void SetLoadingStateChange(LoadingStateChangedEventArgs args);
+        void SetTitle(TitleChangedEventArgs args);
         void SetTooltipText(string tooltipText);
 
         void OnFrameLoadStart(FrameLoadStartEventArgs args);
         void OnFrameLoadEnd(FrameLoadEndEventArgs args);
-        void OnConsoleMessage(string message, string source, int line);
-        void OnStatusMessage(string value);
-        void OnLoadError(IFrame frame, CefErrorCode errorCode, string errorText, string failedUrl);
+        void OnConsoleMessage(ConsoleMessageEventArgs args);
+        void OnStatusMessage(StatusMessageEventArgs args);
+        void OnLoadError(LoadErrorEventArgs args);
 
         IBrowserAdapter BrowserAdapter { get; }
         bool HasParent { get; set; }

--- a/CefSharp/LoadErrorEventArgs.cs
+++ b/CefSharp/LoadErrorEventArgs.cs
@@ -11,13 +11,19 @@ namespace CefSharp
     /// </summary>
     public class LoadErrorEventArgs : EventArgs
     {
-        public LoadErrorEventArgs(IFrame frame, CefErrorCode errorCode, string errorText, string failedUrl)
+        public LoadErrorEventArgs(IBrowser browser, IFrame frame, CefErrorCode errorCode, string errorText, string failedUrl)
         {
+            Browser = browser;
             Frame = frame;
             ErrorCode = errorCode;
             ErrorText = errorText;
             FailedUrl = failedUrl;
         }
+
+        /// <summary>
+        /// The browser object
+        /// </summary>
+        public IBrowser Browser { get; private set; }
 
         /// <summary>
         /// The frame that failed to load.

--- a/CefSharp/LoadingStateChangedEventArgs.cs
+++ b/CefSharp/LoadingStateChangedEventArgs.cs
@@ -15,9 +15,11 @@ namespace CefSharp
         public bool CanGoBack { get; private set; }
         public bool CanReload { get; private set; }
         public bool IsLoading { get; private set; }
+        public IBrowser Browser { get; private set; }
 
-        public LoadingStateChangedEventArgs(bool canGoBack, bool canGoForward, bool isLoading)
+        public LoadingStateChangedEventArgs(IBrowser browser, bool canGoBack, bool canGoForward, bool isLoading)
         {
+            Browser = browser;
             CanGoBack = canGoBack;
             CanGoForward = canGoForward;
             IsLoading = isLoading;

--- a/CefSharp/StatusMessageEventHandler.cs
+++ b/CefSharp/StatusMessageEventHandler.cs
@@ -11,10 +11,16 @@ namespace CefSharp
     /// </summary>
     public class StatusMessageEventArgs : EventArgs
     {
-        public StatusMessageEventArgs(string value)
+        public StatusMessageEventArgs(IBrowser browser, string value)
         {
+            Browser = browser;
             Value = value;
         }
+
+        /// <summary>
+        /// The browser object
+        /// </summary>
+        public IBrowser Browser { get; private set; }
 
         /// <summary>
         /// The value of the status message.


### PR DESCRIPTION
I think it's worth releasing a `-pre` release of `master` shortly, so trying to get the last `API` changes done before then (at least all the ones that I can think of).

- `EventArgs` are now directly passed into `IWebBrowserInternal` methods so simplify things, make it much easier to add params now
- Mark `WPF CanReload` property as `Obsolete` (minor cleanup, use `IsLoading` now)
- All the `EventArgs` wrappers should now have access to the relevant underlying `CEF` object e.g. browser/frame
- Moved the `Title` property from `IWebBrowser`, to `IWpfWebBrowser`, makes more sense to subscribe to the event in `WinForms` and `OffScreen`
