### PR TITLE
Feature default exception strings browser subprocess

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
@@ -38,7 +38,7 @@ namespace CefSharp
         }
         catch (Exception^ ex)
         {
-            exception = StringUtils::ToNative(ex->Message);
+            exception = StringUtils::ToNative(ex->ToString());
         }
 
         //NOTE: Return true otherwise exception is ignored

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -118,7 +118,14 @@ namespace CefSharp.Internals
                     parameters = paramList.ToArray();
                 }
 
-                result = method.Function(obj.Value, parameters);
+                try
+                {
+                    result = method.Function(obj.Value, parameters);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException("Could not execute method: " + name + "(" + String.Join(", ", parameters) + ")" + " - Missing Parameters: " + missingParams, e);
+                }
 
                 if(result != null && IsComplexType(result.GetType()))
                 {
@@ -137,11 +144,11 @@ namespace CefSharp.Internals
             catch(TargetInvocationException e)
             {
                 var baseException = e.GetBaseException();
-                exception = baseException.Message;
+                exception = baseException.ToString();
             }
             catch (Exception ex)
             {
-                exception = ex.Message;
+                exception = ex.ToString();
             }
 
             return false;
@@ -171,7 +178,7 @@ namespace CefSharp.Internals
             }
             catch (Exception ex)
             {
-                exception = ex.Message;
+                exception = ex.ToString();
             }
 
             return false;
@@ -199,7 +206,7 @@ namespace CefSharp.Internals
             }
             catch (Exception ex)
             {
-                exception = ex.Message;
+                exception = ex.ToString();
             }
 
             return false;


### PR DESCRIPTION
Added detailed exception string generation for exceptions in injected native functions / properties.
In contrast to #1253 this version does not use custom formatting for the exceptions

Output of this version using the ExceptionTest of #1254

```
Exception string for nested exceptions:
System.InvalidOperationException: Could not execute method: triggerNestedExceptions() - Missing Parameters: 0 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.OperationCanceledException: Nested Exception Canceled ---> System.InvalidOperationException: Nested Exception Invalid ---> System.DivideByZeroException: Attempted to divide by zero. 
at CefSharp.Example.ExceptionTestBoundObject.DivisionByZero(Int32 zero) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 19 
at CefSharp.Example.ExceptionTestBoundObject.TriggerNestedExceptions() in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 29 
--- End of inner exception stack trace --- 
at CefSharp.Example.ExceptionTestBoundObject.TriggerNestedExceptions() in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 33 
--- End of inner exception stack trace --- 
at CefSharp.Example.ExceptionTestBoundObject.TriggerNestedExceptions() in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 37 
--- End of inner exception stack trace --- 
at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor) 
at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments) 
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 123 
--- End of inner exception stack trace --- 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 127
Stack:
Error: System.InvalidOperationException: Could not execute method: triggerNestedExceptions() - Missing Parameters: 0 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.OperationCanceledException: Nested Exception Canceled ---> System.InvalidOperationException: Nested Exception Invalid ---> System.DivideByZeroException: Attempted to divide by zero. 
at CefSharp.Example.ExceptionTestBoundObject.DivisionByZero(Int32 zero) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 19 
at CefSharp.Example.ExceptionTestBoundObject.TriggerNestedExceptions() in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 29 
--- End of inner exception stack trace --- 
at CefSharp.Example.ExceptionTestBoundObject.TriggerNestedExceptions() in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 33 
--- End of inner exception stack trace --- 
at CefSharp.Example.ExceptionTestBoundObject.TriggerNestedExceptions() in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp.Example\ExceptionTestBoundObject.cs:line 37 
--- End of inner exception stack trace --- 
at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor) 
at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments) 
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 123 
--- End of inner exception stack trace --- 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 127
at Error (native)
at custom://cefsharp/ExceptionTest.html:16:47

Exception string for wrong parameter type:
System.InvalidOperationException: Could not execute method: triggerParameterException(3.14159265358979) - Missing Parameters: 0 ---> System.ArgumentException: Object of type 'System.Double' cannot be converted to type 'System.Int32'. 
at System.RuntimeType.TryChangeType(Object value, Binder binder, CultureInfo culture, Boolean needsSpecialCast) 
at System.RuntimeType.CheckValue(Object value, Binder binder, CultureInfo culture, BindingFlags invokeAttr) 
at System.Reflection.MethodBase.CheckArguments(Object[] parameters, Binder binder, BindingFlags invokeAttr, CultureInfo culture, Signature sig) 
at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 123 
--- End of inner exception stack trace --- 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 127
Stack:
Error: System.InvalidOperationException: Could not execute method: triggerParameterException(3.14159265358979) - Missing Parameters: 0 ---> System.ArgumentException: Object of type 'System.Double' cannot be converted to type 'System.Int32'. 
at System.RuntimeType.TryChangeType(Object value, Binder binder, CultureInfo culture, Boolean needsSpecialCast) 
at System.RuntimeType.CheckValue(Object value, Binder binder, CultureInfo culture, BindingFlags invokeAttr) 
at System.Reflection.MethodBase.CheckArguments(Object[] parameters, Binder binder, BindingFlags invokeAttr, CultureInfo culture, Signature sig) 
at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 123 
--- End of inner exception stack trace --- 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 127
at Error (native)
at custom://cefsharp/ExceptionTest.html:27:47

Exception string for missing parameter:
System.InvalidOperationException: Could not execute method: triggerParameterException(System.Reflection.Missing) - Missing Parameters: 1 ---> System.ArgumentException: Missing parameter does not have a default value. 
Parameter name: parameters 
at System.Reflection.MethodBase.CheckArguments(Object[] parameters, Binder binder, BindingFlags invokeAttr, CultureInfo culture, Signature sig) 
at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 123 
--- End of inner exception stack trace --- 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 127
Stack:
Error: System.InvalidOperationException: Could not execute method: triggerParameterException(System.Reflection.Missing) - Missing Parameters: 1 ---> System.ArgumentException: Missing parameter does not have a default value. 
Parameter name: parameters 
at System.Reflection.MethodBase.CheckArguments(Object[] parameters, Binder binder, BindingFlags invokeAttr, CultureInfo culture, Signature sig) 
at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 123 
--- End of inner exception stack trace --- 
at CefSharp.Internals.JavascriptObjectRepository.TryCallMethod(Int64 objectId, String name, Object[] parameters, Object& result, String& exception) in c:\Users\kevin\Desktop\MyCefSharp\CefSharp\CefSharp\Internals\JavascriptObjectRepository.cs:line 127
at Error (native)
at custom://cefsharp/ExceptionTest.html:38:47
```