### PR TITLE
Fix offscreen browser browser settings nullptr (breaking current interface)

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -107,7 +107,7 @@ namespace CefSharp.OffScreen
 
             if(automaticallyCreateBrowser)
             {
-                CreateBrowser(IntPtr.Zero, address, browserSettings, requestcontext);
+                CreateBrowser(IntPtr.Zero);
             }
             
         }
@@ -168,13 +168,11 @@ namespace CefSharp.OffScreen
         }
 
         /// <summary>
-        /// Create the underlying browser
+        /// Create the underlying browser. The instance address, browser settings and request context will be used.
         /// </summary>
         /// <param name="windowHandle">Window handle if any, IntPtr.Zero is the default</param>
-        /// <param name="address">Initial address (url) to load</param>
-        /// <param name="browserSettings">The browser settings to use. If null, the default settings are used.</param>
-        /// <param name="requestcontext">See <see cref="RequestContext"/> for more details. Defaults to null</param>
-        public void CreateBrowser(IntPtr windowHandle, string address = "", BrowserSettings browserSettings = null, RequestContext requestcontext = null)
+        
+        public void CreateBrowser(IntPtr windowHandle)
         {
             if (browserCreated)
             {
@@ -183,7 +181,7 @@ namespace CefSharp.OffScreen
 
             browserCreated = true;
 
-            managedCefBrowserAdapter.CreateOffscreenBrowser(windowHandle, browserSettings, requestcontext, address);
+            managedCefBrowserAdapter.CreateOffscreenBrowser(windowHandle, BrowserSettings, RequestContext, Address);
         }
 
         /// <summary>


### PR DESCRIPTION
There is a bug with the optional browser settings in the offscreen browser project which will lead to a null poiinter exception if no settings are available.

Example:
https://github.com/illfang/CefSharp/tree/offscreen-browser-browser-settings-nullptr-test
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CefSharp.BrowserSettings.get_OffScreenTransparentBackground()
   at CefSharp.ManagedCefBrowserAdapter.CreateOffscreenBrowser(IntPtr windowHandle, BrowserSettings browserSettings, RequestContext requestContext, String address)
   at CefSharp.OffScreen.ChromiumWebBrowser.CreateBrowser(IntPtr windowHandle, String address, BrowserSettings browserSettings, RequestContext requestcontext)
   at CefSharp.OffScreen.ChromiumWebBrowser..ctor(String address, BrowserSettings browserSettings, RequestContext requestcontext, Boolean automaticallyCreateBrowser)
```

Probably related to dca52f931fcb7e0d435b2e1f46cd1d49fed5a2d3

I suggest two version to fix this. This is the first version which will always create the offscreen browser using the instance settings, request context and address. The instance browser settings are checked for null in the constructor.

The second solution is described in cefsharp/CefSharp/pull/1359

I'm looking forward to your feedback. Feel free to close one of the PRs if you decide to merge one.