### PR TITLE
Adjusted details about CefSharp v37 (requiring VC++ 2013 redist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,7 @@ Every commit on `master` produces a `Nuget` package. Use at your own risk! [CefS
 | [cefsharp/43](https://github.com/cefsharp/CefSharp/tree/cefsharp/43) | 2357 | 2012 | 4.0 | **Release** |
 | [cefsharp/41](https://github.com/cefsharp/CefSharp/tree/cefsharp/41) | 2272 | 2012 | 4.0 | Unsupported |
 | [cefsharp/39](https://github.com/cefsharp/CefSharp/tree/cefsharp/39) | 2171 | 2012 | 4.0 | Unsupported |
-| [cefsharp/37](https://github.com/cefsharp/CefSharp/tree/cefsharp/37) | 2062 | 2012 | 4.0 | Unsupported |
-
-#### CefSharp1
-
-**Ultra stable/LTS** Read "He's dead Jim", based on Chromium 25. See the [CefSharp1](https://github.com/cefsharp/CefSharp/tree/CefSharp1#binary-release) branch README for CefSharp1 info. Please note that this version is no longer developed or supported.
+| [cefsharp/37](https://github.com/cefsharp/CefSharp/tree/cefsharp/37) | 2062 | 2013 | 4.0 | Unsupported |
 
 ## Links
 


### PR DESCRIPTION
Also removed link to CefSharp v1. It's so outdated these days that there's no reason even linking to it. It was an important part of getting the project started, but... let's kill it now.