### PR TITLE
Generate CefSharp.Core.pdb file for Release builds

### DIFF
--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -178,7 +178,7 @@
       <AdditionalDependencies>opengl32.lib;glu32.lib;libcef.lib;libcef_dll_wrapper.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerbose</ShowProgress>
       <AdditionalLibraryDirectories>$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration);$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration)\VS$(VisualStudioProductVersion)</AdditionalLibraryDirectories>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
       <KeyFile>$(LinkKeyFile)</KeyFile>
     </Link>
@@ -197,7 +197,7 @@
       <AdditionalDependencies>opengl32.lib;glu32.lib;libcef.lib;libcef_dll_wrapper.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerbose</ShowProgress>
       <AdditionalLibraryDirectories>$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration);$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration)\VS$(VisualStudioProductVersion)</AdditionalLibraryDirectories>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <KeyFile>$(LinkKeyFile)</KeyFile>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
This makes it easier to figure out `.dmp` crash dumps where CefSharp.Core.dll is part of the stack, like in the following:

```
 	libcef.dll!`anonymous namespace'::PureCall()  Line 29	C++
 	libcef.dll!_purecall()  Line 58	C
 	libcef.dll!CefCppToC<CefCallbackCppToC,CefCallback,_cef_callback_t>::Release()  Line 110	C++
 	libcef.dll!CefCppToC<CefRequestCallbackCppToC,CefRequestCallback,_cef_request_callback_t>::struct_release(_cef_base_t * base)  Line 148 + 0xa bytes	C++
 	CefSharp.Core.dll!000007feed2ede70() 	
 	[Frames below may be incorrect and/or missing, no symbols loaded for CefSharp.Core.dll]	
 	[Managed to Native Transition]	
 	CefSharp.Core.dll!CefSharp.Internals.MCefRefPtr<CefCallback>.op_Assign() + 0xfe bytes	
 	CefSharp.Core.dll!CefSharp.CefCallbackWrapper.Dispose(bool A_0) + 0x28 bytes	
 	CefSharp.Core.dll!CefSharp.CefCallbackWrapper.Dispose() + 0x18 bytes	
 	CefSharp.Core.dll!CefSharp.CefCallbackWrapper.Continue() + 0xbb bytes	
```