### PR TITLE
Rewrite IResourceHandler - Expose all methods

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -689,17 +689,13 @@ namespace CefSharp
             }
 
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup(), false);
-            auto frameWrapper = gcnew CefFrameWrapper(frame);
-            auto requestWrapper = gcnew CefRequestWrapper(request);
+            CefFrameWrapper frameWrapper(frame);
+            CefRequestWrapper requestWrapper(request);
 
-            auto handler = factory->GetResourceHandler(_browserControl, browserWrapper, frameWrapper, requestWrapper);
+            auto handler = factory->GetResourceHandler(_browserControl, browserWrapper, %frameWrapper, %requestWrapper);
 
             if (handler == nullptr)
             {
-                // Clean up our disposables if our factory doesn't want
-                // this request.
-                delete frameWrapper;
-                delete requestWrapper;
                 return NULL;
             }
 
@@ -712,10 +708,7 @@ namespace CefSharp
                 }
             }
 
-            // No need to pass browserWrapper for disposable lifetime management here
-            // because GetBrowserWrapper returned IBrowser^s are already properly
-            // managed.
-            return new ResourceHandlerWrapper(handler, nullptr, frameWrapper, requestWrapper);
+            return new ResourceHandlerWrapper(handler);
         }
 
         cef_return_value_t ClientAdapter::OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefRefPtr<CefRequestCallback> callback)

--- a/CefSharp.Core/ResourceHandlerWrapper.h
+++ b/CefSharp.Core/ResourceHandlerWrapper.h
@@ -15,13 +15,9 @@ namespace CefSharp
     public class ResourceHandlerWrapper : public CefResourceHandler
     {
     private:
-        gcroot<IRequest^> _request;
         gcroot<IResourceHandler^> _handler;
-        gcroot<Stream^> _stream;
-        gcroot<IBrowser^> _browser;
-        gcroot<IFrame^> _frame;
 
-        int64 SizeFromStream();
+        Cookie^ GetCookie(const CefCookie& cookie);
 
     public:
 
@@ -30,18 +26,14 @@ namespace CefSharp
         /// lifetime management container  (i.e. calling .Dispose at the correct time) on 
         /// managed objects that contain MCefRefPtrs.
         /// </summary>
-        ResourceHandlerWrapper(IResourceHandler^ handler, IBrowser ^browser, IFrame^ frame, IRequest^ request)
-            : _handler(handler), _browser(browser), _frame(frame), _request(request)
+        ResourceHandlerWrapper(IResourceHandler^ handler)
+            : _handler(handler)
         {
         }
 
         ~ResourceHandlerWrapper()
         {
             _handler = nullptr;
-            _stream = nullptr;
-            delete _request;
-            delete _browser;
-            delete _frame;
         }
 
         virtual bool ProcessRequest(CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback) OVERRIDE;

--- a/CefSharp.Core/SchemeHandlerFactoryWrapper.h
+++ b/CefSharp.Core/SchemeHandlerFactoryWrapper.h
@@ -33,21 +33,11 @@ namespace CefSharp
 
         virtual CefRefPtr<CefResourceHandler> Create(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& schemeName, CefRefPtr<CefRequest> request) OVERRIDE
         {
-            auto browserWrapper = gcnew CefSharpBrowserWrapper(browser);
-            auto frameWrapper = gcnew CefFrameWrapper(frame);
-            auto requestWrapper = gcnew CefRequestWrapper(request);
+            CefSharpBrowserWrapper browserWrapper(browser);
+            CefFrameWrapper frameWrapper(frame);
+            CefRequestWrapper requestWrapper(request);
 
-            auto handler = _factory->Create(browserWrapper, frameWrapper, StringUtils::ToClr(schemeName), requestWrapper);
-
-            if (handler == nullptr)
-            {
-                // Clean up our disposables if our factory doesn't want
-                // this request.
-                delete browserWrapper;
-                delete frameWrapper;
-                delete requestWrapper;
-                return NULL;
-            }
+            auto handler = _factory->Create(%browserWrapper, %frameWrapper, StringUtils::ToClr(schemeName), %requestWrapper);
 
             if (handler->GetType() == ResourceHandler::typeid)
             {
@@ -58,7 +48,7 @@ namespace CefSharp
                 }
             }
 
-            return new ResourceHandlerWrapper(handler, browserWrapper, frameWrapper, requestWrapper);
+            return new ResourceHandlerWrapper(handler);
         }
 
         IMPLEMENT_REFCOUNTING(SchemeHandlerFactoryWrapper);

--- a/CefSharp.Example/CefSharpSchemeHandler.cs
+++ b/CefSharp.Example/CefSharpSchemeHandler.cs
@@ -51,13 +51,13 @@ namespace CefSharp.Example
             };
         }
 
-        public bool ProcessRequestAsync(IRequest request, ICallback callback)
+        bool IResourceHandler.ProcessRequest(IRequest request, ICallback callback)
         {
             // The 'host' portion is entirely ignored by this scheme handler.
             var uri = new Uri(request.Url);
             var fileName = uri.AbsolutePath;
 
-            if(string.Equals(fileName, "/PostDataTest.html", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(fileName, "/PostDataTest.html", StringComparison.OrdinalIgnoreCase))
             {
                 var postDataElement = request.PostData.Elements.FirstOrDefault();
                 var resourceHandler = ResourceHandler.FromString("Post Data: " + (postDataElement == null ? "null" : postDataElement.GetBody()));
@@ -70,7 +70,7 @@ namespace CefSharp.Example
             if (string.Equals(fileName, "/PostDataAjaxTest.html", StringComparison.OrdinalIgnoreCase))
             {
                 var postData = request.PostData;
-                if(postData == null)
+                if (postData == null)
                 {
                     var resourceHandler = ResourceHandler.FromString("Post Data: null");
                     stream = (MemoryStream)resourceHandler.Stream;
@@ -78,7 +78,7 @@ namespace CefSharp.Example
                     callback.Continue();
                 }
                 else
-                { 
+                {
                     var postDataElement = postData.Elements.FirstOrDefault();
                     var resourceHandler = ResourceHandler.FromString("Post Data: " + (postDataElement == null ? "null" : postDataElement.GetBody()));
                     stream = (MemoryStream)resourceHandler.Stream;
@@ -104,7 +104,7 @@ namespace CefSharp.Example
                 Task.Run(() =>
                 {
                     using (callback)
-                    { 
+                    {
                         var bytes = Encoding.UTF8.GetBytes(resource);
                         stream = new MemoryStream(bytes);
 
@@ -124,8 +124,9 @@ namespace CefSharp.Example
 
             return false;
         }
+        
 
-        public Stream GetResponse(IResponse response, out long responseLength, out string redirectUrl)
+        void IResourceHandler.GetResponseHeaders(IResponse response, out long responseLength, out string redirectUrl)
         {
             responseLength = stream == null ? 0 : stream.Length;
             redirectUrl = null;
@@ -133,8 +134,41 @@ namespace CefSharp.Example
             response.StatusCode = (int)HttpStatusCode.OK;
             response.StatusText = "OK";
             response.MimeType = mimeType;
+        }
 
-            return stream;
+        bool IResourceHandler.ReadResponse(Stream dataOut, out int bytesRead, ICallback callback)
+        {
+            //Dispose the callback as it's an unmanaged resource, we don't need it in this case
+            callback.Dispose();
+
+            if(stream == null)
+            {
+                bytesRead = 0;
+                return false;
+            }
+
+            //Data out represents an underlying buffer (typically 32kb in size).
+            var buffer = new byte[dataOut.Length];
+            bytesRead = stream.Read(buffer, 0, buffer.Length);
+            
+            dataOut.Write(buffer, 0, buffer.Length);
+
+            return bytesRead > 0;
+        }
+
+        bool IResourceHandler.CanGetCookie(Cookie cookie)
+        {
+            return true;
+        }
+
+        bool IResourceHandler.CanSetCookie(Cookie cookie)
+        {
+            return true;
+        }
+
+        void IResourceHandler.Cancel()
+        {
+            
         }
     }
 }

--- a/CefSharp.Example/FlashResourceHandler.cs
+++ b/CefSharp.Example/FlashResourceHandler.cs
@@ -8,12 +8,12 @@ using System.Threading.Tasks;
 
 namespace CefSharp.Example
 {
-    public class FlashResourceHandler : IResourceHandler
+    public class FlashResourceHandler : ResourceHandler
     {
         private MemoryStream stream;
         private string mime;
 
-        bool IResourceHandler.ProcessRequestAsync(IRequest request, ICallback callback)
+        public override bool ProcessRequestAsync(IRequest request, ICallback callback)
         {
             Task.Run(() =>
             {
@@ -38,7 +38,7 @@ namespace CefSharp.Example
             return true;
         }
 
-        Stream IResourceHandler.GetResponse(IResponse response, out long responseLength, out string redirectUrl)
+        public override Stream GetResponse(IResponse response, out long responseLength, out string redirectUrl)
         {
             responseLength = stream.Length;
             redirectUrl = null;

--- a/CefSharp/IResourceHandler.cs
+++ b/CefSharp/IResourceHandler.cs
@@ -17,22 +17,63 @@ namespace CefSharp
     public interface IResourceHandler
     {
         /// <summary>
-        /// Processes request asynchronously.
+        /// Begin processing the request.  
         /// </summary>
         /// <param name="request">The request object.</param>
         /// <param name="callback">The callback used to Continue or Cancel the request (async).</param>
-        /// <returns>true if the request is handled, false otherwise.</returns>
-        bool ProcessRequestAsync(IRequest request, ICallback callback);
+        /// <returns>To handle the request return true and call
+        /// ICallback.Continue() once the response header information is available
+        /// (ICallback.Continue() can also be called from inside this method if
+        /// header information is available immediately).
+        /// To cancel the request return false.</returns>
+        bool ProcessRequest(IRequest request, ICallback callback);
 
         /// <summary>
-        /// Populate the response stream, response length. When this method is called
-        /// the response should be fully populated with data
-        /// It is possible to redirect to another url at this point in time
+        /// Retrieve response header information. If the response length is not known
+        /// set responseLength to -1 and ReadResponse() will be called until it
+        /// returns false. If the response length is known set responseLength
+        /// to a positive value and ReadResponse() will be called until it returns
+        /// false or the specified number of bytes have been read.  
         /// </summary>
-        /// <param name="response">The response object used to set Headers, StatusCode, etc</param>
-        /// <param name="responseLength">length of the response</param>
-        /// <param name="redirectUrl">If set the request will be redirect to specified Url</param>
-        /// <returns>The response stream</returns>
-        Stream GetResponse(IResponse response, out long responseLength, out string redirectUrl);
+        /// <param name="response">Use the response object to set the mime type, http status code and other optional header values.</param>
+        /// <param name="responseLength">If the response length is not known set responseLength to -1</param>
+        /// <param name="redirectUrl">To redirect the request to a new URL set redirectUrl to the new Url.</param>
+        void GetResponseHeaders(IResponse response, out long responseLength, out string redirectUrl);
+
+        /// <summary>
+        /// Read response data. If data is available immediately copy to
+        /// dataOut, set bytesRead to the number of bytes copied, and return true.
+        /// To read the data at a later time set bytesRead to 0, return true and call ICallback.Continue() when the
+        /// data is available. To indicate response completion return false.
+        /// </summary>
+        /// <param name="dataOut">Stream to write to</param>
+        /// <param name="bytesRead">Number of bytes copied to the stream</param>
+        /// <param name="callback">The callback used to Continue or Cancel the request (async).</param>
+        /// <returns>If data is available immediately copy to dataOut, set bytesRead to the number of bytes copied,
+        /// and return true.To indicate response completion return false.</returns>
+        bool ReadResponse(Stream dataOut, out int bytesRead, ICallback callback);
+
+        /// <summary>
+        /// Return true if the specified cookie can be sent with the request or false
+        /// otherwise. If false is returned for any cookie then no cookies will be sent
+        /// with the request.
+        /// </summary>
+        /// <param name="cookie">cookie</param>
+        /// <returns>Return true if the specified cookie can be sent with the request or false
+        /// otherwise. If false is returned for any cookie then no cookies will be sent
+        /// with the request.</returns>
+        bool CanGetCookie(Cookie cookie);
+
+        /// <summary>
+        /// Return true if the specified cookie returned with the response can be set or false otherwise.
+        /// </summary>
+        /// <param name="cookie">cookie</param>
+        /// <returns>Return true if the specified cookie returned with the response can be set or false otherwise.</returns>
+        bool CanSetCookie(Cookie cookie);
+
+        /// <summary>
+        /// Request processing has been canceled.
+        /// </summary>
+        void Cancel();
     }
 }


### PR DESCRIPTION
Expose all methods of CefResourceHandler - Resolves #1592
Previously we were passing in the frame, request wrappers which hadn't been used, so just keep things simple and remove the code.
Current users should extend ResourceHandler instead of IResourceHandler and add the override keyword