### PR TITLE
Make JS bindings work with subprocesses hosting multiple browser instances

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -60,41 +60,11 @@ namespace CefSharp
 
     void CefAppUnmanagedWrapper::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context)
     {
-        //Send a message to the browser processing signaling that OnContextCreated has been called
-        //only param is the FrameId. Currently an IPC message is only sent for the main frame - will see
-        //how viable this solution is and if it's worth expanding to sub/child frames.
-        if (frame->IsMain())
-        {
-            auto contextCreatedMessage = CefProcessMessage::Create(kOnContextCreatedRequest);
+        auto contextCreatedMessage = CefProcessMessage::Create(kOnContextCreatedRequest);
 
-            SetInt64(contextCreatedMessage->GetArgumentList(), 0, frame->GetIdentifier());
+        SetInt64(contextCreatedMessage->GetArgumentList(), 0, frame->GetIdentifier());
 
-            browser->SendProcessMessage(CefProcessId::PID_BROWSER, contextCreatedMessage);
-        }
-
-        auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier(), true);
-
-        auto rootObjectWrappers = browserWrapper->JavascriptRootObjectWrappers;
-        auto frameId = frame->GetIdentifier();
-
-        JavascriptRootObjectWrapper^ rootObject;
-        if (!rootObjectWrappers->TryGetValue(frameId, rootObject))
-        {
-            rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), browserWrapper->BrowserProcess);
-            rootObjectWrappers->TryAdd(frameId, rootObject);
-        }
-
-        if (rootObject->IsBound)
-        {
-            LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
-        }
-        else
-        {
-            if (!Object::ReferenceEquals(_javascriptRootObject, nullptr) || !Object::ReferenceEquals(_javascriptAsyncRootObject, nullptr))
-            {
-                rootObject->Bind(_javascriptRootObject, _javascriptAsyncRootObject, context->GetGlobal());
-            }
-        }
+        browser->SendProcessMessage(CefProcessId::PID_BROWSER, contextCreatedMessage);
     };
 
     void CefAppUnmanagedWrapper::OnContextReleased(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context)
@@ -179,7 +149,8 @@ namespace CefSharp
         {
             if (name == kJavascriptCallbackDestroyRequest ||
                 name == kJavascriptRootObjectRequest ||
-                name == kJavascriptAsyncMethodCallResponse)
+                name == kJavascriptAsyncMethodCallResponse ||
+                name == kStartJavascriptBindingRequest)
             {
                 //If we can't find the browser wrapper then we'll just
                 //ignore this as it's likely already been disposed of
@@ -215,7 +186,7 @@ namespace CefSharp
 
             return true;
         }
-    
+
         //these messages are roughly handled the same way
         if (name == kEvaluateJavascriptRequest || name == kJavascriptCallbackRequest)
         {
@@ -242,7 +213,7 @@ namespace CefSharp
 
                 JavascriptRootObjectWrapper^ rootObjectWrapper;
                 browserWrapper->JavascriptRootObjectWrappers->TryGetValue(frameId, rootObjectWrapper);
-                
+
                 //NOTE: In the rare case when when OnContextCreated hasn't been called we need to manually create the rootObjectWrapper
                 //It appears that OnContextCreated is only called for pages that have javascript on them, which makes sense
                 //as without javascript there is no need for a context.
@@ -261,14 +232,14 @@ namespace CefSharp
                 if (frame.get())
                 {
                     auto context = frame->GetV8Context();
-                    
+
                     if (context.get() && context->Enter())
                     {
                         try
                         {
                             CefRefPtr<CefV8Exception> exception;
                             success = context->Eval(script, result, exception);
-                            
+
                             //we need to do this here to be able to store the v8context
                             if (success)
                             {
@@ -317,14 +288,14 @@ namespace CefSharp
                     {
                         auto context = callbackWrapper->GetContext();
                         auto value = callbackWrapper->GetValue();
-                
+
                         if (context.get() && context->Enter())
                         {
                             try
                             {
                                 auto parameterList = argList->GetList(3);
                                 CefV8ValueList params;
-                                
+
                                 //Needs to be called within the context as for Dictionary (mapped to struct)
                                 //a V8Object will be created
                                 for (CefV8ValueList::size_type i = 0; i < parameterList->GetSize(); i++)
@@ -334,7 +305,7 @@ namespace CefSharp
 
                                 result = value->ExecuteFunction(nullptr, params);
                                 success = result.get() != nullptr;
-                        
+
                                 //we need to do this here to be able to store the v8context
                                 if (success)
                                 {
@@ -388,13 +359,16 @@ namespace CefSharp
         {
             _javascriptAsyncRootObject = DeserializeJsRootObject(argList, 0);
             _javascriptRootObject = DeserializeJsRootObject(argList, 1);
+
+            browser->SendProcessMessage(CefProcessId::PID_BROWSER, CefProcessMessage::Create(kJavascriptRootObjectResponse));
+
             handled = true;
         }
         else if (name == kJavascriptAsyncMethodCallResponse)
         {
             auto frameId = GetInt64(argList, 0);
             auto callbackId = GetInt64(argList, 1);
-            
+
             JavascriptRootObjectWrapper^ rootObjectWrapper;
             browserWrapper->JavascriptRootObjectWrappers->TryGetValue(frameId, rootObjectWrapper);
 
@@ -417,6 +391,16 @@ namespace CefSharp
                 }
             }
             handled = true;
+        }
+        else if (name == kStartJavascriptBindingRequest)
+        {
+            auto frameList = argList->GetList(0);
+
+            for (auto i = 0; i < frameList->GetSize(); i++)
+            {
+                auto frameId = GetInt64(frameList, i);
+                BindObjectForFrame(browser, browserWrapper, frameId);
+            }
         }
 
         return handled;
@@ -452,6 +436,46 @@ namespace CefSharp
         for each (CefCustomScheme^ scheme in _schemes->AsReadOnly())
         {
             registrar->AddCustomScheme(StringUtils::ToNative(scheme->SchemeName), scheme->IsStandard, scheme->IsLocal, scheme->IsDisplayIsolated);
+        }
+    }
+
+    void CefAppUnmanagedWrapper::BindObjectForFrame(const CefRefPtr<CefBrowser> &browser, CefBrowserWrapper^ wrapper, int64 frameId)
+    {
+        auto frame = browser->GetFrame(frameId);
+        auto rootObjectWrappers = wrapper->JavascriptRootObjectWrappers;
+
+        if (frame.get())
+        {
+            JavascriptRootObjectWrapper^ rootObject;
+            if (!rootObjectWrappers->TryGetValue(frameId, rootObject))
+            {
+                rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), wrapper->BrowserProcess);
+                rootObjectWrappers->TryAdd(frameId, rootObject);
+            }
+
+            if (rootObject->IsBound)
+            {
+                LOG(WARNING) << "A context has been created for the same browser / frame without context released called previously";
+            }
+            else
+            {
+                auto context = frame->GetV8Context();
+                try
+                {
+                    if (context.get() && context->IsValid() && context->Enter())
+                    {
+                        if (static_cast<JavascriptRootObject^>(_javascriptRootObject) != nullptr || 
+                            static_cast<JavascriptRootObject^>(_javascriptAsyncRootObject) != nullptr)
+                        {
+                            rootObject->Bind(_javascriptRootObject, _javascriptAsyncRootObject, context->GetGlobal());
+                        }
+                    }
+                }
+                finally
+                {
+                    context->Exit();
+                }
+            }
         }
     }
 }

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -26,6 +26,7 @@ namespace CefSharp
         gcroot<List<CefExtension^>^> _extensions;
         gcroot<List<CefCustomScheme^>^> _schemes;
         bool _focusedNodeChangedEnabled;
+        bool _separatedPopupBoundObjectsEnable;
 
         // The serialized registered object data waiting to be used (only contains methods and bound async).
         gcroot<JavascriptRootObject^> _javascriptAsyncRootObject;
@@ -33,11 +34,18 @@ namespace CefSharp
         // The serialized registered object data waiting to be used.
         gcroot<JavascriptRootObject^> _javascriptRootObject;
 
+        // The serialized registered object data waiting to be used (only contains methods and bound async) when
+        // separate bound objects are enabled.
+        gcroot<ConcurrentDictionary<int, JavascriptRootObject^>^> _javascriptAsyncRootObjects;
+
+        // The serialized registered object data waiting to be used when separate bound objects are enabled.
+        gcroot<ConcurrentDictionary<int, JavascriptRootObject^>^> _javascriptRootObjects;
+
         void BindObjectForFrame(const CefRefPtr<CefBrowser> &browser, CefSharp::CefBrowserWrapper^ wrapper, int64 frameId);
     public:
         static const CefString kPromiseCreatorFunction;
 
-        CefAppUnmanagedWrapper(List<CefCustomScheme^>^ schemes, bool enableFocusedNodeChanged, Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestoryed)
+        CefAppUnmanagedWrapper(List<CefCustomScheme^>^ schemes, bool enableFocusedNodeChanged, bool enableSeparatedPopupBoundObjects, Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestoryed)
         {
             _onBrowserCreated = onBrowserCreated;
             _onBrowserDestroyed = onBrowserDestoryed;
@@ -45,6 +53,9 @@ namespace CefSharp
             _extensions = gcnew List<CefExtension^>();
             _schemes = schemes;
             _focusedNodeChangedEnabled = enableFocusedNodeChanged;
+            _separatedPopupBoundObjectsEnable = enableSeparatedPopupBoundObjects;
+            _javascriptRootObjects = gcnew ConcurrentDictionary<int, JavascriptRootObject^>();
+            _javascriptAsyncRootObjects = gcnew ConcurrentDictionary<int, JavascriptRootObject^>();
         }
 
         ~CefAppUnmanagedWrapper()

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -33,6 +33,7 @@ namespace CefSharp
         // The serialized registered object data waiting to be used.
         gcroot<JavascriptRootObject^> _javascriptRootObject;
 
+        void BindObjectForFrame(const CefRefPtr<CefBrowser> &browser, CefSharp::CefBrowserWrapper^ wrapper, int64 frameId);
     public:
         static const CefString kPromiseCreatorFunction;
 

--- a/CefSharp.BrowserSubprocess.Core/SubProcess.h
+++ b/CefSharp.BrowserSubprocess.Core/SubProcess.h
@@ -32,8 +32,9 @@ namespace CefSharp
                 auto onBrowserDestroyed = gcnew Action<CefBrowserWrapper^>(this, &SubProcess::OnBrowserDestroyed);
                 auto schemes = CefCustomScheme::ParseCommandLineArguments(args);
                 auto enableFocusedNodeChanged = CommandLineArgsParser::HasArgument(args, CefSharpArguments::FocusedNodeChangedEnabledArgument);
+                auto enableSeparatedBoundObjects = CommandLineArgsParser::HasArgument(args, CefSharpArguments::SeparateBoundObjectsArgument);
 
-                _cefApp = new CefAppUnmanagedWrapper(schemes, enableFocusedNodeChanged, onBrowserCreated, onBrowserDestroyed);
+                _cefApp = new CefAppUnmanagedWrapper(schemes, enableFocusedNodeChanged, enableSeparatedBoundObjects, onBrowserCreated, onBrowserDestroyed);
             }
 
             !SubProcess()

--- a/CefSharp.Core/CefSettings.h
+++ b/CefSharp.Core/CefSettings.h
@@ -41,9 +41,6 @@ namespace CefSharp
             //Automatically discovered and load a system-wide installation of Pepper Flash.
             _cefCommandLineArgs->Add("enable-system-flash", "1");
 
-            //Temp workaround for https://github.com/cefsharp/CefSharp/issues/1203
-            _cefCommandLineArgs->Add("process-per-tab", "1");
-
             _focusedNodeChangedEnabled = false;
         }
 

--- a/CefSharp.Core/Internals/CefSharpApp.h
+++ b/CefSharp.Core/Internals/CefSharpApp.h
@@ -60,6 +60,11 @@ namespace CefSharp
                 commandLine->AppendArgument(StringUtils::ToNative(CefSharpArguments::WcfEnabledArgument));
             }
 
+            if (CefSharpSettings::SeparateBoundObjects)
+            {
+                commandLine->AppendArgument(StringUtils::ToNative(CefSharpArguments::SeparateBoundObjectsArgument));
+            }
+
             if (_cefSettings->_cefCustomSchemes->Count > 0)
             {
                 String^ argument = "=";

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -37,6 +37,7 @@ namespace CefSharp
             HWND _browserHwnd;
             CefRefPtr<CefBrowser> _cefBrowser;
 
+            gcroot<BoundObjectTransmitHelper^> _boundObjectTransmitHelper;
             gcroot<IBrowser^> _browser;
             gcroot<Dictionary<int, IBrowser^>^> _popupBrowsers;
             gcroot<String^> _tooltip;
@@ -52,11 +53,13 @@ namespace CefSharp
 
             IBrowser^ GetBrowserWrapper(int browserId, bool isPopup);
 
+            void SendJavascriptBindMessage(const CefRefPtr<CefBrowser> &browser, const std::vector<int64> &frameIdentifiers);
         public:
             ClientAdapter(IWebBrowserInternal^ browserControl, IBrowserAdapter^ browserAdapter) :
                 _browserControl(browserControl), 
                 _popupBrowsers(gcnew Dictionary<int, IBrowser^>()),
                 _pendingTaskRepository(gcnew PendingTaskRepository<JavascriptResponse^>()),
+                _boundObjectTransmitHelper(gcnew BoundObjectTransmitHelper()),
                 _browserAdapter(browserAdapter),
                 _browserHwnd(NULL)
             {

--- a/CefSharp.Core/Internals/Messaging/Messages.h
+++ b/CefSharp.Core/Internals/Messaging/Messages.h
@@ -26,12 +26,16 @@ namespace CefSharp
             const CefString kJavascriptCallbackResponse = "JavascriptCallbackDoneResponse";
             //Message containing a js root object for js bindings
             const CefString kJavascriptRootObjectRequest = "JavascriptRootObjectRequest";
+            //Message to ack js root object for js bindings
+            const CefString kJavascriptRootObjectResponse = "JavascriptRootObjectResponse";
             //Message from the render process to request a method invocation on a bound object
             const CefString kJavascriptAsyncMethodCallRequest = "JavascriptAsyncMethodCallRequest";
             //Message from the browser process containing the result of a bound method invocation
             const CefString kJavascriptAsyncMethodCallResponse = "JavascriptAsyncMethodCallResponse";
             //Message that signals a new V8Context has been created
             const CefString kOnContextCreatedRequest = "OnContextCreated";
+            //Message that initiates javacript bindings in the subprocess
+            const CefString kStartJavascriptBindingRequest = "StartJavascriptBindingRequest";
             // Message from the render process that an element (or nothing) has
             // gotten focus. This message is only sent if specified as an
             // optional message via command line argument when the subprocess is

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -24,6 +24,7 @@ namespace CefSharp.Example
         public const string BasicSchemeTestUrl = "custom://cefsharp/SchemeTest.html";
         public const string ResponseFilterTestUrl = "custom://cefsharp/ResponseFilterTest.html";
         public const string DraggableRegionTestUrl = "custom://cefsharp/DraggableRegionTest.html";
+        public const string MultitenantTestUrl = "custom://cefsharp/MultitenantTest.html";
         public const string TestResourceUrl = "http://test/resource/load";
         public const string RenderProcessCrashedUrl = "http://processcrashed";
         public const string TestUnicodeResourceUrl = "http://test/resource/loadUnicode";

--- a/CefSharp.Example/CefSharp.Example.csproj
+++ b/CefSharp.Example/CefSharp.Example.csproj
@@ -102,6 +102,7 @@
     </Compile>
     <Compile Include="CefSharpSchemeHandler.cs" />
     <Compile Include="CefSharpSchemeHandlerFactory.cs" />
+    <Compile Include="UniqueBoundObject.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">
@@ -128,6 +129,7 @@
     <Content Include="Resources\MultiBindingTest.html" />
     <Content Include="Resources\home.html" />
     <Content Include="Resources\FramedWebGLTest.html" />
+    <Content Include="Resources\MultitenantTest.html" />
     <Content Include="Resources\PopupTest.html" />
     <Content Include="Resources\DraggableRegionTest.html" />
     <Content Include="Resources\ResponseFilterTest.html" />

--- a/CefSharp.Example/CefSharpSchemeHandler.cs
+++ b/CefSharp.Example/CefSharpSchemeHandler.cs
@@ -40,6 +40,7 @@ namespace CefSharp.Example
                 { "/bootstrap/bootstrap.min.js", Resources.bootstrap_min_js },
 
                 { "/BindingTest.html", Resources.BindingTest },
+                { "/MultitenantTest.html", Resources.MultitenantTest },
                 { "/ExceptionTest.html", Resources.ExceptionTest },
                 { "/PopupTest.html", Resources.PopupTest },
                 { "/SchemeTest.html", Resources.SchemeTest },

--- a/CefSharp.Example/Properties/Resources.Designer.cs
+++ b/CefSharp.Example/Properties/Resources.Designer.cs
@@ -467,6 +467,31 @@ namespace CefSharp.Example.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;!DOCTYPE html&gt;
+        ///&lt;html lang=&quot;en&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot;&gt;
+        ///&lt;head&gt;
+        ///    &lt;meta charset=&quot;utf-8&quot; /&gt;
+        ///    &lt;title&gt;Multitenant Test&lt;/title&gt;
+        ///    &lt;script&gt;
+        ///        function onLoad()
+        ///        {
+        ///            var p = document.getElementById(&apos;p&apos;);
+        ///            var btn = document.getElementById(&apos;btn&apos;);
+        ///            if (window.opener)
+        ///            {
+        ///                btn.parentElement.removeChild(btn);
+        ///            }
+        ///            uniqueObject.id().then(function(res) {
+        ///                p.innerText = res;
+        ///     [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MultitenantTest {
+            get {
+                return ResourceManager.GetString("MultitenantTest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0 Transitional//EN&quot;&gt;
         ///&lt;html&gt;
         ///    &lt;head&gt;

--- a/CefSharp.Example/Properties/Resources.resx
+++ b/CefSharp.Example/Properties/Resources.resx
@@ -187,4 +187,7 @@
   <data name="DraggableRegionTest" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DraggableRegionTest.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="MultitenantTest" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\multitenanttest.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/CefSharp.Example/Resources/MultitenantTest.html
+++ b/CefSharp.Example/Resources/MultitenantTest.html
@@ -1,0 +1,77 @@
+﻿<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Multitenant Test</title>
+    <script>
+        var windows = [];
+
+        window.onmessage = function(e)
+        {
+            var data;
+            try
+            {
+                data = JSON.parse(e.data);
+            } catch (e)
+            {
+                // fail silent...?
+                return;
+            }
+            switch (data.event)
+            {
+                case "QueryOpenWindows":
+                    if (windows.indexOf(e.source) === -1)
+                    {
+                        windows.push(e.source);
+                    }
+                    break;
+            }
+        }
+
+        setInterval(function () {
+            try {
+                if (window.opener) {
+                    window.opener.postMessage(JSON.stringify({ "event": "QueryOpenWindows"}), "*");
+                }
+            }
+            catch (e) {
+            }
+        }, 100);
+
+        function onLoad()
+        {
+            var p = document.getElementById('p');
+            var btn = document.getElementById('btn');
+            if (window.opener) {
+                btn.parentElement.removeChild(btn);
+            }
+
+            setTimeout(function () {
+                for (var i = 0; i < windows.length; i++)
+                {
+                    windows[i].location.reload();
+                }
+                try {
+                    uniqueObject.id().then(function (res) {
+                        p.innerText = res;
+                    }, function (error) {
+                        p.innerText = error;
+                    });
+                } catch (err) {
+                    p.innerText = err;
+                }
+            }, 500);
+        }
+
+        function openWindow()
+        {
+            window.open(window.location, '', 'width=300,height=300');
+            window.location.reload();
+        }
+    </script>
+</head>
+<body onload="onLoad()">
+    <button id="btn" onclick="openWindow()">New Window</button>
+    <p id="p"></p>
+</body>
+</html>

--- a/CefSharp.Example/UniqueBoundObject.cs
+++ b/CefSharp.Example/UniqueBoundObject.cs
@@ -1,0 +1,24 @@
+﻿// Copyright © 2010-2016 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Threading;
+
+namespace CefSharp.Example
+{
+    public class UniqueBoundObject
+    {
+        private static int lastId = 0;
+        private int id;
+
+        public UniqueBoundObject()
+        {
+            id = Interlocked.Increment(ref lastId);
+        }
+
+        public int Id()
+        {
+            return id;
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/App.xaml.cs
+++ b/CefSharp.Wpf.Example/App.xaml.cs
@@ -19,7 +19,7 @@ namespace CefSharp.Wpf.Example
                                 "please make sure you compile in `Release` mode.", "Warning");
             }
 #endif
-
+            CefSharpSettings.SeparateBoundObjects = true;
             CefExample.Init(true, multiThreadedMessageLoop: true, browserProcessHandler: new BrowserProcessHandler());
 
             base.OnStartup(e);

--- a/CefSharp.Wpf.Example/Handlers/LifespanHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/LifespanHandler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Windows;
 using System.Windows.Interop;
+using CefSharp.Example;
 
 namespace CefSharp.Wpf.Example.Handlers
 {
@@ -14,79 +15,80 @@ namespace CefSharp.Wpf.Example.Handlers
         {
             newBrowser = null;
 
-            return false;
+//            return false;
 
             //NOTE: This is experimental
-            //var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
+            var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
 
-            //ChromiumWebBrowser chromiumBrowser = null;
+            ChromiumWebBrowser chromiumBrowser = null;
 
-            //var windowX = (windowInfo.X == int.MinValue) ? double.NaN : windowInfo.X;
-            //var windowY = (windowInfo.Y == int.MinValue) ? double.NaN : windowInfo.Y;
-            //var windowWidth = (windowInfo.Width == int.MinValue) ? double.NaN : windowInfo.Width;
-            //var windowHeight = (windowInfo.Height == int.MinValue) ? double.NaN : windowInfo.Height;
+            var windowX = (windowInfo.X == int.MinValue) ? double.NaN : windowInfo.X;
+            var windowY = (windowInfo.Y == int.MinValue) ? double.NaN : windowInfo.Y;
+            var windowWidth = (windowInfo.Width == int.MinValue) ? double.NaN : windowInfo.Width;
+            var windowHeight = (windowInfo.Height == int.MinValue) ? double.NaN : windowInfo.Height;
 
-            //chromiumWebBrowser.Dispatcher.Invoke(() =>
-            //{
-            //	var owner = Window.GetWindow(chromiumWebBrowser);
-            //	chromiumBrowser = new ChromiumWebBrowser
-            //	{
-            //		Address = targetUrl,
-            //	};
+            chromiumWebBrowser.Dispatcher.Invoke(() =>
+            {
+                var owner = Window.GetWindow(chromiumWebBrowser);
+                chromiumBrowser = new ChromiumWebBrowser
+                {
+                    Address = targetUrl,
+                };
+                chromiumBrowser.RegisterAsyncJsObject("uniqueObject", new UniqueBoundObject());
 
-            //	chromiumBrowser.SetAsPopup();
-            //	chromiumBrowser.LifeSpanHandler = this;
+                chromiumBrowser.SetAsPopup();
+                chromiumBrowser.LifeSpanHandler = this;
 
-            //	var popup = new Window
-            //	{
-            //		Left = windowX,
-            //		Top = windowY,
-            //		Width = windowWidth,
-            //		Height = windowHeight,
-            //		Content = chromiumBrowser,
-            //		Owner = owner,
-            //		Title = targetFrameName
-            //	};
+                var popup = new Window
+                {
+                    Left = windowX,
+                    Top = windowY,
+                    Width = windowWidth,
+                    Height = windowHeight,
+                    Content = chromiumBrowser,
+                    Owner = owner,
+                    Title = targetFrameName
+                };
 
-            //	var windowInteropHelper = new WindowInteropHelper(popup);
-            //	//Create the handle Window handle (In WPF there's only one handle per window, not per control)
-            //	var handle = windowInteropHelper.EnsureHandle();
+                var windowInteropHelper = new WindowInteropHelper(popup);
+                //Create the handle Window handle (In WPF there's only one handle per window, not per control)
+                var handle = windowInteropHelper.EnsureHandle();
 
-            //	//The parentHandle value will be used to identify monitor info and to act as the parent window for dialogs,
-            //	//context menus, etc. If parentHandle is not provided then the main screen monitor will be used and some
-            //	//functionality that requires a parent window may not function correctly.
-            //	windowInfo.SetAsWindowless(handle, true);
+                //The parentHandle value will be used to identify monitor info and to act as the parent window for dialogs,
+                //context menus, etc. If parentHandle is not provided then the main screen monitor will be used and some
+                //functionality that requires a parent window may not function correctly.
+                windowInfo.SetAsWindowless(handle, true);
 
-            //	popup.Closed += (o, e) => 
-            //	{
-            //		var w = o as Window;
-            //		if (w != null && w.Content is IWebBrowser)
-            //		{
-            //			(w.Content as IWebBrowser).Dispose();
-            //			w.Content = null;
-            //		}
-            //	};
-            //});
+                popup.Closed += (o, e) =>
+                {
+                    var w = o as Window;
+                    if (w != null && w.Content is IWebBrowser)
+                    {
+                        (w.Content as IWebBrowser).Dispose();
+                        w.Content = null;
+                    }
+                };
+            });
 
-            //newBrowser = chromiumBrowser;
+            newBrowser = chromiumBrowser;
 
-            //return false;
+            return false;
         }
 
         void ILifeSpanHandler.OnAfterCreated(IWebBrowser browserControl, IBrowser browser)
         {
             //NOTE: This is experimental
-            //var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
+            var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
 
-            //chromiumWebBrowser.Dispatcher.Invoke(() =>
-            //{
-            //	var owner = Window.GetWindow(chromiumWebBrowser);
+            chromiumWebBrowser.Dispatcher.Invoke(() =>
+            {
+                var owner = Window.GetWindow(chromiumWebBrowser);
 
-            //	if (owner != null && owner.Content == browserControl)
-            //	{
-            //		owner.Show();
-            //	}
-            //});
+                if (owner != null && owner.Content == browserControl)
+                {
+                    owner.Show();
+                }
+            });
         }
 
         bool ILifeSpanHandler.DoClose(IWebBrowser browserControl, IBrowser browser)
@@ -97,17 +99,17 @@ namespace CefSharp.Wpf.Example.Handlers
         void ILifeSpanHandler.OnBeforeClose(IWebBrowser browserControl, IBrowser browser)
         {
             //NOTE: This is experimental
-            //var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
+            var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
 
-            //chromiumWebBrowser.Dispatcher.Invoke(() =>
-            //{
-            //	var owner = Window.GetWindow(chromiumWebBrowser);
+            chromiumWebBrowser.Dispatcher.Invoke(() =>
+            {
+                var owner = Window.GetWindow(chromiumWebBrowser);
 
-            //	if (owner != null && owner.Content == browserControl)
-            //	{
-            //		owner.Close();
-            //	}
-            //});
+                if (owner != null && owner.Content == browserControl)
+                {
+                    owner.Close();
+                }
+            });
         }
     }
 }

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -21,6 +21,7 @@
             </MenuItem>
             <MenuItem Header="_Tests">
                 <MenuItem Header="_Binding Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.BindingTestUrl}}"/>
+                <MenuItem Header="M_ultitenant Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.MultitenantTestUrl}}"/>
                 <MenuItem Header="_List Plugins" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.PluginsTestUrl}}"/>
                 <MenuItem Header="_Tooltip Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.TooltipTestUrl}}"/>
                 <MenuItem Header="_Popup Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.PopupParentUrl}}"/>

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -26,6 +26,7 @@ namespace CefSharp.Wpf.Example.Views
             browser.RequestHandler = new RequestHandler();
             browser.RegisterJsObject("bound", new BoundObject(), BindingOptions.DefaultBinder);
             browser.RegisterAsyncJsObject("boundAsync", new AsyncBoundObject());
+            browser.RegisterAsyncJsObject("uniqueObject", new UniqueBoundObject());
             // Enable touch scrolling - once properly tested this will likely become the default
             //browser.IsManipulationEnabled = true;
 

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -92,6 +92,7 @@
     <Compile Include="IDomNode.cs" />
     <Compile Include="IFindHandler.cs" />
     <Compile Include="INavigationEntryVisitor.cs" />
+    <Compile Include="Internals\BoundObjectTransmitHelper.cs" />
     <Compile Include="Internals\CefTimeUtils.cs" />
     <Compile Include="Internals\CommandLineArgsParser.cs" />
     <Compile Include="Internals\MethodParameter.cs" />

--- a/CefSharp/CefSharpSettings.cs
+++ b/CefSharp/CefSharpSettings.cs
@@ -41,5 +41,13 @@ namespace CefSharp
         /// the event handlers are hooked in the static constructor for the ChromiumWebBrowser class
         /// </summary>
         public static bool ShutdownOnExit { get; set; }
+
+        /// <summary>
+        /// By default when multiple browser instances are hosted in the same subprocess, there can 
+        /// be only one set of bound objects. Enabling this will allow registering separate objects for them
+        /// for example when doing window.open and custom popup management with <see cref="ILifeSpanHandler"/>
+        /// or limiting subprocess count.
+        /// </summary>
+        public static bool SeparateBoundObjects { get; set; }
     }
 }

--- a/CefSharp/Internals/BoundObjectTransmitHelper.cs
+++ b/CefSharp/Internals/BoundObjectTransmitHelper.cs
@@ -1,0 +1,129 @@
+﻿// Copyright © 2010-2016 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.Internals
+{
+    public sealed class BoundObjectTransmitHelper
+    {
+        //dummy IRequestCallback implementation that stores callback values
+        private class DummyCallback : IRequestCallback
+        {
+            private bool isDisposed;
+
+            public bool Allowed { get; private set; }
+
+            public bool Cancelled { get; private set; }
+
+            public void Dispose()
+            {
+                isDisposed = true;
+            }
+
+            public void Continue(bool allow)
+            {
+                Allowed = allow;
+            }
+
+            public void Cancel()
+            {
+                Cancelled = true;
+            }
+
+            public bool IsDisposed
+            {
+                get { return isDisposed; }
+            }
+        }
+
+        private DummyCallback passableCallback;
+        private CefReturnValue returnValue;
+        private IRequestCallback originalCallback;
+
+        //bound objects has arrived to the subprocess
+        public bool Completed { get; private set; }
+
+        public IRequestCallback PassableCallback
+        {
+            get
+            {
+                if (passableCallback == null)
+                {
+                    passableCallback = new DummyCallback();
+                }
+                return passableCallback;
+            }
+        }
+
+        //mark it complete without further action (for example when no bound objects)
+        public void CompleteSync()
+        {
+            Completed = true;
+        }
+
+        //complete after ack received from subprocess for bound object message
+        public void CompleteAsync()
+        {
+            if (Completed)
+                return;
+
+            switch (returnValue)
+            {
+                case CefReturnValue.Cancel:
+                    originalCallback.Cancel();
+                    break;
+                case CefReturnValue.ContinueAsync:
+                    ContinueAsyncBasedOnPassableCallback();
+                    break;
+                case CefReturnValue.Continue:
+                    originalCallback.Continue(true);
+                    break;
+            }
+
+            ResetCallbacks();
+            Completed = true;
+        }
+
+        public void Reset()
+        {
+            ResetCallbacks();
+            Completed = false;
+        }
+
+        public CefReturnValue DoYield(IRequestCallback originalCallback, CefReturnValue returnValue)
+        {
+            this.originalCallback = originalCallback;
+            this.returnValue = returnValue;
+            return CefReturnValue.ContinueAsync;
+        }
+
+        private void ResetCallbacks()
+        {
+            if (originalCallback != null)
+            {
+                originalCallback.Dispose();
+            }
+            originalCallback = null;
+            passableCallback = null;
+        }
+
+        private void ContinueAsyncBasedOnPassableCallback()
+        {
+            if (passableCallback != null)
+            {
+                if (passableCallback.Cancelled)
+                {
+                    originalCallback.Cancel();
+                }
+                else
+                {
+                    originalCallback.Continue(passableCallback.Allowed);
+                }
+            }
+            else
+            {
+                originalCallback.Continue(true);
+            }
+        }
+    }
+}

--- a/CefSharp/Internals/CefSharpArguments.cs
+++ b/CefSharp/Internals/CefSharpArguments.cs
@@ -9,5 +9,6 @@ namespace CefSharp.Internals
         public const string WcfEnabledArgument = "--wcf-enabled";
         public const string CustomSchemeArgument = "--custom-scheme";
         public const string FocusedNodeChangedEnabledArgument = "--focused-node-enabled";
+        public const string SeparateBoundObjectsArgument = "--separate-bound-objects";
     }
 }


### PR DESCRIPTION
When the popup functionality is used, more than one browser instance can be hosted in the same subprocess. As the bound JS objects are not stored on a per-browser basis they won't work properly in this scenario. I modified the storage and binding mechanism a bit to solve this.
