### PR TITLE
Update comments and examples to avoid users disposing of callback objects

### DIFF
--- a/CefSharp.Example/DownloadHandler.cs
+++ b/CefSharp.Example/DownloadHandler.cs
@@ -11,7 +11,6 @@ namespace CefSharp.Example
             if (!callback.IsDisposed)
             {
                 callback.Continue(downloadItem.SuggestedFileName, showDialog: true);
-                callback.Dispose();
             }
         }
 

--- a/CefSharp.Example/RequestHandler.cs
+++ b/CefSharp.Example/RequestHandler.cs
@@ -26,12 +26,9 @@ namespace CefSharp.Example
             //NOTE: When executing the callback in an async fashion need to check to see if it's disposed
             if (!callback.IsDisposed)
             {
-                using (callback)
-                {
-                    //To allow certificate
-                    //callback.Continue(true);
-                    //return true;
-                }
+                //To allow certificate
+                //callback.Continue(true);
+                //return true;
             }
 
             return false;
@@ -47,36 +44,33 @@ namespace CefSharp.Example
             //NOTE: When executing the callback in an async fashion need to check to see if it's disposed
             if (!callback.IsDisposed)
             {
-                using (callback)
+                if (request.Method == "POST")
                 {
-                    if (request.Method == "POST")
+                    using (var postData = request.PostData)
                     {
-                        using (var postData = request.PostData)
+                        var elements = postData.Elements;
+
+                        var charSet = request.GetCharSet();
+
+                        foreach (var element in elements)
                         {
-                            var elements = postData.Elements;
-
-                            var charSet = request.GetCharSet();
-
-                            foreach (var element in elements)
+                            if (element.Type == PostDataElementType.Bytes)
                             {
-                                if (element.Type == PostDataElementType.Bytes)
-                                {
-                                    var body = element.GetBody(charSet);
-                                }
+                                var body = element.GetBody(charSet);
                             }
                         }
                     }
-
-                    //Note to Redirect simply set the request Url
-                    //if (request.Url.StartsWith("https://www.google.com", StringComparison.OrdinalIgnoreCase))
-                    //{
-                    //    request.Url = "https://github.com/";
-                    //}
-
-                    //Callback in async fashion
-                    //callback.Continue(true);
-                    //return CefReturnValue.ContinueAsync;
                 }
+
+                //Note to Redirect simply set the request Url
+                //if (request.Url.StartsWith("https://www.google.com", StringComparison.OrdinalIgnoreCase))
+                //{
+                //    request.Url = "https://github.com/";
+                //}
+
+                //Callback in async fashion
+                //callback.Continue(true);
+                //return CefReturnValue.ContinueAsync;
             }
 
             return CefReturnValue.Continue;
@@ -110,12 +104,9 @@ namespace CefSharp.Example
             //NOTE: When executing the callback in an async fashion need to check to see if it's disposed
             if (!callback.IsDisposed)
             {
-                using (callback)
-                {
-                    //Accept Request to raise Quota
-                    //callback.Continue(true);
-                    //return true;
-                }
+                //Accept Request to raise Quota
+                //callback.Continue(true);
+                //return true;
             }
 
             return false;

--- a/CefSharp.WinForms.Example/Handlers/GeolocationHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/GeolocationHandler.cs
@@ -14,7 +14,6 @@ namespace CefSharp.WinForms.Example.Handlers
             var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButtons.YesNo);
             
             callback.Continue(result == DialogResult.Yes);
-            callback.Dispose();
 
             return result == DialogResult.Yes;
         }

--- a/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
@@ -14,7 +14,6 @@ namespace CefSharp.Wpf.Example.Handlers
             var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButton.YesNo);
 
             callback.Continue(result == MessageBoxResult.Yes);
-            callback.Dispose();
 
             return result == MessageBoxResult.Yes;
         }

--- a/CefSharp/ICallback.cs
+++ b/CefSharp/ICallback.cs
@@ -9,6 +9,11 @@ namespace CefSharp
     /// <summary>
     /// Generic callback interface used for asynchronous continuation.
     /// </summary>
+    /// <remarks>
+    /// All callback objects self-dispose on <see cref="Continue"/> or <see cref="Cancel"/>.
+    /// You should not dispose of these objects in your own code because they
+    /// manage native CEF resources and may need to be disposed on specific threads.
+    /// </remarks>
     public interface ICallback : IDisposable
     {
         /// <summary>

--- a/CefSharp/ICallback.cs
+++ b/CefSharp/ICallback.cs
@@ -10,9 +10,10 @@ namespace CefSharp
     /// Generic callback interface used for asynchronous continuation.
     /// </summary>
     /// <remarks>
-    /// All callback objects self-dispose on <see cref="Continue"/> or <see cref="Cancel"/>.
-    /// You should not dispose of these objects in your own code because they
-    /// manage native CEF resources and may need to be disposed on specific threads.
+    /// All callback objects are self-disposing.  You must not dispose of
+    /// these objects in your own code.
+    /// Some callbacks self-dispose after <see cref="Continue"/> or <see cref="Cancel"/> are called,
+    /// and others are disposed asynchronously on a separate thread.
     /// </remarks>
     public interface ICallback : IDisposable
     {


### PR DESCRIPTION
So that users leave the disposal of these objects to CefSharp.  Related to #1143.