### PR TITLE
Publish Symbol Packages

### DIFF
--- a/CefSharp.WinForms/CefSharp.WinForms.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.csproj
@@ -21,6 +21,9 @@
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>bin\x64\Release\</OutputPath>
     <DocumentationFile>bin\x64\Release\CefSharp.WinForms.XML</DocumentationFile>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -38,6 +41,10 @@
     <OutputPath>bin\x86\Release\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <DocumentationFile>bin\x86\Release\CefSharp.WinForms.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CefSharp.Wpf/CefSharp.Wpf.csproj
+++ b/CefSharp.Wpf/CefSharp.Wpf.csproj
@@ -58,6 +58,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\x86\Release\CefSharp.Wpf.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/NuGet/CefSharp.Common.nuspec
+++ b/NuGet/CefSharp.Common.nuspec
@@ -22,24 +22,34 @@
 
     <!-- Common CefSharp stuff (shared between both WPF and WinForms) -->
     <file src="..\Win32\Release\CefSharp.Core.dll" target="CefSharp\x86"/>
-    <file src="..\x64\Release\CefSharp.Core.dll" target="CefSharp\x64"/>
-    <file src="..\CefSharp\bin\x86\Release\CefSharp.dll" target="CefSharp\x86"/>
-    <file src="..\CefSharp\bin\x64\Release\CefSharp.dll" target="CefSharp\x64"/>
-    <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x86"/>
-    <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.exe" target="CefSharp\x86"/>
-    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x64"/>
-    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.exe" target="CefSharp\x64"/>
-
     <file src="..\Win32\Release\CefSharp.Core.xml" target="CefSharp\x86"/>
+    <file src="..\x64\Release\CefSharp.Core.dll" target="CefSharp\x64"/>
     <file src="..\x64\Release\CefSharp.Core.xml" target="CefSharp\x64"/>
-    <file src="..\x64\Release\CefSharp.Core.xml" target="lib"/>
-    <file src="..\CefSharp\bin\x64\Release\CefSharp.xml" target="CefSharp\x64"/>
+  
+    <file src="..\CefSharp\bin\x86\Release\CefSharp.dll" target="CefSharp\x86"/>
     <file src="..\CefSharp\bin\x64\Release\CefSharp.xml" target="CefSharp\x86"/>
-    <!-- Long shot, to see if it's here NuDoq.org looks for it, trial and error at it's best -->
-    <file src="..\CefSharp\bin\x64\Release\CefSharp.xml" target="lib" />
+    <file src="..\CefSharp\bin\x64\Release\CefSharp.dll" target="CefSharp\x64"/>
+    <file src="..\CefSharp\bin\x64\Release\CefSharp.xml" target="CefSharp\x64"/>
+  
+    <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x86"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.Core.pdb" target="CefSharp\x86"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.exe" target="CefSharp\x86"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.pdb" target="CefSharp\x86"/>
+  
+    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x64"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.Core.pdb" target="CefSharp\x64"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.exe" target="CefSharp\x64"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.pdb" target="CefSharp\x64"/>
 
     <file src="CefSharp.Common.props" target="build" />
     <file src="CefSharp.Common.targets" target="build" />
+  
+    <file src="..\CefSharp\**\*.cs" target="src\CefSharp" />
+    <file src="..\CefSharp.Core\**\*.h" target="src\CefSharp.Core" />
+    <file src="..\CefSharp.Core\**\*.cpp" target="src\CefSharp.Core" />
+    <file src="..\CefSharp.BrowserSubprocess.Core\**\*.h" target="src\CefSharp.BrowserSubprocess.Core" exclude="packages\**;obj\**" />
+    <file src="..\CefSharp.BrowserSubprocess.Core\**\*.cpp" target="src\CefSharp.BrowserSubprocess.Core" exclude="packages\**;obj\**" />
+    <file src="..\CefSharp.BrowserSubprocess\**\*.cs" target="src\CefSharp.BrowserSubprocess" exclude="packages\**;obj\**" />
   </files>
 </package>
 

--- a/NuGet/CefSharp.OffScreen.nuspec
+++ b/NuGet/CefSharp.OffScreen.nuspec
@@ -19,15 +19,17 @@
     <!-- Cannot put these inside lib\net40 etc, since there are both x86 and x64 versions which we must distinguish between. We
          solve this using a .props file instead. -->
     <file src="..\CefSharp.OffScreen\bin\x86\Release\CefSharp.OffScreen.dll" target="CefSharp\x86" />
-    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.dll" target="CefSharp\x64" />
-
-    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.xml" target="CefSharp\x64" />
     <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.xml" target="CefSharp\x86" />
-    <!-- Long shot, to see if it's here NuDoq.org looks for it, trial and error at it's best -->
-    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.xml" target="lib" />
+    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.pdb" target="CefSharp\x86" />
+
+    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.dll" target="CefSharp\x64" />
+    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.xml" target="CefSharp\x64" />
+    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.pdb" target="CefSharp\x64" />    
 
     <file src="CefSharp.OffScreen.props" target="build" />
 
     <file src="Readme.txt" target="" />
+
+    <file src="..\CefSharp.OffScreen\**\*.cs" target="src\CefSharp.OffScreen" />
   </files>
 </package>

--- a/NuGet/CefSharp.WinForms.nuspec
+++ b/NuGet/CefSharp.WinForms.nuspec
@@ -19,15 +19,17 @@
     <!-- Cannot put these inside lib\net40 etc, since there are both x86 and x64 versions which we must distinguish between. We
          solve this using a .props file instead. -->
     <file src="..\CefSharp.WinForms\bin\x86\Release\CefSharp.WinForms.dll" target="CefSharp\x86" />
-    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.dll" target="CefSharp\x64" />
-
     <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.xml" target="CefSharp\x86" />
+    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.pdb" target="CefSharp\x86" />
+
+    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.dll" target="CefSharp\x64" />
     <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.xml" target="CefSharp\x64" />
-    <!-- Long shot, to see if it's here NuDoq.org looks for it, trial and error at it's best -->
-    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.xml" target="lib" />
+    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.pdb" target="CefSharp\x64" />
 
     <file src="CefSharp.WinForms.props" target="build" />
 
     <file src="Readme.txt" target="" />
+
+    <file src="..\CefSharp.WinForms\**\*.cs" target="src\CefSharp.WinForms" />
   </files>
 </package>

--- a/NuGet/CefSharp.Wpf.nuspec
+++ b/NuGet/CefSharp.Wpf.nuspec
@@ -19,15 +19,17 @@
     <!-- Cannot put these inside lib\net40 etc, since there are both x86 and x64 versions which we must distinguish between. We
          solve this using a .props file instead. -->
     <file src="..\CefSharp.Wpf\bin\x86\Release\CefSharp.Wpf.dll" target="CefSharp\x86" />
-    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.dll" target="CefSharp\x64" />
+    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.xml" target="CefSharp\x86" />
+    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.pdb" target="CefSharp\x86" />
 
     <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.xml" target="CefSharp\x64" />
-    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.xml" target="CefSharp\x86" />
-    <!-- Long shot, to see if it's here NuDoq.org looks for it, trial and error at it's best -->
-    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.xml" target="lib" />
+    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.dll" target="CefSharp\x64" />
+    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.pdb" target="CefSharp\x64" />
 
     <file src="CefSharp.Wpf.props" target="build" />
 
     <file src="Readme.txt" target="" />
+
+    <file src="..\CefSharp.Wpf\**\*.cs" target="src\CefSharp.Wpf" />
   </files>
 </package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,5 +22,6 @@ deploy:
   server: https://www.myget.org/F/cefsharp/
   api_key:
     secure: T3yoLSioRwXa7byUvu17t4I88RTQTvICh2j+KplLb1YVimd1IYy2m2akGqgOMJhY
-  skip_symbols: true
+  skip_symbols: false
+  symbol_server: https://www.myget.org/F/cefsharp
   artifact: nupkgfiles

--- a/build.ps1
+++ b/build.ps1
@@ -253,10 +253,10 @@ function Nupkg
     Write-Diagnostic "Building nuget package"
 
     # Build packages
-    . $nuget pack nuget\CefSharp.Common.nuspec -NoPackageAnalysis -Version $Version -OutputDirectory nuget -Properties "RedistVersion=$RedistVersion"
-    . $nuget pack nuget\CefSharp.Wpf.nuspec -NoPackageAnalysis -Version $Version -OutputDirectory nuget
-    . $nuget pack nuget\CefSharp.OffScreen.nuspec -NoPackageAnalysis -Version $Version -OutputDirectory nuget
-    . $nuget pack nuget\CefSharp.WinForms.nuspec -NoPackageAnalysis -Version $Version -OutputDirectory nuget
+    . $nuget pack nuget\CefSharp.Common.nuspec -NoPackageAnalysis -Symbol -Version $Version -OutputDirectory nuget -Properties "RedistVersion=$RedistVersion"
+    . $nuget pack nuget\CefSharp.Wpf.nuspec -NoPackageAnalysis -Symbol -Version $Version -OutputDirectory nuget
+    . $nuget pack nuget\CefSharp.OffScreen.nuspec -NoPackageAnalysis -Symbol -Version $Version -OutputDirectory nuget
+    . $nuget pack nuget\CefSharp.WinForms.nuspec -NoPackageAnalysis -Symbol -Version $Version -OutputDirectory nuget
 
     # Invoke `AfterBuild` script if available (ie. upload packages to myget)
     if(-not (Test-Path $WorkingDir\AfterBuild.ps1)) {


### PR DESCRIPTION
Add pdb files to nuspec - they're only included when the -symbol flag is used
Add src files to nuspec - they're only included when the -symbol flag is used
Update appveyor.yml to push symbol packages to the MyGet feed
Add -symbol flag to build.ps1 so the symbol packages are generated
WinForms project not outputs pdb files
WinForms release builds are not optimized - probably should have been already

Unfortunately this will need to be merged into `master` to test fully. The packages build locally, so hopefully they'll appears on the `MyGet` feed shrotly.