### PR TITLE
Add missing XML documentation comments

### DIFF
--- a/CefSharp.WinForms/Internals/ControlExtensions.cs
+++ b/CefSharp.WinForms/Internals/ControlExtensions.cs
@@ -41,8 +41,8 @@ namespace CefSharp.WinForms.Internals
         /// Returns whether the supplied control is the currently
         /// active control.
         /// </summary>
-        /// <param name="control"></param>
-        /// <returns></returns>
+        /// <param name="control">the control to check</param>
+        /// <returns>true if the control is the currently active control</returns>
         public static bool IsActiveControl(this Control control)
         {
             Control activeControl = control.FindForm().ActiveControl;

--- a/CefSharp.WinForms/Internals/ParentFormMessageInterceptor.cs
+++ b/CefSharp.WinForms/Internals/ParentFormMessageInterceptor.cs
@@ -48,7 +48,7 @@ namespace CefSharp.WinForms.Internals
         /// Adjust the form to listen to if the ChromiumWebBrowserControl's parent changes.
         /// </summary>
         /// <param name="sender">The ChromiumWebBrowser whose parent has changed.</param>
-        /// <param name="e"></param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         private void ParentParentChanged(object sender, EventArgs e)
         {
             var control = (Control)sender;

--- a/CefSharp.Wpf.Example/Controls/NonReloadingTabControl.cs
+++ b/CefSharp.Wpf.Example/Controls/NonReloadingTabControl.cs
@@ -29,8 +29,8 @@ namespace CefSharp.Wpf.Example.Controls
         /// <summary>
         /// If containers are done, generate the selected item
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         private void ItemContainerGeneratorStatusChanged(object sender, EventArgs e)
         {
             if (ItemContainerGenerator.Status == GeneratorStatus.ContainersGenerated)
@@ -53,7 +53,7 @@ namespace CefSharp.Wpf.Example.Controls
         /// <summary>
         /// When the items change we remove any generated panel children and add any new ones as necessary
         /// </summary>
-        /// <param name="e"></param>
+        /// <param name="e">The <see cref="NotifyCollectionChangedEventArgs"/> instance containing the event data.</param>
         protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
         {
             base.OnItemsChanged(e);

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -97,7 +97,7 @@ namespace CefSharp
         /// <param name="checkOptional">check to see if optional dependencies are present</param>
         /// <param name="packLoadingDisabled">Is loading of pack files disabled?</param>
         /// <param name="path">path to check for dependencies</param>
-        /// <param name="resourcesDirPath"></param>
+        /// <param name="resourcesDirPath">The path to the resources directory, if empty the Executing Assembly path is used.</param>
         /// <param name="browserSubProcessPath">The path to a separate executable that will be launched for sub-processes.</param>
         /// <param name="localePackFile">The locale pack file e.g. <see cref="LocalesPackFile"/> </param>
         /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
@@ -151,7 +151,7 @@ namespace CefSharp
         /// </summary>
         /// <param name="dir">The directory of the dependencies, or the current directory if null.</param>
         /// <param name="files">The dependencies to check.</param>
-        /// <returns></returns>
+        /// <returns>List of missing dependencies, if all present an empty List will be returned</returns>
         private static List<string> CheckDependencyList(string dir, IEnumerable<string> files)
         {
             var missingDependencies = new List<string>();

--- a/CefSharp/DisposableResource.cs
+++ b/CefSharp/DisposableResource.cs
@@ -48,7 +48,7 @@ namespace CefSharp
         /// If this Object is disposed the Method will throw a <see cref="ObjectDisposedException"/>.
         /// Use this method to guard methods that are not allowed to be called after dispose was called
         /// </summary>
-        /// <exception cref="System.ObjectDisposedException"></exception>
+        /// <exception cref="System.ObjectDisposedException">Thrown when this resource is disposed.</exception>
         protected virtual void DisposeGuard()
         {
             if (IsDisposed)

--- a/CefSharp/IBrowser.cs
+++ b/CefSharp/IBrowser.cs
@@ -15,7 +15,7 @@ namespace CefSharp
         /// <summary>
         /// Returns the browser host object. This method can only be called in the browser process.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>the browser host object</returns>
         IBrowserHost GetHost();
 
         /// <summary>
@@ -58,7 +58,10 @@ namespace CefSharp
         /// <summary>
         /// Reload the current page.
         /// </summary>
-        /// <param name="ignoreCache"></param>
+        /// <param name="ignoreCache">
+        /// <c>true</c> a reload is performed ignoring browser cache; <c>false</c> a reload is
+        /// performed using files from the browser cache, if available.
+        /// </param>
         void Reload(bool ignoreCache = false);
 
         /// <summary>
@@ -115,7 +118,7 @@ namespace CefSharp
         /// <summary>
         /// Returns the number of frames that currently exist.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>the number of frames</returns>
         int GetFrameCount();
 
         /// <summary>

--- a/CefSharp/IContextMenuHandler.cs
+++ b/CefSharp/IContextMenuHandler.cs
@@ -53,7 +53,7 @@ namespace CefSharp
         /// <param name="frame">The frame the request is coming from</param>
         /// <param name="parameters">provides information about the context menu state</param>
         /// <param name="model">contains the context menu model resulting from OnBeforeContextMenu</param>
-        /// <param name="callback"></param>
+        /// <param name="callback">the callback to execute for custom display</param>
         /// <returns>For custom display return true and execute callback either synchronously or asynchronously with the selected command ID.</returns>
         bool RunContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model, IRunContextMenuCallback callback);
     }

--- a/CefSharp/IDisplayHandler.cs
+++ b/CefSharp/IDisplayHandler.cs
@@ -52,7 +52,7 @@ namespace CefSharp
         /// drawing tooltips and the return value is ignored.
         /// </summary>
         /// <param name="browserControl">The ChromiumWebBrowser control</param>
-        /// <param name="text"></param>
+        /// <param name="text">the text that will be displayed in the tooltip</param>
         bool OnTooltipChanged(IWebBrowser browserControl, string text);
 
         /// <summary>

--- a/CefSharp/IDragData.cs
+++ b/CefSharp/IDragData.cs
@@ -85,10 +85,10 @@ namespace CefSharp
         void ResetFileContents();
 
         /// <summary>
-        /// Gets the Contents of the File as a <see cref="Stream"/>
+        /// Gets the contents of the File as a <see cref="Stream"/>
         /// For a suggested filename check the <see cref="FileName"/> property
         /// </summary>
-        /// <returns></returns>
+        /// <returns>the contents of the file</returns>
         Stream GetFileContents();
 
         /// <summary>

--- a/CefSharp/IFrame.cs
+++ b/CefSharp/IFrame.cs
@@ -62,13 +62,17 @@ namespace CefSharp
         /// <summary>
         /// Retrieve this frame's HTML source as a string sent to the specified visitor.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// a <see cref="Task{String}"/> that when executed returns this frame's HTML source as a string.
+        /// </returns>
         Task<string> GetSourceAsync();
 
         /// <summary>
         /// Retrieve this frame's display text as a string sent to the specified visitor.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// a <see cref="Task{String}"/> that when executed returns the frame's display text as a string.
+        /// </returns>
         Task<string> GetTextAsync();
 
         // TODO: Expose a public constructor to CefRequestWrapper maybe?

--- a/CefSharp/IMenuModel.cs
+++ b/CefSharp/IMenuModel.cs
@@ -14,7 +14,7 @@ namespace CefSharp
         /// <summary>
         /// Remove all menu items. Can be used to disable the context menu. Returns true on success.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Returns true on success</returns>
         bool Clear();
 
         /// <summary>
@@ -36,14 +36,14 @@ namespace CefSharp
         /// Removes the item with the specified commandId.
         /// </summary>
         /// <param name="commandId">the command Id</param>
-        /// <returns> Returns true on success</returns>
+        /// <returns>Returns true on success</returns>
         bool Remove(CefMenuCommand commandId);
 
         /// <summary>
         /// Add an item to the menu. 
         /// </summary>
-        /// <param name="commandId"></param>
-        /// <param name="label"></param>
+        /// <param name="commandId">the command Id</param>
+        /// <param name="label">the label of the item</param>
         /// <returns>Returns true on success.</returns>
         bool AddItem(CefMenuCommand commandId, string label);
 

--- a/CefSharp/Internals/IntPtrExtensions.cs
+++ b/CefSharp/Internals/IntPtrExtensions.cs
@@ -12,8 +12,8 @@ namespace CefSharp.Internals
         /// Do an unchecked conversion from IntPtr to int
         /// so overflow exceptions don't get thrown.
         /// </summary>
-        /// <param name="intPtr"></param>
-        /// <returns></returns>
+        /// <param name="intPtr">the IntPtr to cast</param>
+        /// <returns>a 32-bit signed integer</returns>
         public static int CastToInt32(this IntPtr intPtr)
         {
             return unchecked((int)intPtr.ToInt64());

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -124,7 +124,7 @@ namespace CefSharp
         /// </summary>
         /// <param name="stream">A stream of the resource.</param>
         /// <param name="mimeType">Type of MIME.</param>
-        /// <returns></returns>
+        /// <returns>ResourceHandler.</returns>
         public static ResourceHandler FromStream(Stream stream, string mimeType = DefaultMimeType)
         {
             return new ResourceHandler(mimeType, ResourceHandlerType.Stream) { Stream = stream };

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -367,7 +367,7 @@ namespace CefSharp
         /// Reloads the page being displayed, optionally ignoring the cache (which means the whole page including all .css, .js
         /// etc. resources will be re-fetched).
         /// </summary>
-        /// <param name="browser"></param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
         /// <param name="ignoreCache"><c>true</c> A reload is performed ignoring browser cache; <c>false</c> A reload is
         /// performed using files from the browser cache, if available.</param>
         public static void Reload(this IWebBrowser browser, bool ignoreCache)


### PR DESCRIPTION
When I updated to *45.0.0-pre01* my not so forgiving StyleCop rules notified me of a missing parameter comment in the method *IContextMenuHandler.RunContextMenu*.

I did a quick search for some more empty XML comments and added them when necessary.

This fixes some warnings from #1162.