### PR TITLE
Missing callback registry for browsers created without registered js objects

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -60,22 +60,22 @@ namespace CefSharp
     {
         auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier(), true);
 
-        if (!Object::ReferenceEquals(_javascriptRootObject, nullptr) || !Object::ReferenceEquals(_javascriptAsyncRootObject, nullptr))
+        auto rootObjectWrappers = browserWrapper->JavascriptRootObjectWrappers;
+        auto frameId = frame->GetIdentifier();
+
+        if (rootObjectWrappers->ContainsKey(frameId))
         {
-            auto rootObjectWrappers = browserWrapper->JavascriptRootObjectWrappers;
-            auto frameId = frame->GetIdentifier();
-
-            if (rootObjectWrappers->ContainsKey(frameId))
+            LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
+        }
+        else
+        {
+            auto rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
+            if (!Object::ReferenceEquals(_javascriptRootObject, nullptr) || !Object::ReferenceEquals(_javascriptAsyncRootObject, nullptr))
             {
-                LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
-            }
-            else
-            {
-                auto rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
                 rootObject->Bind(_javascriptRootObject, _javascriptAsyncRootObject, context->GetGlobal());
-
-                rootObjectWrappers->TryAdd(frameId, rootObject);
             }
+
+            rootObjectWrappers->TryAdd(frameId, rootObject);
         }
     };
 


### PR DESCRIPTION
Branch master, currently 7aa128781df73d37d9be9e1534338d61943d04a9

I discovered this issue when investigating the erroneous execution of 
```
await browser.EvaluateScriptAsync("document.getElementById('lst-ib').value = 'CefSharp Was Here!'");
```
in the CefSharp.OffScreen.Example
Since e9675a2c3e104405b15f4f9cad54778b0cc232a8

In this commit the execution of evaluated script will stop if no root object could be found as the evaluated script could create a callback during the `SerializeV8Object(result, responseArgList, 2, callbackRegistry);` call.

Browsers no object (sync & asnyc) has been registered will not hold a root object and therefore, no callback registry which would, prior to e9675a2c3e104405b15f4f9cad54778b0cc232a8, lead to an exception when the evaluted javascript source code would return a callback function.

This leads to the CefSharp.OffScreen.Example not executing properly. Of course, if the check for a missing root object would be removed the example would execute. However, callback functions could not be used.

Therefore, I think that a root object should be created even if no objects have been registered. The root object itself checks if a sync / async object exists and will therefore, only act as a manager for the callbacks which should not be too heavy.