### PR TITLE
WPF: Change ChromiumWebBrowser's to be Control instead of UserControl

### DIFF
--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:cefSharp="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf" xmlns:local="clr-namespace:CefSharp.Wpf.Example.ViewModels"
+             xmlns:cefSharp="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+             xmlns:local="clr-namespace:CefSharp.Wpf.Example.ViewModels"
              mc:Ignorable="d"
              d:DesignWidth="640"
              d:DesignHeight="480"
@@ -50,6 +51,7 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -73,6 +75,21 @@
                                 Maximum="1"
                                 TickFrequency="0.01"
                                 Value="0.95" />
+                        <Label Grid.Row="2" 
+                               Grid.Column="0"
+                               Content="Bitmap scaling mode" />
+                        <ComboBox Grid.Row="2" 
+                                  Grid.Column="1"
+                                  Name="scalingModeCB"
+                                  SelectedIndex="0">
+                            <ComboBox.ItemsSource>
+                                <x:Array Type="BitmapScalingMode">
+                                    <BitmapScalingMode>NearestNeighbor</BitmapScalingMode>
+                                    <BitmapScalingMode>LowQuality</BitmapScalingMode>
+                                    <BitmapScalingMode>HighQuality</BitmapScalingMode>
+                                </x:Array>
+                            </ComboBox.ItemsSource>
+                        </ComboBox>
                     </Grid>
                 </GroupBox>
                 <GroupBox Header="Execute Javascript (asynchronously)">
@@ -170,6 +187,7 @@
 
                 <cefSharp:ChromiumWebBrowser x:Name="browser"
                                   Opacity="{Binding ElementName=opacitySlider, Path=Value}"
+                                  RenderOptions.BitmapScalingMode="{Binding ElementName=scalingModeCB, Path=SelectedItem}"
                                   Address="{Binding Address, Mode=TwoWay}"
                                   Title="{Binding Title, Mode=OneWayToSource}"
                                   AllowDrop="True"

--- a/CefSharp.Wpf/CefSharp.Wpf.csproj
+++ b/CefSharp.Wpf/CefSharp.Wpf.csproj
@@ -98,7 +98,12 @@
       <Name>CefSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Page Include="Themes\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -20,7 +21,7 @@ using System.Windows.Threading;
 
 namespace CefSharp.Wpf
 {
-    public class ChromiumWebBrowser : ContentControl, IRenderWebBrowser, IWpfWebBrowser
+    public class ChromiumWebBrowser : Control, IRenderWebBrowser, IWpfWebBrowser
     {
         private readonly List<IDisposable> disposables = new List<IDisposable>();
 
@@ -87,6 +88,10 @@ namespace CefSharp.Wpf
 
         static ChromiumWebBrowser()
         {
+            DefaultStyleKeyProperty.OverrideMetadata(
+                typeof(ChromiumWebBrowser),
+                new FrameworkPropertyMetadata(typeof(ChromiumWebBrowser)));
+
             if (CefSharpSettings.ShutdownOnExit)
             {
                 var app = Application.Current;
@@ -917,31 +922,30 @@ namespace CefSharp.Wpf
             base.OnApplyTemplate();
 
             // Create main window
-            Content = image = CreateImage();
-
+            image = (Image)GetTemplateChild("PART_image");
             popup = CreatePopup();
-        }
-
-        private Image CreateImage()
-        {
-            var img = new Image();
-
-            var bitmapScalingMode = RenderOptions.GetBitmapScalingMode(this);
-            //Default to using BitmapScalingMode.NearestNeighbor
-            RenderOptions.SetBitmapScalingMode(img, (bitmapScalingMode == BitmapScalingMode.Unspecified ? BitmapScalingMode.NearestNeighbor : bitmapScalingMode));
-
-            img.Stretch = Stretch.None;
-            img.HorizontalAlignment = HorizontalAlignment.Left;
-            img.VerticalAlignment = VerticalAlignment.Top;
-
-            return img;
         }
 
         private Popup CreatePopup()
         {
+            popupImage = new Image
+            {
+                Stretch = Stretch.None,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+            var binding = new Binding
+            {
+                Path = new PropertyPath(RenderOptions.BitmapScalingModeProperty),
+                Source = this,
+            };
+            BindingOperations.SetBinding(
+                popupImage,
+                RenderOptions.BitmapScalingModeProperty,
+                binding);
             var newPopup = new Popup
             {
-                Child = popupImage = CreateImage(),
+                Child = popupImage,
                 PlacementTarget = this,
                 Placement = PlacementMode.Absolute,
             };

--- a/CefSharp.Wpf/Themes/Generic.xaml
+++ b/CefSharp.Wpf/Themes/Generic.xaml
@@ -1,0 +1,24 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:CefSharp.Wpf">
+
+    <Style TargetType="{x:Type local:ChromiumWebBrowser}">
+        <Setter Property="RenderOptions.BitmapScalingMode" Value="NearestNeighbor" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:ChromiumWebBrowser}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <Image Name="PART_image" 
+                               Stretch="None"
+                               HorizontalAlignment="Left"
+                               VerticalAlignment="Top"
+                               RenderOptions.BitmapScalingMode="{TemplateBinding Property=RenderOptions.BitmapScalingMode}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
I think `Control` is more proper than `ContentControl` for Wpf.ChromiumWebBrowser's base class,
because we can't change Content value!
Content value must be Image control.
I suggest using default style.
