### PR TITLE
Add Support for executing a JavascriptCallback with a Struct as a param

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -251,12 +251,6 @@ namespace CefSharp
                 else
                 {
                     auto jsCallbackId = GetInt64(argList, 2);
-                    auto parameterList = argList->GetList(3);
-                    CefV8ValueList params;
-                    for (CefV8ValueList::size_type i = 0; i < parameterList->GetSize(); i++)
-                    {
-                        params.push_back(DeserializeV8Object(parameterList, static_cast<int>(i)));
-                    }
 
                     auto callbackWrapper = callbackRegistry->FindWrapper(jsCallbackId);
                     if (callbackWrapper == nullptr)
@@ -272,6 +266,16 @@ namespace CefSharp
                         {
                             try
                             {
+                                auto parameterList = argList->GetList(3);
+                                CefV8ValueList params;
+                                
+                                //Needs to be called within the context as for Dictionary (mapped to struct)
+                                //a V8Object will be created
+                                for (CefV8ValueList::size_type i = 0; i < parameterList->GetSize(); i++)
+                                {
+                                    params.push_back(DeserializeV8Object(parameterList, static_cast<int>(i)));
+                                }
+
                                 result = value->ExecuteFunction(nullptr, params);
                                 success = result.get() != nullptr;
                         

--- a/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
@@ -160,7 +160,7 @@ namespace CefSharp
                     auto size = subDict->GetSize();
                     std::vector<CefString> keys;
                     subDict->GetKeys(keys);
-                    result = CefV8Value::CreateArray(size);
+                    result = CefV8Value::CreateObject(nullptr);
                     for (auto i = 0; i < size; i++)
                     {
                         result->SetValue(keys[i], DeserializeV8Object(subDict, keys[i]), V8_PROPERTY_ATTRIBUTE_NONE);

--- a/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
@@ -122,52 +122,61 @@ namespace CefSharp
             CefRefPtr<CefV8Value> DeserializeV8Object(const CefRefPtr<TList>& list, const TIndex& index)
             {
                 auto type = list->GetType(index);
-                auto result = CefV8Value::CreateNull();
 
                 if (type == VTYPE_BOOL)
                 {
-                    result = CefV8Value::CreateBool(list->GetBool(index));
+                    return CefV8Value::CreateBool(list->GetBool(index));
                 }
-                else if (type == VTYPE_INT)
+
+                if (type == VTYPE_INT)
                 {
-                    result = CefV8Value::CreateInt(list->GetInt(index));
+                    return CefV8Value::CreateInt(list->GetInt(index));
                 }
-                else if (type == VTYPE_DOUBLE)
+
+                if (type == VTYPE_DOUBLE)
                 {
-                    result = CefV8Value::CreateDouble(list->GetDouble(index));
+                    return CefV8Value::CreateDouble(list->GetDouble(index));
                 }
-                else if (type == VTYPE_STRING)
+
+                if (type == VTYPE_STRING)
                 {
-                    result = CefV8Value::CreateString(list->GetString(index));
+                    return CefV8Value::CreateString(list->GetString(index));
                 }
-                else if (IsCefTime(list, index))
+
+                if (IsCefTime(list, index))
                 {
-                    result = CefV8Value::CreateDate(GetCefTime(list, index));
+                    return CefV8Value::CreateDate(GetCefTime(list, index));
                 }
-                else if (type == VTYPE_LIST)
+
+                if (type == VTYPE_LIST)
                 {
                     auto subList = list->GetList(index);
                     auto size = subList->GetSize();
-                    result = CefV8Value::CreateArray(size);
+                    auto result = CefV8Value::CreateArray(size);
                     for (auto i = 0; i < size; i++)
                     {
                         result->SetValue(i, DeserializeV8Object(subList, i));
                     }
+
+                    return result;
                 }
-                else if (type == VTYPE_DICTIONARY)
+
+                if (type == VTYPE_DICTIONARY)
                 {
                     auto subDict = list->GetDictionary(index);
                     auto size = subDict->GetSize();
                     std::vector<CefString> keys;
                     subDict->GetKeys(keys);
-                    result = CefV8Value::CreateObject(nullptr);
+                    auto result = CefV8Value::CreateObject(nullptr);
                     for (auto i = 0; i < size; i++)
                     {
                         result->SetValue(keys[i], DeserializeV8Object(subDict, keys[i]), V8_PROPERTY_ATTRIBUTE_NONE);
                     }
+
+                    return result;
                 }
 
-                return result;
+                return CefV8Value::CreateNull();
             }
 
             template void SerializeV8Object(const CefRefPtr<CefV8Value> &value, const CefRefPtr<CefListValue>& list, const int& index, JavascriptCallbackRegistry^ callbackRegistry);

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -1074,7 +1074,7 @@ namespace CefSharp
                 argList->SetBool(2, result->Success);
                 if (result->Success)
                 {
-                    SerializeV8Object(result->Result, argList, 3);
+                    SerializeV8Object(argList, 3, result->Result);
                 }
                 else
                 {

--- a/CefSharp.Core/Internals/JavascriptCallbackProxy.cpp
+++ b/CefSharp.Core/Internals/JavascriptCallbackProxy.cpp
@@ -38,7 +38,7 @@ namespace CefSharp
             for (int i = 0; i < parameters->Length; i++)
             {
                 auto param = parameters[i];
-                SerializeV8Object(param, paramList, i);
+                SerializeV8Object(paramList, i, param);
             }
             argList->SetList(3, paramList);
 

--- a/CefSharp.Core/Internals/Serialization/JsObjectsSerialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/JsObjectsSerialization.cpp
@@ -54,7 +54,7 @@ namespace CefSharp
 
                     if (jsProperty->PropertyValue != nullptr)
                     {
-                        SerializeV8Object(jsProperty->PropertyValue, propertyList, j++);
+                        SerializeV8Object(propertyList, j++, jsProperty->PropertyValue);
                     }
                     else
                     {

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -126,6 +126,7 @@ namespace CefSharp
                         auto fieldVal = fields[i]->GetValue(obj);
                         SerializeV8SimpleObject(fieldVal, subDict, strFieldName, seen);
                     }
+                    list->SetDictionary(index, subDict);
                 } 
                 else
                 {

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -118,10 +118,9 @@ namespace CefSharp
 
                     for (int i = 0; i < fields->Length; i++)
                     {
-                        auto fieldName = fields[i]->Name;
-                        auto strFieldName = StringUtils::ToNative(safe_cast<String^>(fieldName));
-                        auto fieldVal = fields[i]->GetValue(obj);
-                        SerializeV8SimpleObject(subDict, strFieldName, fieldVal, seen);
+                        auto fieldName = StringUtils::ToNative(fields[i]->Name);
+                        auto fieldValue = fields[i]->GetValue(obj);
+                        SerializeV8SimpleObject(subDict, fieldName, fieldValue, seen);
                     }
                     list->SetDictionary(index, subDict);
                 } 

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -18,14 +18,14 @@ namespace CefSharp
         namespace Serialization
         {
             template<typename TList, typename TIndex>
-            void SerializeV8Object(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index)
+            void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj)
             {
                 auto seen = gcnew Stack<Object^>();
-                SerializeV8SimpleObject(obj, list, index, seen);
+                SerializeV8SimpleObject(list, index, obj, seen);
             }
 
             template<typename TList, typename TIndex>
-            void SerializeV8SimpleObject(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index, Stack<Object^>^ seen)
+            void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, Stack<Object^>^ seen)
             {
                 list->SetNull(index);
 
@@ -107,7 +107,7 @@ namespace CefSharp
                     {
                         Object^ arrObj;
                         arrObj = managedArray->GetValue(i);
-                        SerializeV8SimpleObject(arrObj, subList, i, seen);
+                        SerializeV8SimpleObject(subList, i, arrObj, seen);
                     }
                     list->SetList(index, subList);
                 }
@@ -121,7 +121,7 @@ namespace CefSharp
                         auto fieldName = fields[i]->Name;
                         auto strFieldName = StringUtils::ToNative(safe_cast<String^>(fieldName));
                         auto fieldVal = fields[i]->GetValue(obj);
-                        SerializeV8SimpleObject(fieldVal, subDict, strFieldName, seen);
+                        SerializeV8SimpleObject(subDict, strFieldName, fieldVal, seen);
                     }
                     list->SetDictionary(index, subDict);
                 } 
@@ -140,8 +140,8 @@ namespace CefSharp
                 return CefTime(timeSpan.TotalSeconds);
             }
 
-            template void SerializeV8Object(Object^ obj, const CefRefPtr<CefListValue>& list, const int& index);
-            template void SerializeV8Object(Object^ obj, const CefRefPtr<CefDictionaryValue>& list, const CefString& index);
+            template void SerializeV8Object(const CefRefPtr<CefListValue>& list, const int& index, Object^ obj);
+            template void SerializeV8Object(const CefRefPtr<CefDictionaryValue>& list, const CefString& index, Object^ obj);
         }
     }
 }

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -18,17 +18,14 @@ namespace CefSharp
         namespace Serialization
         {
             template<typename TList, typename TIndex>
-            void SerializeV8SimpleObject(Object^ obj, CefRefPtr<TList> list, TIndex index, Stack<Object^>^ seen);
-
-            template<typename TList, typename TIndex>
-            void SerializeV8Object(Object^ obj, CefRefPtr<TList> list, TIndex index)
+            void SerializeV8Object(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index)
             {
                 auto seen = gcnew Stack<Object^>();
                 SerializeV8SimpleObject(obj, list, index, seen);
             }
 
             template<typename TList, typename TIndex>
-            void SerializeV8SimpleObject(Object^ obj, CefRefPtr<TList> list, TIndex index, Stack<Object^>^ seen)
+            void SerializeV8SimpleObject(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index, Stack<Object^>^ seen)
             {
                 list->SetNull(index);
 
@@ -143,8 +140,8 @@ namespace CefSharp
                 return CefTime(timeSpan.TotalSeconds);
             }
 
-            template void SerializeV8Object(Object^ obj, CefRefPtr<CefListValue> list, int index);
-            template void SerializeV8Object(Object^ obj, CefRefPtr<CefDictionaryValue> list, CefString index);
+            template void SerializeV8Object(Object^ obj, const CefRefPtr<CefListValue>& list, const int& index);
+            template void SerializeV8Object(Object^ obj, const CefRefPtr<CefDictionaryValue>& list, const CefString& index);
         }
     }
 }

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.h
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.h
@@ -14,7 +14,10 @@ namespace CefSharp
 
             //Serializes data into a given position in a CefListValue or CefDictionaryValue
             template<typename TList, typename TIndex>
-            void SerializeV8Object(Object^ obj, CefRefPtr<TList> list, TIndex index);
+            void SerializeV8Object(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index);
+
+            template<typename TList, typename TIndex>
+            void SerializeV8SimpleObject(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index, Stack<Object^>^ seen);
         }
     }
 }

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.h
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.h
@@ -14,10 +14,10 @@ namespace CefSharp
 
             //Serializes data into a given position in a CefListValue or CefDictionaryValue
             template<typename TList, typename TIndex>
-            void SerializeV8Object(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index);
+            void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index,Object^ obj);
 
             template<typename TList, typename TIndex>
-            void SerializeV8SimpleObject(Object^ obj, const CefRefPtr<TList>& list, const TIndex& index, Stack<Object^>^ seen);
+            void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, Stack<Object^>^ seen);
         }
     }
 }

--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -56,7 +56,9 @@ namespace CefSharp.Example
 
                 using (javascriptCallback)
                 {
-                    await javascriptCallback.ExecuteAsync("This callback from C# was delayed " + taskDelay + "ms");
+                    //NOTE: Classes are not supported, simple structs are
+                    var response = new CallbackResponseStruct("This callback from C# was delayed " + taskDelay + "ms");
+                    await javascriptCallback.ExecuteAsync(response);
                 }
             });
         }

--- a/CefSharp.Example/CallbackResponseStruct.cs
+++ b/CefSharp.Example/CallbackResponseStruct.cs
@@ -1,0 +1,17 @@
+﻿using System;
+// Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.Example
+{
+    public struct CallbackResponseStruct
+    {
+        public string Response;
+
+        public CallbackResponseStruct(string response)
+        {
+            Response = response;
+        }
+    }
+}

--- a/CefSharp.Example/CefSharp.Example.csproj
+++ b/CefSharp.Example/CefSharp.Example.csproj
@@ -92,6 +92,7 @@
   <ItemGroup>
     <Compile Include="AsyncBoundObject.cs" />
     <Compile Include="BoundObject.cs" />
+    <Compile Include="CallbackResponseStruct.cs" />
     <Compile Include="DragHandler.cs" />
     <Compile Include="ExceptionTestBoundObject.cs" />
     <Compile Include="JsDialogHandler.cs" />

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -96,7 +96,7 @@
                 function callback(s)
                 {
                     var result = document.getElementById('cbresult');
-                    result.innerText += "Callback: " + s + "" + Date();
+                    result.innerText += "Callback: " + s.Response + "" + Date();
                 }
 
                 function testCallback()


### PR DESCRIPTION
Resolves #1407
More the DeserializeV8Object call to within the `context->Enter` so a V8Object can be created
Change callback to use a struct as it's return type to demo the solution to this bug
Add missing list->SetDictionary call in V8Serialization.cpp