### PR TITLE
Upgrade build.ps1 to reference cef.redist 3.2454.1326

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ param(
     [Parameter(Position = 2)]
     [string] $AssemblyVersion = "45.0.0",
     [Parameter(Position = 3)]
-    [string] $RedistVersion = "3.2454.1317"
+    [string] $RedistVersion = "3.2454.1326"
 )
 
 $WorkingDir = split-path -parent $MyInvocation.MyCommand.Definition


### PR DESCRIPTION
Updated the default redist version in the build script from 3.2454.1317 to 3.2454.1326

cefsharp/CefSharp#1306