### PR TITLE
Fix Issue #1582, Use ToLowerInvariant while converting Javascript Function names to camelCase

### DIFF
--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -382,7 +382,7 @@ namespace CefSharp.Internals
                 return string.Empty;
             }
 
-            return char.ToLower(str[0]) + str.Substring(1);
+            return char.ToLowerInvariant(str[0]) + str.Substring(1);
         }
     }
 }


### PR DESCRIPTION
Fix Issue #1582, Use ToLowerInvariant while converting Javascript Function names to camelCase