### PR TITLE
Feature sanitized and verbose js exception strings

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -207,7 +207,7 @@ namespace CefSharp
                             }
                             else
                             {
-                                errorMessage = exception->GetMessage();
+                                errorMessage = StringUtils::CreateExceptionString(exception);
                             }
                         }
                         finally
@@ -261,10 +261,7 @@ namespace CefSharp
                             else
                             {
                                 auto exception = value->GetException();
-                                if (exception.get())
-                                {
-                                    errorMessage = exception->GetMessage();
-                                }
+                                errorMessage = StringUtils::CreateExceptionString(exception);
                             }
                         }
                         finally

--- a/CefSharp.Core/Internals/StringUtils.h
+++ b/CefSharp.Core/Internals/StringUtils.h
@@ -6,7 +6,7 @@
 
 #include <vector>
 #include "vcclr_local.h"
-#include "include\internal\cef_string.h"
+#include "include\cef_v8.h"
 
 using namespace System;
 using namespace System::Collections::Generic;
@@ -115,6 +115,26 @@ namespace CefSharp
                 {
                     pin_ptr<const wchar_t> pStr = PtrToStringChars(str);
                     cef_string_copy(pStr, str->Length, &cefStr);
+                }
+            }
+
+            /// <summary>
+            /// Creates a detailed expection string from a provided Cef V8 exception.
+            /// </summary>
+            /// <param name="exception">The exception which will be used as base for the message</param>
+            [DebuggerStepThrough]
+            static CefString CreateExceptionString(CefRefPtr<CefV8Exception> exception)
+            {
+                if (exception.get())
+                {
+                    std::wstringstream logMessageBuilder;
+                    logMessageBuilder << exception->GetMessage().c_str() << L"\n@ " <<
+                        exception->GetScriptResourceName().c_str() << L":" << exception->GetLineNumber() << L":" << exception->GetStartColumn();
+                    return CefString(logMessageBuilder.str());
+                }
+                else
+                {
+                    return "Exception occured but the Cef V8 exception is null";
                 }
             }
         };

--- a/CefSharp.Core/Internals/StringUtils.h
+++ b/CefSharp.Core/Internals/StringUtils.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <vector>
+#include <sstream>
 #include "vcclr_local.h"
 #include "include\cef_v8.h"
 

--- a/CefSharp.Example/ExceptionTestBoundObject.cs
+++ b/CefSharp.Example/ExceptionTestBoundObject.cs
@@ -43,5 +43,30 @@ namespace CefSharp.Example
         {
             return parameter;
         }
+
+        public void TestCallbackException(IJavascriptCallback errorCallback, IJavascriptCallback errorCallbackResult)
+        {
+            const int taskDelay = 500;
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(taskDelay);
+
+                using (errorCallback)
+                {
+                    JavascriptResponse result = await errorCallback.ExecuteAsync("This callback from C# was delayed " + taskDelay + "ms");
+                    string resultMessage;
+                    if (result.Success)
+                    {
+                        resultMessage = "Fatal: No Exception thrown in error callback";
+                    }
+                    else
+                    {
+                        resultMessage = "Exception Thrown: " + result.Message;
+                    }
+                    await errorCallbackResult.ExecuteAsync(resultMessage);
+                }
+            });
+        }
     }
 }

--- a/CefSharp.Example/Resources/ExceptionTest.html
+++ b/CefSharp.Example/Resources/ExceptionTest.html
@@ -52,5 +52,23 @@
                 }
             </script>
         </p>
+        <p>
+            Exception string for error callback:<br />
+            <script type="text/javascript">
+                function errorCallback(s)
+                {
+                    throw "Callback Error (" + s + ")";
+                }
+                function errorCallbackResultLogger(s)
+                {
+                    var logArea = document.getElementById('errorCallbackResult');
+                    logArea.innerText = s;
+                }
+                bound.exceptionTestObject.testCallbackException(errorCallback, errorCallbackResultLogger);
+            </script>
+            <p>Received Exception:</p>
+            <p id="errorCallbackResult"></p>
+        </p>
+
     </body>
 </html>


### PR DESCRIPTION
- added a test case for logging JavaScript exceptions created in a Callback
- added a CreateExceptionString to the StringUtils for creating a verbose message for Javascript exceptions including the message, filename, line number and column; this methods also checks if the exception is available
- use the util function in the app unmanaged wrapper to create the JS exception string for callbacks and js evaluations, by this the `if (exception.get())` will now also be executed in both cases.

New log message (ExceptionTest.html)
```
Uncaught Callback Error (This callback from C# was delayed 500ms)
@ custom://cefsharp/ExceptionTest.html:59:20
```

Previous message
```
Uncaught Callback Error (This callback from C# was delayed 500ms)
```