### PR TITLE
Feature multi context wrapper binding

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -72,7 +72,8 @@ namespace CefSharp
                 wrapper = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
                 rootObjectWrapperDictionary[frameID] = wrapper;
             }
-            else {
+            else
+            {
                 LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
             }
             LOG(INFO) << "Bound Root Object Wrapper:" << browser->GetIdentifier() << ":" << frame->GetIdentifier();

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -65,12 +65,12 @@ namespace CefSharp
         if (!Object::ReferenceEquals(_javascriptRootObject, nullptr) || !Object::ReferenceEquals(_javascriptAsyncRootObject, nullptr))
         {
             auto rootObjectWrapperDictionary = browserWrapper->JavascriptRootObjectWrappers;
-            auto frameID = frame->GetIdentifier();
+            auto frameId = frame->GetIdentifier();
             JavascriptRootObjectWrapper^ wrapper;
-            if (!rootObjectWrapperDictionary->TryGetValue(frameID, wrapper) || wrapper == nullptr)
+            if (!rootObjectWrapperDictionary->TryGetValue(frameId, wrapper) || wrapper == nullptr)
             {
                 wrapper = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
-                rootObjectWrapperDictionary[frameID] = wrapper;
+                rootObjectWrapperDictionary[frameId] = wrapper;
             }
             else
             {

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -22,7 +22,7 @@ namespace CefSharp
 
         gcroot<Action<CefBrowserWrapper^>^> _onBrowserCreated;
         gcroot<Action<CefBrowserWrapper^>^> _onBrowserDestroyed;
-        gcroot<Dictionary<int, CefBrowserWrapper^>^> _browserWrappers;
+        gcroot<ConcurrentDictionary<int, CefBrowserWrapper^>^> _browserWrappers;
         gcroot<List<CefExtension^>^> _extensions;
         gcroot<List<CefCustomScheme^>^> _schemes;
 
@@ -39,7 +39,7 @@ namespace CefSharp
         {
             _onBrowserCreated = onBrowserCreated;
             _onBrowserDestroyed = onBrowserDestoryed;
-            _browserWrappers = gcnew Dictionary<int, CefBrowserWrapper^>();
+            _browserWrappers = gcnew ConcurrentDictionary<int, CefBrowserWrapper^>();
             _extensions = gcnew List<CefExtension^>();
             _schemes = schemes;
         }

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -54,7 +54,7 @@ namespace CefSharp
     public:
         CefBrowserWrapper(CefRefPtr<CefBrowser> cefBrowser)
         {
-            _methodCallbacks = gcnew ConcurrentObjectRegistry<JavascriptAsyncMethodCallback^>(true);
+            _methodCallbacks = gcnew ConcurrentObjectRegistry<JavascriptAsyncMethodCallback^>();
             JavascriptRootObjectWrappers = gcnew ConcurrentDictionary<int64, JavascriptRootObjectWrapper^>();
             _cefBrowser = cefBrowser;
             BrowserId = cefBrowser->GetIdentifier();

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -12,6 +12,7 @@
 #include "Stdafx.h"
 #include "JavascriptRootObjectWrapper.h"
 #include "Async/JavascriptAsyncMethodCallback.h"
+#include "ConcurrentObjectRegistry.h"
 
 using namespace CefSharp::Internals::Async;
 using namespace System::ServiceModel;
@@ -26,15 +27,38 @@ namespace CefSharp
     {
     private:
         MCefRefPtr<CefBrowser> _cefBrowser;
+        // The entire set of possible JavaScript functions to
+        // call directly into.
+        JavascriptCallbackRegistry^ _callbackRegistry;
+        ConcurrentObjectRegistry<JavascriptAsyncMethodCallback^>^ _methodCallbacks;
     
     internal:
-        property JavascriptRootObjectWrapper^ JavascriptRootObjectWrapper;
+        property ConcurrentDictionary<int64, JavascriptRootObjectWrapper^>^ JavascriptRootObjectWrappers;
+        
+        property JavascriptCallbackRegistry^ CallbackRegistry
+        {
+            CefSharp::Internals::JavascriptCallbackRegistry^ get()
+            {
+                return _callbackRegistry;
+            }
+        }
+
+        property ConcurrentObjectRegistry<JavascriptAsyncMethodCallback^>^ MethodCallbackRegistry
+        {
+            CefSharp::Internals::ConcurrentObjectRegistry<JavascriptAsyncMethodCallback^>^ get()
+            {
+                return _methodCallbacks;
+            }
+        }
 
     public:
         CefBrowserWrapper(CefRefPtr<CefBrowser> cefBrowser)
         {
+            _methodCallbacks = gcnew ConcurrentObjectRegistry<JavascriptAsyncMethodCallback^>(true);
+            JavascriptRootObjectWrappers = gcnew ConcurrentDictionary<int64, JavascriptRootObjectWrapper^>();
             _cefBrowser = cefBrowser;
             BrowserId = cefBrowser->GetIdentifier();
+            _callbackRegistry = gcnew JavascriptCallbackRegistry(BrowserId);
             IsPopup = cefBrowser->IsPopup();
         }
         
@@ -46,12 +70,26 @@ namespace CefSharp
         ~CefBrowserWrapper()
         {
             this->!CefBrowserWrapper();
-
-            if (JavascriptRootObjectWrapper != nullptr)
+            if (JavascriptRootObjectWrappers != nullptr)
             {
-                delete JavascriptRootObjectWrapper;
+                for each(auto entry in JavascriptRootObjectWrappers)
+                {
+                    delete entry.Value;
+                }
+                delete JavascriptRootObjectWrappers;
 
-                JavascriptRootObjectWrapper = nullptr;
+                JavascriptRootObjectWrappers = nullptr;
+            }
+            if (_callbackRegistry != nullptr)
+            {
+                delete _callbackRegistry;
+                _callbackRegistry = nullptr;
+            }
+
+            if (_methodCallbacks != nullptr)
+            {
+                delete _methodCallbacks;
+                _methodCallbacks = nullptr;
             }
         }
 

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -164,6 +164,7 @@
     <ClInclude Include="CefAppUnmanagedWrapper.h" />
     <ClInclude Include="CefAppWrapper.h" />
     <ClInclude Include="CefBrowserWrapper.h" />
+    <ClInclude Include="ConcurrentObjectRegistry.h" />
     <ClInclude Include="JavascriptCallbackRegistry.h" />
     <ClInclude Include="JavascriptCallbackWrapper.h" />
     <ClInclude Include="JavascriptMethodWrapper.h" />
@@ -188,6 +189,7 @@
     <ClCompile Include="Async\JavascriptAsyncObjectWrapper.cpp" />
     <ClCompile Include="CefAppUnmanagedWrapper.cpp" />
     <ClCompile Include="CefAppWrapper.cpp" />
+    <ClCompile Include="ConcurrentObjectRegistry.cpp" />
     <ClCompile Include="JavascriptCallbackRegistry.cpp" />
     <ClCompile Include="JavascriptMethodHandler.cpp" />
     <ClCompile Include="JavascriptMethodWrapper.cpp" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClInclude Include="Serialization\JsObjectsSerialization.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ConcurrentObjectRegistry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp">
@@ -143,6 +146,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Serialization\JsObjectsSerialization.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ConcurrentObjectRegistry.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/CefSharp.BrowserSubprocess.Core/ConcurrentObjectRegistry.cpp
+++ b/CefSharp.BrowserSubprocess.Core/ConcurrentObjectRegistry.cpp
@@ -1,0 +1,33 @@
+﻿// Copyright © 2010-2015 The CefSharp Project. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#include "stdafx.h"
+#include "ConcurrentObjectRegistry.h"
+
+using namespace System::Threading;
+
+namespace CefSharp
+{
+    namespace Internals
+    {
+        generic <typename T>
+        int64 ConcurrentObjectRegistry<T>::RegisterObject(T entry)
+        {
+            int64 objectId = Interlocked::Increment(_lastId);
+            _entries->TryAdd(objectId, entry);
+            return objectId;
+        }
+        generic <typename T>
+        bool ConcurrentObjectRegistry<T>::TryGetObject(int64 id, T% entry)
+        {
+            return _entries->TryGetValue(id, entry) && entry != nullptr;
+        }
+        generic <typename T>
+        bool ConcurrentObjectRegistry<T>::TryRemoveObject(int64 id, T% entry)
+        {
+            return _entries->TryRemove(id, entry) && entry != nullptr;
+        }
+
+    }
+}

--- a/CefSharp.BrowserSubprocess.Core/ConcurrentObjectRegistry.h
+++ b/CefSharp.BrowserSubprocess.Core/ConcurrentObjectRegistry.h
@@ -1,0 +1,53 @@
+﻿// Copyright © 2010-2015 The CefSharp Project. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "JavascriptCallbackWrapper.h"
+
+using namespace System::Collections::Concurrent;
+
+namespace CefSharp
+{
+    namespace Internals
+    {
+        generic <typename T>
+        public ref class ConcurrentObjectRegistry
+        {
+        private:
+            bool _deleteEntriesOnDestroy;
+            Int64 _lastId;
+            ConcurrentDictionary<Int64, T>^ _entries;
+
+        public:
+            ConcurrentObjectRegistry(bool deleteEntriesOnDestroy) :
+                _deleteEntriesOnDestroy(deleteEntriesOnDestroy),
+                _entries(gcnew ConcurrentDictionary<Int64, T>())
+            {
+            }
+
+            ~ConcurrentObjectRegistry()
+            {
+                if (_entries != nullptr)
+                {
+                    if (_deleteEntriesOnDestroy)
+                    {
+                        for each (T entry in _entries->Values)
+                        {
+                            delete entry;
+                        }
+                    }
+                    _entries->Clear();
+                    delete _entries;
+                    _entries = nullptr;
+                }
+            }
+
+            int64 RegisterObject(T entry);
+            bool TryGetObject(int64 id, T% entry);
+            bool TryRemoveObject(int64 id, T% entry);
+        };
+    }
+}
+

--- a/CefSharp.BrowserSubprocess.Core/ConcurrentObjectRegistry.h
+++ b/CefSharp.BrowserSubprocess.Core/ConcurrentObjectRegistry.h
@@ -16,14 +16,11 @@ namespace CefSharp
         public ref class ConcurrentObjectRegistry
         {
         private:
-            bool _deleteEntriesOnDestroy;
             Int64 _lastId;
             ConcurrentDictionary<Int64, T>^ _entries;
 
         public:
-            ConcurrentObjectRegistry(bool deleteEntriesOnDestroy) :
-                _deleteEntriesOnDestroy(deleteEntriesOnDestroy),
-                _entries(gcnew ConcurrentDictionary<Int64, T>())
+            ConcurrentObjectRegistry() : _entries(gcnew ConcurrentDictionary<Int64, T>())
             {
             }
 
@@ -31,12 +28,9 @@ namespace CefSharp
             {
                 if (_entries != nullptr)
                 {
-                    if (_deleteEntriesOnDestroy)
+                    for each (T entry in _entries->Values)
                     {
-                        for each (T entry in _entries->Values)
-                        {
-                            delete entry;
-                        }
+                        delete entry;
                     }
                     _entries->Clear();
                     delete _entries;

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
@@ -32,7 +32,7 @@ namespace CefSharp
         void JavascriptCallbackRegistry::Deregister(Int64 id)
         {
             JavascriptCallbackWrapper^ callback;
-            if(_callbacks->TryGetObject(id, callback))
+            if(_callbacks->TryRemoveObject(id, callback))
             {
                 delete callback;
             }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2015 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2015 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
@@ -13,9 +13,8 @@ namespace CefSharp
     {
         JavascriptCallback^ JavascriptCallbackRegistry::Register(const CefRefPtr<CefV8Context>& context, const CefRefPtr<CefV8Value>& value)
         {
-            Int64 newId = Interlocked::Increment(_lastId);
             JavascriptCallbackWrapper^ wrapper = gcnew JavascriptCallbackWrapper(value, context);
-            _callbacks->TryAdd(newId, wrapper);
+            Int64 newId = _callbacks->RegisterObject(wrapper);
 
             auto result = gcnew JavascriptCallback();
             result->Id = newId;
@@ -26,14 +25,14 @@ namespace CefSharp
         JavascriptCallbackWrapper^ JavascriptCallbackRegistry::FindWrapper(int64 id)
         {
             JavascriptCallbackWrapper^ callback;
-            _callbacks->TryGetValue(id, callback);
+            _callbacks->TryGetObject(id, callback);
             return callback;
         }
 
         void JavascriptCallbackRegistry::Deregister(Int64 id)
         {
             JavascriptCallbackWrapper^ callback;
-            if(_callbacks->TryRemove(id, callback))
+            if(_callbacks->TryGetObject(id, callback))
             {
                 delete callback;
             }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.h
@@ -1,10 +1,11 @@
-// Copyright � 2010-2015 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2015 The CefSharp Project. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 #pragma once
 
 #include "JavascriptCallbackWrapper.h"
+#include "ConcurrentObjectRegistry.h"
 
 using namespace System::Collections::Concurrent;
 
@@ -16,8 +17,7 @@ namespace CefSharp
         {
         private:
             int _browserId;
-            Int64 _lastId;
-            ConcurrentDictionary<Int64, JavascriptCallbackWrapper^>^ _callbacks;
+            ConcurrentObjectRegistry<JavascriptCallbackWrapper^>^ _callbacks;
 
         internal:
             JavascriptCallbackWrapper^ FindWrapper(int64 id);
@@ -25,18 +25,14 @@ namespace CefSharp
         public:
             JavascriptCallbackRegistry(int browserId) : _browserId(browserId)
             {
-                _callbacks = gcnew ConcurrentDictionary<Int64, JavascriptCallbackWrapper^>();
+                _callbacks = gcnew ConcurrentObjectRegistry<JavascriptCallbackWrapper^>(true);
             }
 
             ~JavascriptCallbackRegistry()
             {
                 if (_callbacks != nullptr)
                 {
-                    for each (JavascriptCallbackWrapper^ callback in _callbacks->Values)
-                    {
-                        delete callback;
-                    }
-                    _callbacks->Clear();
+                    delete _callbacks;
                     _callbacks = nullptr;
                 }
             }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.h
@@ -25,7 +25,7 @@ namespace CefSharp
         public:
             JavascriptCallbackRegistry(int browserId) : _browserId(browserId)
             {
-                _callbacks = gcnew ConcurrentObjectRegistry<JavascriptCallbackWrapper^>(true);
+                _callbacks = gcnew ConcurrentObjectRegistry<JavascriptCallbackWrapper^>();
             }
 
             ~JavascriptCallbackRegistry()

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
@@ -16,7 +16,7 @@ namespace CefSharp
         {
             if (arguments[i]->IsFunction())
             {
-                parameter[i] = _callbackRegistry->Register(CefV8Context::GetCurrentContext(), arguments[i]);
+                parameter[i] = _callbackRegistryReference->Register(CefV8Context::GetCurrentContext(), arguments[i]);
             }
             else
             {

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.h
@@ -13,19 +13,20 @@ namespace CefSharp
     {
     private:
         gcroot<Func<array<Object^>^, BrowserProcessResponse^>^> _method;
-        gcroot<JavascriptCallbackRegistry^> _callbackRegistry;
+        gcroot<JavascriptCallbackRegistry^> _callbackRegistryReference;
 
     public:
-        JavascriptMethodHandler(Func<array<Object^>^, BrowserProcessResponse^>^ method, JavascriptCallbackRegistry^ callbackRegistry)
+        JavascriptMethodHandler(Func<array<Object^>^, BrowserProcessResponse^>^ method, JavascriptCallbackRegistry^ callbackRegistryReference)
         {
             _method = method;
-            _callbackRegistry = callbackRegistry;
+            _callbackRegistryReference = callbackRegistryReference;
         }
 
         ~JavascriptMethodHandler()
         {
             delete _method;
-            delete _callbackRegistry;
+            _callbackRegistryReference = nullptr;
+            _method = nullptr;
         }
 
         virtual bool Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8ValueList& arguments, CefRefPtr<CefV8Value>& retval, CefString& exception) OVERRIDE;

--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodWrapper.h
@@ -21,11 +21,11 @@ namespace CefSharp
         IBrowserProcess^ _browserProcess;
 
     public:
-        JavascriptMethodWrapper(int64 ownerId, IBrowserProcess^ browserProcess, JavascriptCallbackRegistry^ callbackRegistry)
+        JavascriptMethodWrapper(int64 ownerId, IBrowserProcess^ browserProcess, JavascriptCallbackRegistry^ callbackRegistryReference)
         {
             _ownerId = ownerId;
             _browserProcess = browserProcess;
-            _javascriptMethodHandler = new JavascriptMethodHandler(gcnew Func<array<Object^>^, BrowserProcessResponse^>(this, &JavascriptMethodWrapper::Execute), callbackRegistry);
+            _javascriptMethodHandler = new JavascriptMethodHandler(gcnew Func<array<Object^>^, BrowserProcessResponse^>(this, &JavascriptMethodWrapper::Execute), callbackRegistryReference);
         }
 
         !JavascriptMethodWrapper()

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -17,6 +17,8 @@ using namespace CefSharp::Internals::Async;
 
 namespace CefSharp
 {
+    ref class CefBrowserWrapper;
+
     // This wraps the transmitted registered objects
     // by binding the meta-data to V8 JavaScript objects
     // and installing callbacks for changes to those
@@ -26,20 +28,7 @@ namespace CefSharp
     private:
         initonly List<JavascriptObjectWrapper^>^ _wrappedObjects;
         initonly List<JavascriptAsyncObjectWrapper^>^ _wrappedAsyncObjects;
-        initonly Dictionary<int64, JavascriptAsyncMethodCallback^>^ _methodCallbacks;
-        int64 _lastCallback;
         IBrowserProcess^ _browserProcess;
-        // The entire set of possible JavaScript functions to
-        // call directly into.
-        JavascriptCallbackRegistry^ _callbackRegistry;
-
-        int64 SaveMethodCallback(JavascriptAsyncMethodCallback^ callback);
-
-    internal:
-        property JavascriptCallbackRegistry^ CallbackRegistry
-        {
-            CefSharp::Internals::JavascriptCallbackRegistry^ get();
-        }
 
     public:
         JavascriptRootObjectWrapper(int browserId, IBrowserProcess^ browserProcess)
@@ -47,18 +36,10 @@ namespace CefSharp
             _browserProcess = browserProcess;
             _wrappedObjects = gcnew List<JavascriptObjectWrapper^>();
             _wrappedAsyncObjects = gcnew List<JavascriptAsyncObjectWrapper^>();
-            _callbackRegistry = gcnew JavascriptCallbackRegistry(browserId);
-            _methodCallbacks = gcnew Dictionary<int64, JavascriptAsyncMethodCallback^>();
         }
 
         ~JavascriptRootObjectWrapper()
         {
-            if (_callbackRegistry != nullptr)
-            {
-                delete _callbackRegistry;
-                _callbackRegistry = nullptr;
-            }
-
             for each (JavascriptObjectWrapper^ var in _wrappedObjects)
             {
                 delete var;
@@ -70,17 +51,9 @@ namespace CefSharp
                 delete var;
             }
             _wrappedAsyncObjects->Clear();
-
-            for each(JavascriptAsyncMethodCallback^ var in _methodCallbacks->Values)
-            {
-                delete var;
-            }
-            _methodCallbacks->Clear();
         }
 
-        bool TryGetAndRemoveMethodCallback(int64 id, JavascriptAsyncMethodCallback^% callback);
-
-        void Bind(JavascriptRootObject^ rootObject, JavascriptRootObject^ asyncRootObject, const CefRefPtr<CefV8Value>& v8Value);
+        void Bind(CefBrowserWrapper^ browserWrapper, JavascriptRootObject^ rootObject, JavascriptRootObject^ asyncRootObject, const CefRefPtr<CefV8Value>& v8Value);
     };
 }
 


### PR DESCRIPTION
The binding of the root objects seems to be flawed. During the context creation the root object wrapper of the browser will be set:
```
wrapper->JavascriptRootObjectWrapper = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), wrapper->BrowserProcess);
```
And during the context destruction the root object wrapper is getting released.
However, the context creation and destruction for a browser is frame related and therefore can happen multiple times with arbitrary order. e.g.
- iframe 1 added: context create (overriding the root object of the main site as context destroyed is not called, resources of site root object leaked)
- iframe 2 added: context create  (overriding the root object of frame 1 as context destroyed is not called, resources of iframe 1 root object leaked)
- remove iframe 1: context destroyed is invoked destroying the root object of iframe 2 resulting in exceptions when invoking e.g. callbacks

Without the changes here the test of #1318 will result in application crashes / render process termination / results not being passed back.
e.g.
- Invoke Callback in an iframe after another iframe has been refreshed -> render process crash
- Invoke Callback in an iframe after another iframe has been refreshed in a popup -> application crash similar to #1317 
- Async bound object results are not shown when the result is not available before an iframe is refreshed

With the changes introduced here the above errors do not occur.

```
refactored root object binding to be context aware
- as the binding of root objects occurs during context creation, root
objects are now frame bound and contained within the browser wrapper
- callbacks are browser bound as they keep track of their target for
themself
- introduced concurrent object registry storing objects with an auto
generated id, refactored method and js callback handling to use new type
```

#1315 

I would be glad to hear your feedback on these changes.