### PR TITLE
Added support for drag & drop from input fields

### DIFF
--- a/CefSharp.Wpf/Internals/WpfExtensions.cs
+++ b/CefSharp.Wpf/Internals/WpfExtensions.cs
@@ -2,11 +2,12 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using CefSharp.Internals;
+using System;
 using System.IO;
 using System.Text;
 using System.Windows;
 using System.Windows.Input;
-using CefSharp.Internals;
 
 namespace CefSharp.Wpf.Internals
 {
@@ -115,7 +116,12 @@ namespace CefSharp.Wpf.Internals
             if (dragData.IsFragment)
             {
                 dragData.FragmentText = (string)e.Data.GetData(DataFormats.Text);
-                dragData.FragmentHtml = (string)e.Data.GetData(DataFormats.Html);
+
+                var htmlData = (string)e.Data.GetData(DataFormats.Html);
+                if (htmlData != String.Empty)
+                {
+                    dragData.FragmentHtml = htmlData;
+                }
             }
 
             return dragData;


### PR DESCRIPTION
There was a problem with the previous implementation. It worked correctly for many use cases:

- Dragging from a web app to a WPF control.
- Dragging from a WPF control to a web app.
- Dragging _html content_ from a web app to an input field

**But**: when dragging text from one input field to another, the text would vanish (!) when you drop it.

We debugged this here quite extensively. It turned out that if you have _set_ the `FragmentHtml` (even though you've set it to an empty string), it behaves like this. The solution is to avoid setting it if it is empty.

Merging so I can make a v47.0.1 with this included. @amaitland, do you want the PR towards the `master` branch also?