### PR TITLE
Adjustments to make it possible to build CefSharp v37 using VS2013:

### DIFF
--- a/CefSharp/Properties/AssemblyInfo.cs
+++ b/CefSharp/Properties/AssemblyInfo.cs
@@ -33,8 +33,8 @@ namespace CefSharp
         public const bool ComVisible = false;
         public const string AssemblyCompany = "The CefSharp Authors";
         public const string AssemblyProduct = "CefSharp";
-        public const string AssemblyVersion = "37.0.1";
-        public const string AssemblyFileVersion = "37.0.1.0";
+        public const string AssemblyVersion = "37.0.3";
+        public const string AssemblyFileVersion = "37.0.2.0";
         public const string AssemblyCopyright = "Copyright © The CefSharp Authors 2010-2015";
         public const string CefSharpCoreProject = "CefSharp.Core, PublicKey=" + PublicKey;
         public const string CefSharpBrowserSubprocessProject = "CefSharp.BrowserSubprocess, PublicKey=" + PublicKey;


### PR DESCRIPTION
This fixes #849, by providing a "reasonably official" CefSharp build that works correctly on Windows Server 2003 R2. Windows XP is untested, please report if it works or not.

Note: This changes the prerequisite from Visual C++ 2012 Redistributable to Visual C++ **2013** redistributable.

I have built versin 37.0.3 using this PR, and pushed it to NuGet (apart from the OffScreen package where I did not have publish rights, @amaitland :smirk:).

Merging.