### PR TITLE
Rename EnableFocusedNodeChanged to FocusedNodeChangedEnabled

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -111,7 +111,7 @@ namespace CefSharp
 
     void CefAppUnmanagedWrapper::OnFocusedNodeChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefDOMNode> node)
     {
-        if (!_enableFocusedNodeChanged)
+        if (!_focusedNodeChangedEnabled)
         {
             return;
         }

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -25,7 +25,7 @@ namespace CefSharp
         gcroot<ConcurrentDictionary<int, CefBrowserWrapper^>^> _browserWrappers;
         gcroot<List<CefExtension^>^> _extensions;
         gcroot<List<CefCustomScheme^>^> _schemes;
-        bool _enableFocusedNodeChanged;
+        bool _focusedNodeChangedEnabled;
 
         // The serialized registered object data waiting to be used (only contains methods and bound async).
         gcroot<JavascriptRootObject^> _javascriptAsyncRootObject;
@@ -43,7 +43,7 @@ namespace CefSharp
             _browserWrappers = gcnew ConcurrentDictionary<int, CefBrowserWrapper^>();
             _extensions = gcnew List<CefExtension^>();
             _schemes = schemes;
-            _enableFocusedNodeChanged = enableFocusedNodeChanged;
+            _focusedNodeChangedEnabled = enableFocusedNodeChanged;
         }
 
         ~CefAppUnmanagedWrapper()

--- a/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppWrapper.h
@@ -29,7 +29,7 @@ namespace CefSharp
             auto onBrowserCreated = gcnew Action<CefBrowserWrapper^>(this, &CefAppWrapper::OnBrowserCreated);
             auto onBrowserDestroyed = gcnew Action<CefBrowserWrapper^>(this, &CefAppWrapper::OnBrowserDestroyed);
             auto schemes = CefCustomScheme::ParseCommandLineArguments(args);
-            auto enableFocusedNodeChanged = CommandLineArgsParser::HasArgument(args, CefSharpArguments::EnableFocusedNodeChangedArgument);
+            auto enableFocusedNodeChanged = CommandLineArgsParser::HasArgument(args, CefSharpArguments::FocusedNodeChangedEnabledArgument);
 
             _cefApp = new CefAppUnmanagedWrapper(schemes, enableFocusedNodeChanged, onBrowserCreated, onBrowserDestroyed);
         };

--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -19,7 +19,7 @@ namespace CefSharp
     internal:
         ::CefSettings* _cefSettings;
         List<CefCustomScheme^>^ _cefCustomSchemes;
-        bool _enableFocusedNodeChanged;
+        bool _focusedNodeChangedEnabled;
 
     public:
         CefSettings() : _cefSettings(new ::CefSettings())
@@ -37,7 +37,7 @@ namespace CefSharp
             //Temp workaround for https://github.com/cefsharp/CefSharp/issues/1203
             _cefCommandLineArgs->Add("process-per-tab", "1");
 
-            _enableFocusedNodeChanged = false;
+            _focusedNodeChangedEnabled = false;
         }
 
         !CefSettings()
@@ -214,10 +214,10 @@ namespace CefSharp
         /// browser when a DOM node (or no node) gets focus. The default is
         /// false.
         /// </summary>
-        property bool EnableFocusedNodeChanged
+        property bool FocusedNodeChangedEnabled
         {
-            bool get() { return _enableFocusedNodeChanged; }
-            void set(bool value) { _enableFocusedNodeChanged = value; }
+            bool get() { return _focusedNodeChangedEnabled; }
+            void set(bool value) { _focusedNodeChangedEnabled = value; }
         }
 
         /// <summary>

--- a/CefSharp.Core/Internals/CefSharpApp.h
+++ b/CefSharp.Core/Internals/CefSharpApp.h
@@ -67,9 +67,9 @@ namespace CefSharp
                 commandLine->AppendArgument(StringUtils::ToNative(CefSharpArguments::CustomSchemeArgument + argument));
             }
 
-            if (_cefSettings->EnableFocusedNodeChanged)
+            if (_cefSettings->FocusedNodeChangedEnabled)
             {
-                commandLine->AppendArgument(StringUtils::ToNative(CefSharpArguments::EnableFocusedNodeChangedArgument));
+                commandLine->AppendArgument(StringUtils::ToNative(CefSharpArguments::FocusedNodeChangedEnabledArgument));
             }
         }
         

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -129,7 +129,7 @@ namespace CefSharp.Example
 
             settings.RegisterExtension(new CefExtension("cefsharp/example", Resources.extension));
 
-            settings.EnableFocusedNodeChanged = true;
+            settings.FocusedNodeChangedEnabled = true;
 
             Cef.OnContextInitialized = delegate
             {

--- a/CefSharp/Internals/CefSharpArguments.cs
+++ b/CefSharp/Internals/CefSharpArguments.cs
@@ -8,6 +8,6 @@ namespace CefSharp.Internals
     {
         public const string WcfEnabledArgument = "--wcf-enabled";
         public const string CustomSchemeArgument = "--custom-scheme";
-        public const string EnableFocusedNodeChangedArgument = "--enable-focused-node";
+        public const string FocusedNodeChangedEnabledArgument = "--focused-node-enabled";
     }
 }


### PR DESCRIPTION
Change from EnableFocusedNodeChanged to FocusedNodeChangedEnabled to match the existing WindowlessRenderingEnabled setting property.