### PR TITLE
Implement start drag for WPF browser

### DIFF
--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -177,11 +177,11 @@ namespace CefSharp
                 _renderWebBrowser->SetCursor((IntPtr)cursor, (CefSharp::CefCursorType)type);
             };
 
-            virtual DECL bool StartDragging(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> drag_data,
-                CefRenderHandler::DragOperationsMask allowed_ops, int x, int y)
+            virtual DECL bool StartDragging(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData,
+                CefRenderHandler::DragOperationsMask allowedOps, int x, int y)
             {
-                CefDragDataWrapper dragDataWrapper(drag_data);
-                return _renderWebBrowser->StartDragging(%dragDataWrapper, (CefSharp::DragOperationsMask)allowed_ops, x, y);
+                CefDragDataWrapper dragDataWrapper(dragData);
+                return _renderWebBrowser->StartDragging(%dragDataWrapper, (CefSharp::DragOperationsMask)allowedOps, x, y);
             }
 
         private:

--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -177,6 +177,13 @@ namespace CefSharp
                 _renderWebBrowser->SetCursor((IntPtr)cursor, (CefSharp::CefCursorType)type);
             };
 
+            virtual DECL bool StartDragging(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> drag_data,
+                CefRenderHandler::DragOperationsMask allowed_ops, int x, int y)
+            {
+                CefDragDataWrapper dragDataWrapper(drag_data);
+                return _renderWebBrowser->StartDragging(%dragDataWrapper, (CefSharp::DragOperationsMask)allowed_ops, x, y);
+            }
+
         private:
             void ReleaseBitmapHandlers(BitmapInfo^ bitmapInfo)
             {

--- a/CefSharp.Core/ManagedCefBrowserAdapter.cpp
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.cpp
@@ -335,6 +335,26 @@ void ManagedCefBrowserAdapter::OnDragTargetDragDrop(MouseEvent^ mouseEvent)
     }
 }
 
+void ManagedCefBrowserAdapter::OnDragSourceEndedAt(int x, int y, DragOperationsMask op)
+{
+    auto browser = _clientAdapter->GetCefBrowser();
+
+    if (browser != nullptr)
+    {
+        browser->GetHost()->DragSourceEndedAt(x, y, (CefBrowserHost::DragOperationsMask)op);
+    }
+}
+
+void ManagedCefBrowserAdapter::OnDragSourceSystemDragEnded()
+{
+    auto browser = _clientAdapter->GetCefBrowser();
+
+    if (browser != nullptr)
+    {
+        browser->GetHost()->DragSourceSystemDragEnded();
+    }
+}
+
 /// <summary>
 /// Gets the CefBrowserWrapper instance
 /// </summary>

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -133,6 +133,9 @@ namespace CefSharp
         void OnDragTargetDragLeave();
         void OnDragTargetDragDrop(MouseEvent^ mouseEvent);
 
+        void OnDragSourceEndedAt(int x, int y, DragOperationsMask op);
+        void OnDragSourceSystemDragEnded();
+
         /// <summary>
         /// Gets the CefBrowserWrapper instance
         /// </summary>

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -324,6 +324,11 @@ namespace CefSharp.OffScreen
         {
         }
 
+        bool IRenderWebBrowser.StartDragging(IDragData dragData, DragOperationsMask mask, int x, int y)
+        {
+            return false;
+        }
+
         void IRenderWebBrowser.SetPopupIsOpen(bool show)
         {
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -251,6 +251,21 @@ namespace CefSharp.Wpf
             return BitmapFactory.CreateBitmap(isPopup);
         }
 
+        bool IRenderWebBrowser.StartDragging(IDragData dragData, DragOperationsMask mask, int x, int y)
+        {
+            var dragDataCopy = CefDragDataWrapper.Create();
+            dragDataCopy.FragmentText = dragData.FragmentText;
+            dragDataCopy.FragmentHtml = dragData.FragmentHtml;
+
+            UiThreadRunAsync(delegate
+            {
+                var results = DragDrop.DoDragDrop(this, dragDataCopy.FragmentHtml, GetDragEffects(mask));
+                managedCefBrowserAdapter.OnDragSourceEndedAt(0, 0, GetDragOperationsMask((DragDropEffects)results));
+                managedCefBrowserAdapter.OnDragSourceSystemDragEnded();
+            });
+            return true;
+        }
+
         void IRenderWebBrowser.InvokeRenderAsync(BitmapInfo bitmapInfo)
         {
             UiThreadRunAsync(delegate
@@ -752,6 +767,27 @@ namespace CefSharp.Wpf
             }
 
             return operations;
+        }
+
+        private DragDropEffects GetDragEffects(DragOperationsMask mask)
+        {
+            if ((mask & DragOperationsMask.Every) == DragOperationsMask.Every)
+            {
+                return DragDropEffects.All;
+            }
+            if ((mask & DragOperationsMask.Copy) == DragOperationsMask.Copy)
+            {
+                return DragDropEffects.Copy;
+            }
+            if ((mask & DragOperationsMask.Move) == DragOperationsMask.Move)
+            {
+                return DragDropEffects.Move;
+            }
+            if ((mask & DragOperationsMask.Link) == DragOperationsMask.Link)
+            {
+                return DragDropEffects.Link;
+            }
+            return DragDropEffects.None;
         }
 
         private void PresentationSourceChangedHandler(object sender, SourceChangedEventArgs args)

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -259,7 +259,7 @@ namespace CefSharp.Wpf
 
             UiThreadRunAsync(delegate
             {
-                var results = DragDrop.DoDragDrop(this, dragDataCopy.FragmentHtml, GetDragEffects(mask));
+                var results = DragDrop.DoDragDrop(this, dragDataCopy.FragmentText, GetDragEffects(mask));
                 managedCefBrowserAdapter.OnDragSourceEndedAt(0, 0, GetDragOperationsMask((DragDropEffects)results));
                 managedCefBrowserAdapter.OnDragSourceSystemDragEnded();
             });

--- a/CefSharp/Internals/IRenderWebBrowser.cs
+++ b/CefSharp/Internals/IRenderWebBrowser.cs
@@ -15,6 +15,8 @@ namespace CefSharp.Internals
 
         void SetCursor(IntPtr cursor, CefCursorType type);
 
+        bool StartDragging(IDragData dragData, DragOperationsMask mask, int x, int y);
+
         void SetPopupIsOpen(bool show);
         void SetPopupSizeAndPosition(int width, int height, int x, int y);
     };


### PR DESCRIPTION
Resolves https://github.com/cefsharp/CefSharp/issues/1154
Exposed the necessary functions for start drag to work:
* StartDragging (RenderClientAdapter)
* OnDragSourceEndedAt (ManagedCefBrowserAdapter)
* OnDragSourceSystemDragEnded (ManagedCefBrowserAdapter)

Implemented IRenderWebBrowser.StartDragging for the WPF
ChromiumWebBrowser.

TODO: Would like to add an adorner layer for the dragged text (using the
supplied fragment html), but feels like a project for later.