### PR TITLE
Allow User Specified RenderOptions (WPF)

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -925,7 +925,8 @@ namespace CefSharp.Wpf
         {
             var img = new Image();
 
-            RenderOptions.SetBitmapScalingMode(img, BitmapScalingMode.NearestNeighbor);
+            BitmapScalingMode oBitmapScalingModeThis = RenderOptions.GetBitmapScalingMode( this );
+            RenderOptions.SetBitmapScalingMode(img, ( oBitmapScalingModeThis != BitmapScalingMode.Unspecified ) ? oBitmapScalingModeThis : BitmapScalingMode.NearestNeighbor);
 
             img.Stretch = Stretch.None;
             img.HorizontalAlignment = HorizontalAlignment.Left;


### PR DESCRIPTION
Use RenderOptions of the control in Wpf ChromiumWebBrowser.cs CreateImage

This little change allows users to set the RenderOptions BitmapScalingMode for the ChromiumWebBrowser Wpf control just like this:

```
<cefSharp:ChromiumWebBrowser RenderOptions.BitmapScalingMode="Fant">
```

While NearestNeighbor (fixed value before my edit) looks fine if each rendered pixel is exactly displayed as a single pixel, using that setting for a browser placed in a viewport leads to ugly results.

You can test the different BitmapScalingMode settings for example in the Wpf.Example application if you set the RenderOptions.BitmapScalingMode property for the ChromiumWebBrowser in BrowserTabView.xaml.
Just change the Angel (Tweak WPF Rendering) of the browser in the running application to actually see the differences.

Best Regards
Johannes Viehmann