### PR TITLE
Improve Callback Handling in Examples

### DIFF
--- a/CefSharp.Core/Internals/CefCallbackWrapper.h
+++ b/CefSharp.Core/Internals/CefCallbackWrapper.h
@@ -42,6 +42,8 @@ namespace CefSharp
                 ThrowIfDisposed();
 
                 _callback->Cancel();
+
+                delete this;
             }
 
             virtual void Continue()
@@ -50,10 +52,7 @@ namespace CefSharp
 
                 _callback->Continue();
 
-                // Do not self-dispose here or in Cancel because ResourceHandlerWrapper
-                // already has a reference to this callback and will take care
-                // of its disposal.  See GitHub issue #1143 for a repro of an
-                // AccessViolationException caused by self-disposal.
+                delete this;
             }
         };
     }

--- a/CefSharp.Core/ResourceHandlerWrapper.cpp
+++ b/CefSharp.Core/ResourceHandlerWrapper.cpp
@@ -16,7 +16,7 @@ namespace CefSharp
 {
     bool ResourceHandlerWrapper::ProcessRequest(CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback)
     {
-        _callbackWrapper = gcnew CefCallbackWrapper(callback);
+        auto callbackWrapper = gcnew CefCallbackWrapper(callback);
 
         // If we already have a non-null _request
         // dispose it via delete before using the parameter for the rest
@@ -26,7 +26,7 @@ namespace CefSharp
 
         _request = gcnew CefRequestWrapper(request);
 
-        return _handler->ProcessRequestAsync(_request, _callbackWrapper);
+        return _handler->ProcessRequestAsync(_request, callbackWrapper);
     }
 
     void ResourceHandlerWrapper::GetResponseHeaders(CefRefPtr<CefResponse> response, int64& response_length, CefString& redirectUrl)

--- a/CefSharp.Core/ResourceHandlerWrapper.h
+++ b/CefSharp.Core/ResourceHandlerWrapper.h
@@ -19,7 +19,6 @@ namespace CefSharp
         gcroot<IRequest^> _request;
         gcroot<IResourceHandler^> _handler;
         gcroot<Stream^> _stream;
-        gcroot<ICallback^> _callbackWrapper;
         gcroot<IBrowser^> _browser;
         gcroot<IFrame^> _frame;
 
@@ -41,7 +40,6 @@ namespace CefSharp
         {
             _handler = nullptr;
             _stream = nullptr;
-            delete _callbackWrapper;
             delete _request;
             delete _browser;
             delete _frame;

--- a/CefSharp.Example/CefSharpSchemeHandler.cs
+++ b/CefSharp.Example/CefSharpSchemeHandler.cs
@@ -56,13 +56,16 @@ namespace CefSharp.Example
             {
                 Task.Run(() =>
                 {
-                    var bytes = Encoding.UTF8.GetBytes(resource);
-                    stream = new MemoryStream(bytes);
+                    using (callback)
+                    { 
+                        var bytes = Encoding.UTF8.GetBytes(resource);
+                        stream = new MemoryStream(bytes);
 
-                    var fileExtension = Path.GetExtension(fileName);
-                    mimeType = ResourceHandler.GetMimeType(fileExtension);
+                        var fileExtension = Path.GetExtension(fileName);
+                        mimeType = ResourceHandler.GetMimeType(fileExtension);
 
-                    callback.Continue();
+                        callback.Continue();
+                    }
                 });
 
                 return true;

--- a/CefSharp.Example/CefSharpSchemeHandler.cs
+++ b/CefSharp.Example/CefSharpSchemeHandler.cs
@@ -67,6 +67,10 @@ namespace CefSharp.Example
 
                 return true;
             }
+            else
+            {
+                callback.Dispose();
+            }
 
             return false;
         }

--- a/CefSharp.Example/DownloadHandler.cs
+++ b/CefSharp.Example/DownloadHandler.cs
@@ -10,8 +10,10 @@ namespace CefSharp.Example
         {
             if (!callback.IsDisposed)
             {
-                callback.Continue(downloadItem.SuggestedFileName, showDialog: true);
-                callback.Dispose();
+                using (callback)
+                {
+                    callback.Continue(downloadItem.SuggestedFileName, showDialog: true);
+                }
             }
         }
 

--- a/CefSharp.Example/RequestHandler.cs
+++ b/CefSharp.Example/RequestHandler.cs
@@ -23,6 +23,11 @@ namespace CefSharp.Example
 
         bool IRequestHandler.OnCertificateError(IWebBrowser browserControl, IBrowser browser, CefErrorCode errorCode, string requestUrl, ISslInfo sslInfo, IRequestCallback callback)
         {
+            //NOTE: If you do not wish to implement this method returning false is the default behaviour
+            // We also suggest you explicitly Dispose of the callback as it wraps an unmanaged resource.
+            //callback.Dispose();
+            //return false;
+
             //NOTE: When executing the callback in an async fashion need to check to see if it's disposed
             if (!callback.IsDisposed)
             {
@@ -44,6 +49,11 @@ namespace CefSharp.Example
 
         CefReturnValue IRequestHandler.OnBeforeResourceLoad(IWebBrowser browserControl, IBrowser browser, IFrame frame, IRequest request, IRequestCallback callback)
         {
+            //NOTE: If you do not wish to implement this method returning false is the default behaviour
+            // We also suggest you explicitly Dispose of the callback as it wraps an unmanaged resource.
+            //callback.Dispose();
+            //return false;
+
             //NOTE: When executing the callback in an async fashion need to check to see if it's disposed
             if (!callback.IsDisposed)
             {
@@ -84,6 +94,10 @@ namespace CefSharp.Example
 
         bool IRequestHandler.GetAuthCredentials(IWebBrowser browserControl, IBrowser browser, IFrame frame, bool isProxy, string host, int port, string realm, string scheme, IAuthCallback callback)
         {
+            //NOTE: If you do not wish to implement this method returning false is the default behaviour
+            // We also suggest you explicitly Dispose of the callback as it wraps an unmanaged resource.
+
+            callback.Dispose();
             return false;
         }
 
@@ -107,6 +121,11 @@ namespace CefSharp.Example
 
         bool IRequestHandler.OnQuotaRequest(IWebBrowser browserControl, IBrowser browser, string originUrl, long newSize, IRequestCallback callback)
         {
+            //NOTE: If you do not wish to implement this method returning false is the default behaviour
+            // We also suggest you explicitly Dispose of the callback as it wraps an unmanaged resource.
+            //callback.Dispose();
+            //return false;
+
             //NOTE: When executing the callback in an async fashion need to check to see if it's disposed
             if (!callback.IsDisposed)
             {

--- a/CefSharp.WinForms.Example/Handlers/GeolocationHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/GeolocationHandler.cs
@@ -11,12 +11,21 @@ namespace CefSharp.WinForms.Example.Handlers
     {
         public bool OnRequestGeolocationPermission(IWebBrowser browserControl, IBrowser browser, string requestingUrl, int requestId, IGeolocationCallback callback)
         {
-            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButtons.YesNo);
-            
-            callback.Continue(result == DialogResult.Yes);
-            callback.Dispose();
+            //The callback has been disposed, so we are unable to continue
+            if(callback.IsDisposed)
+            {
+                return false;
+            }
 
-            return result == DialogResult.Yes;
+            using (callback)
+            {
+                var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButtons.YesNo);
+
+                callback.Continue(result == DialogResult.Yes);
+                callback.Dispose();
+
+                return result == DialogResult.Yes;
+            }
         }
 
         public void OnCancelGeolocationPermission(IWebBrowser browserControl, IBrowser browser, string requestingUrl, int requestId)

--- a/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/GeolocationHandler.cs
@@ -11,12 +11,14 @@ namespace CefSharp.Wpf.Example.Handlers
     {
         public bool OnRequestGeolocationPermission(IWebBrowser browserControl, IBrowser browser, string requestingUrl, int requestId, IGeolocationCallback callback)
         {
-            var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButton.YesNo);
+            using (callback)
+            {
+                var result = MessageBox.Show(String.Format("{0} wants to use your computer's location.  Allow?  ** You must set your Google API key in CefExample.Init() for this to work. **", requestingUrl), "Geolocation", MessageBoxButton.YesNo);
 
-            callback.Continue(result == MessageBoxResult.Yes);
-            callback.Dispose();
+                callback.Continue(result == MessageBoxResult.Yes);
 
-            return result == MessageBoxResult.Yes;
+                return result == MessageBoxResult.Yes;
+            }
         }
 
         public void OnCancelGeolocationPermission(IWebBrowser browserControl, IBrowser browser, string requestingUrl, int requestId)


### PR DESCRIPTION
This reverts  #1246, instead modify `ResourceHandlerWrapper` so it no longer disposes of the callback.

Also added/update how the examples deal with callbacks.