### PR TITLE
Fix ensure context binding of root object

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -64,19 +64,23 @@ namespace CefSharp
         auto rootObjectWrappers = browserWrapper->JavascriptRootObjectWrappers;
         auto frameId = frame->GetIdentifier();
 
-        if (rootObjectWrappers->ContainsKey(frameId))
+        JavascriptRootObjectWrapper^ rootObject;
+        if (!rootObjectWrappers->TryGetValue(frameId, rootObject))
+        {
+            rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
+            rootObjectWrappers->TryAdd(frameId, rootObject);
+        }
+
+        if (rootObject->IsBound)
         {
             LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
         }
         else
         {
-            auto rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
             if (!Object::ReferenceEquals(_javascriptRootObject, nullptr) || !Object::ReferenceEquals(_javascriptAsyncRootObject, nullptr))
             {
                 rootObject->Bind(_javascriptRootObject, _javascriptAsyncRootObject, context->GetGlobal());
             }
-
-            rootObjectWrappers->TryAdd(frameId, rootObject);
         }
     };
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.cpp
@@ -14,6 +14,13 @@ namespace CefSharp
 {
     void JavascriptRootObjectWrapper::Bind(JavascriptRootObject^ rootObject, JavascriptRootObject^ asyncRootObject, const CefRefPtr<CefV8Value>& v8Value)
     {
+        if (_isBound)
+        {
+            throw gcnew InvalidOperationException("This root object has already been bound.");
+        }
+
+        _isBound = true;
+
         if (rootObject != nullptr)
         {
             auto memberObjects = rootObject->MemberObjects;
@@ -44,6 +51,11 @@ namespace CefSharp
     JavascriptCallbackRegistry^ JavascriptRootObjectWrapper::CallbackRegistry::get()
     {
         return _callbackRegistry;
+    }
+
+    bool JavascriptRootObjectWrapper::IsBound::get()
+    {
+        return _isBound;
     }
 
 

--- a/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptRootObjectWrapper.h
@@ -27,6 +27,7 @@ namespace CefSharp
         initonly List<JavascriptObjectWrapper^>^ _wrappedObjects;
         initonly List<JavascriptAsyncObjectWrapper^>^ _wrappedAsyncObjects;
         initonly Dictionary<int64, JavascriptAsyncMethodCallback^>^ _methodCallbacks;
+        bool _isBound;
         int64 _lastCallback;
         IBrowserProcess^ _browserProcess;
         // The entire set of possible JavaScript functions to
@@ -41,6 +42,11 @@ namespace CefSharp
             CefSharp::Internals::JavascriptCallbackRegistry^ get();
         }
 
+        property bool IsBound
+        {
+            bool get();
+        }
+
     public:
         JavascriptRootObjectWrapper(int browserId, IBrowserProcess^ browserProcess)
         {
@@ -49,6 +55,7 @@ namespace CefSharp
             _wrappedAsyncObjects = gcnew List<JavascriptAsyncObjectWrapper^>();
             _callbackRegistry = gcnew JavascriptCallbackRegistry(browserId);
             _methodCallbacks = gcnew Dictionary<int64, JavascriptAsyncMethodCallback^>();
+            _isBound = false;
         }
 
         ~JavascriptRootObjectWrapper()


### PR DESCRIPTION
This PR is an addition to the commit 00c926a4cc66d5ae5ed0a4c25c7b933c358e7224 for solving #1354

In the previous commit, a new root object will be created during the `OnProcessMessageReceived` when there has not yet been a JS context created by the browser. By evanluating JS in the `OnProcessMessageReceived` function, a context will be created and `OnContextCreated` will be called.
As the root object has already been created the following will be the case:
```
LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
```
This will skip the `Bind` of the root object to this new context which this PR tries to solve.