### PR TITLE
Issue 1594 - Updated calls to GetBrowserWrapper()

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -619,7 +619,7 @@ namespace CefSharp
                 return false;
             }
                 
-            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup(), false);
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup(), true);
             CefFrameWrapper frameWrapper(frame);
             CefRequestWrapper requestWrapper(request);
             CefResponseWrapper responseWrapper(response);
@@ -691,7 +691,7 @@ namespace CefSharp
                 return NULL;
             }
 
-            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup(), false);
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup(), true);
             CefFrameWrapper frameWrapper(frame);
             CefRequestWrapper requestWrapper(request);
 


### PR DESCRIPTION
Changed the returnNullIfBrowserNotFound parameter to true for some calls to GetBrowserWrapper() to prevent exceptions when closing a popup window.

Replacing pull request 1658 - targeting against master.