### PR TITLE
Added try-catches to CookieVisitor.cpp to avoid crashes on invalid va…

### DIFF
--- a/CefSharp.Core/Internals/CookieVisitor.cpp
+++ b/CefSharp.Core/Internals/CookieVisitor.cpp
@@ -21,39 +21,54 @@ namespace CefSharp
             cookie->Secure = cefCookie.secure == 1;
             cookie->HttpOnly = cefCookie.httponly == 1;
 
-            if (cefCookie.has_expires)
-            {
-                cookie->Expires = DateTime(
-                    cefCookie.expires.year,
-                    cefCookie.expires.month,
-                    cefCookie.expires.day_of_month,
-                    cefCookie.expires.hour,
-                    cefCookie.expires.minute,
-                    cefCookie.expires.second,
-                    cefCookie.expires.millisecond
-                );
-            }
+			try {
+				if (cefCookie.has_expires)
+				{
+					cookie->Expires = DateTime(
+						cefCookie.expires.year,
+						cefCookie.expires.month,
+						cefCookie.expires.day_of_month,
+						cefCookie.expires.hour,
+						cefCookie.expires.minute,
+						cefCookie.expires.second,
+						cefCookie.expires.millisecond
+						);
+				}
+			}
+			catch (Exception^ ex){
+				// ignore invalid date as we have no way to represent it
+			}
 
             //TODO: There is a method in TypeUtils that's in BrowserSubProcess that convers CefTime, need to make it accessible.
-            cookie->Creation = DateTime(
-                cefCookie.creation.year,
-                cefCookie.creation.month,
-                cefCookie.creation.day_of_month,
-                cefCookie.creation.hour,
-                cefCookie.creation.minute,
-                cefCookie.creation.second,
-                cefCookie.creation.millisecond
-                );
+			try {
+				cookie->Creation = DateTime(
+					cefCookie.creation.year,
+					cefCookie.creation.month,
+					cefCookie.creation.day_of_month,
+					cefCookie.creation.hour,
+					cefCookie.creation.minute,
+					cefCookie.creation.second,
+					cefCookie.creation.millisecond
+					);
+			}
+			catch (Exception^ ex){
+				// ignore invalid date as we have no way to represent it
+			}
 
-            cookie->LastAccess = DateTime(
-                cefCookie.last_access.year,
-                cefCookie.last_access.month,
-                cefCookie.last_access.day_of_month,
-                cefCookie.last_access.hour,
-                cefCookie.last_access.minute,
-                cefCookie.last_access.second,
-                cefCookie.last_access.millisecond
-                );
+			try {
+				cookie->LastAccess = DateTime(
+					cefCookie.last_access.year,
+					cefCookie.last_access.month,
+					cefCookie.last_access.day_of_month,
+					cefCookie.last_access.hour,
+					cefCookie.last_access.minute,
+					cefCookie.last_access.second,
+					cefCookie.last_access.millisecond
+					);
+			}
+			catch (Exception^ ex){
+				// ignore invalid date as we have no way to represent it
+			}
         }
 
         return _visitor->Visit(cookie, count, total, deleteCookie);

--- a/CefSharp.Core/Internals/CookieVisitor.cpp
+++ b/CefSharp.Core/Internals/CookieVisitor.cpp
@@ -21,54 +21,59 @@ namespace CefSharp
             cookie->Secure = cefCookie.secure == 1;
             cookie->HttpOnly = cefCookie.httponly == 1;
 
-			try {
-				if (cefCookie.has_expires)
-				{
-					cookie->Expires = DateTime(
-						cefCookie.expires.year,
-						cefCookie.expires.month,
-						cefCookie.expires.day_of_month,
-						cefCookie.expires.hour,
-						cefCookie.expires.minute,
-						cefCookie.expires.second,
-						cefCookie.expires.millisecond
-						);
-				}
-			}
-			catch (Exception^ ex){
-				// ignore invalid date as we have no way to represent it
-			}
+            try 
+            {
+                if (cefCookie.has_expires)
+                {
+                    cookie->Expires = DateTime(
+                        cefCookie.expires.year,
+                        cefCookie.expires.month,
+                        cefCookie.expires.day_of_month,
+                        cefCookie.expires.hour,
+                        cefCookie.expires.minute,
+                        cefCookie.expires.second,
+                        cefCookie.expires.millisecond
+                        );
+                }
+            }
+            catch (Exception^ ex)
+            {
+                cookie->Expires = DateTime::MinValue;
+            }
 
             //TODO: There is a method in TypeUtils that's in BrowserSubProcess that convers CefTime, need to make it accessible.
-			try {
-				cookie->Creation = DateTime(
-					cefCookie.creation.year,
-					cefCookie.creation.month,
-					cefCookie.creation.day_of_month,
-					cefCookie.creation.hour,
-					cefCookie.creation.minute,
-					cefCookie.creation.second,
-					cefCookie.creation.millisecond
-					);
-			}
-			catch (Exception^ ex){
-				// ignore invalid date as we have no way to represent it
-			}
+            try 
+            {
+                cookie->Creation = DateTime(
+                    cefCookie.creation.year,
+                    cefCookie.creation.month,
+                    cefCookie.creation.day_of_month,
+                    cefCookie.creation.hour,
+                    cefCookie.creation.minute,
+                    cefCookie.creation.second,
+                    cefCookie.creation.millisecond
+                    );
+            }
+            catch (Exception^ ex)
+            {
+                cookie->Creation = DateTime::MinValue;
+            }
 
-			try {
-				cookie->LastAccess = DateTime(
-					cefCookie.last_access.year,
-					cefCookie.last_access.month,
-					cefCookie.last_access.day_of_month,
-					cefCookie.last_access.hour,
-					cefCookie.last_access.minute,
-					cefCookie.last_access.second,
-					cefCookie.last_access.millisecond
-					);
-			}
-			catch (Exception^ ex){
-				// ignore invalid date as we have no way to represent it
-			}
+            try {
+                cookie->LastAccess = DateTime(
+                    cefCookie.last_access.year,
+                    cefCookie.last_access.month,
+                    cefCookie.last_access.day_of_month,
+                    cefCookie.last_access.hour,
+                    cefCookie.last_access.minute,
+                    cefCookie.last_access.second,
+                    cefCookie.last_access.millisecond
+                    );
+            }
+            catch (Exception^ ex)
+            {
+                cookie->LastAccess = DateTime::MinValue;
+            }
         }
 
         return _visitor->Visit(cookie, count, total, deleteCookie);


### PR DESCRIPTION
…lues for DateTime.

This is the simplest possible fix. It ignores cases where the user might want to know what the invalid dates were. If that is important, I would suggest creating a new class (CefDateTime?) that directly corresponds to the values in CefCookie, and then create DateTime on demand in Cookie.cs.