### PR TITLE
Add paramArray support to Javascript Binding

### DIFF
--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace CefSharp.Example
@@ -269,6 +270,26 @@ namespace CefSharp.Example
         public SubBoundObject GetSubObject()
         {
             return SubObject;
+        }
+
+        /// <summary>
+        /// Demonstrates the use of params as an argument in a bound object
+        /// </summary>
+        /// <param name="name">Dummy Argument</param>
+        /// <param name="args">Params Argument</param>
+        public string MethodWithParams(string name, params object[] args)
+        {
+            return String.Join(", ", args.ToArray());
+        }
+
+        public string MethodWithoutParams(string name, string arg2)
+        {
+            return String.Format("{0}, {1}", name, arg2);
+        }
+
+        public string methodWithoutAnything()
+        {
+            return "Method without anything called and returned successfully.";
         }
     }
 }

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -237,5 +237,34 @@
                 }
             </script>
         </ul>
+        <p>
+            Javascript function sending variable number of parameters to Bound Object. (ParamArray Test)
+            <script type="text/javascript">
+                function invokeParamArrayMethod(func) {
+                    var result = func();
+                    document.getElementById('paramArrayResults').innerHTML = result;
+                }
+            </script>
+        <ul>
+            <li style="list-style:none;display:inline-block;">
+                <button onclick="invokeParamArrayMethod(function(){return bound.methodWithParams('test', 'hello-world')})">With 1 Params</button>
+            </li>
+            <li style="list-style:none;display:inline-block;">
+                <button onclick="invokeParamArrayMethod(function(){return bound.methodWithParams('test', 'hello-world', 'chris was here')})">With 2 Params</button>
+            </li>
+            <li style="list-style:none;display:inline-block;">
+                <button onclick="invokeParamArrayMethod(function(){return bound.methodWithParams('test')})">With no Params</button>
+            </li>
+            <li style="list-style:none;display:inline-block;">
+                <button onclick="invokeParamArrayMethod(function(){return bound.methodWithoutParams('test', 'hello')})">Normal Method</button>
+            </li>
+            <li style="list-style:none;display:inline-block;">
+                <button onclick="invokeParamArrayMethod(function(){return bound.methodWithoutAnything()})">Normal Method No Params</button>
+            </li>           
+        </ul>
+            <span>ParamArray Results</span>
+            <br />
+            <span id="paramArrayResults"></span>
+        </p>
     </body>
 </html>

--- a/CefSharp.Example/Resources/Home.html
+++ b/CefSharp.Example/Resources/Home.html
@@ -351,14 +351,6 @@
                         objects.
                     </p>
                     <h3>Hooks by which you can modify and/or override certain features of the web browsing</h3>
-                    <p>
-                        A fix to allow params to be used by the .NET methods called by the javascript<br />
-                        <button onclick="boundEvent.methodWithParams('test', 'hello-world')">With 1 Params</button>
-                        <button onclick="boundEvent.methodWithParams('test', 'hello-world', 'chris was here')">With 2 Params</button>
-                        <button onclick="boundEvent.methodWithParams('test')">With no Params</button>
-                        <button onclick="boundEvent.methodWithoutParams('test', 'hello')">Normal Method</button>
-                        <button onclick="boundEvent.methodWithoutAnything()">Normal Method No Params</button>
-                    </p>
                 </div>
                 <div class="bs-docs-section">
                     <div class="page-header">

--- a/CefSharp.Example/Resources/Home.html
+++ b/CefSharp.Example/Resources/Home.html
@@ -351,6 +351,14 @@
                         objects.
                     </p>
                     <h3>Hooks by which you can modify and/or override certain features of the web browsing</h3>
+                    <p>
+                        A fix to allow params to be used by the .NET methods called by the javascript<br />
+                        <button onclick="boundEvent.methodWithParams('test', 'hello-world')">With 1 Params</button>
+                        <button onclick="boundEvent.methodWithParams('test', 'hello-world', 'chris was here')">With 2 Params</button>
+                        <button onclick="boundEvent.methodWithParams('test')">With no Params</button>
+                        <button onclick="boundEvent.methodWithoutParams('test', 'hello')">Normal Method</button>
+                        <button onclick="boundEvent.methodWithoutAnything()">Normal Method No Params</button>
+                    </p>
                 </div>
                 <div class="bs-docs-section">
                     <div class="page-header">

--- a/CefSharp.Example/ScriptedMethodsBoundObject.cs
+++ b/CefSharp.Example/ScriptedMethodsBoundObject.cs
@@ -36,26 +36,5 @@ namespace CefSharp.Example
                 EventArrived(eventName, eventData);
             }
         }
-
-        /// <summary>
-        /// Demonstrates the use of params as an argument in a bound object
-        /// </summary>
-        /// <param name="name">Dummy Argument</param>
-        /// <param name="args">Params Argument</param>
-        public void MethodWithParams(string name, params object[] args)
-        {
-            var test = args.ElementAtOrDefault(0);
-            var test2 = args.ElementAtOrDefault(1);
-        }
-
-        public void MethodWithoutParams(string name, string arg2)
-        {
-            var test = arg2;
-        }
-
-        public void methodWithoutAnything()
-        {
-            var test = "";
-        }
     }
 }

--- a/CefSharp.Example/ScriptedMethodsBoundObject.cs
+++ b/CefSharp.Example/ScriptedMethodsBoundObject.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 using System;
+using System.Linq;
 
 namespace CefSharp.Example
 {
@@ -34,6 +35,27 @@ namespace CefSharp.Example
             {
                 EventArrived(eventName, eventData);
             }
+        }
+
+        /// <summary>
+        /// Demonstrates the use of params as an argument in a bound object
+        /// </summary>
+        /// <param name="name">Dummy Argument</param>
+        /// <param name="args">Params Argument</param>
+        public void MethodWithParams(string name, params object[] args)
+        {
+            var test = args.ElementAtOrDefault(0);
+            var test2 = args.ElementAtOrDefault(1);
+        }
+
+        public void MethodWithoutParams(string name, string arg2)
+        {
+            var test = arg2;
+        }
+
+        public void methodWithoutAnything()
+        {
+            var test = "";
         }
     }
 }

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -89,6 +89,7 @@
     <Compile Include="IDomNode.cs" />
     <Compile Include="IFindHandler.cs" />
     <Compile Include="Internals\CommandLineArgsParser.cs" />
+    <Compile Include="Internals\MethodParameter.cs" />
     <Compile Include="IPluginHandler.cs" />
     <Compile Include="IPopupFeatures.cs" />
     <Compile Include="IRenderProcessMessageHandler.cs" />

--- a/CefSharp/Internals/JavascriptMethod.cs
+++ b/CefSharp/Internals/JavascriptMethod.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace CefSharp.Internals
@@ -32,6 +33,9 @@ namespace CefSharp.Internals
         /// </summary>
         [DataMember]
         public string JavascriptName { get; set; }
+
+        [DataMember]
+        public List<MethodParameter> MethodParameters { get; set; }
 
         /// <summary>
         /// Number of Params this function exepects

--- a/CefSharp/Internals/JavascriptMethod.cs
+++ b/CefSharp/Internals/JavascriptMethod.cs
@@ -34,7 +34,6 @@ namespace CefSharp.Internals
         [DataMember]
         public string JavascriptName { get; set; }
 
-        [DataMember]
         public List<MethodParameter> MethodParameters { get; set; }
 
         /// <summary>

--- a/CefSharp/Internals/MethodParameter.cs
+++ b/CefSharp/Internals/MethodParameter.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
+﻿// Copyright © 2010-2016 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+using System;
 
 namespace CefSharp.Internals
 {
-    [DataContract]
     public class MethodParameter
     {
-        public String Name { get; set; }
-
-        public Type ParameterType { get; set; }
-
         public Boolean IsParamArray { get; set; }
-
-        public Int32 Position { get; set; }
     }
 }

--- a/CefSharp/Internals/MethodParameter.cs
+++ b/CefSharp/Internals/MethodParameter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace CefSharp.Internals
+{
+    [DataContract]
+    public class MethodParameter
+    {
+        public String Name { get; set; }
+
+        public Type ParameterType { get; set; }
+
+        public Boolean IsParamArray { get; set; }
+
+        public Int32 Position { get; set; }
+    }
+}

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,5 +5,6 @@
     </activePackageSource>
   <packageSources>
     <add key="cefsharp-myget" value="https://www.myget.org/F/cefsharp/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,4 +7,7 @@
     <add key="cefsharp-myget" value="https://www.myget.org/F/cefsharp/" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <disabledPackageSources>
+    <add key="nuget.org" value="true" />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
This fix allow you to use a params array for a parameter in your C# object that is bound to your javascript functions.