### PR TITLE
Windows Server 2008 R2 TerminalServices BEX Access Violation

### DIFF
--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
@@ -111,7 +111,9 @@
     <PostBuildEvent>if $(PlatformName) == x86 (
   call "$(DevEnvDir)..\tools\vsvars32.bat"
   editbin /largeaddressaware $(TargetPath)
-)</PostBuildEvent>
+)
+call "$(DevEnvDir)..\tools\vsvars32.bat"
+ editbin /TSAWARE $(TargetPath)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
@@ -110,7 +110,7 @@
   <PropertyGroup>
     <PostBuildEvent>if $(PlatformName) == x86 (
   call "$(DevEnvDir)..\tools\vsvars32.bat"
-  editbin /largeaddressaware $(TargetPath)  /TSAWARE $(TargetPath)
+  editbin /largeaddressaware /TSAWARE $(TargetPath)
 )else (
   call "$(DevEnvDir)..\tools\vsvars64.bat"
   editbin /TSAWARE $(TargetPath)

--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
@@ -110,10 +110,11 @@
   <PropertyGroup>
     <PostBuildEvent>if $(PlatformName) == x86 (
   call "$(DevEnvDir)..\tools\vsvars32.bat"
-  editbin /largeaddressaware $(TargetPath)
-)
-call "$(DevEnvDir)..\tools\vsvars32.bat"
- editbin /TSAWARE $(TargetPath)</PostBuildEvent>
+  editbin /largeaddressaware $(TargetPath)  /TSAWARE $(TargetPath)
+)else (
+  call "$(DevEnvDir)..\tools\vsvars64.bat"
+  editbin /TSAWARE $(TargetPath)
+  )</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Access Violation of BEX or APPCRASH occurrs on Windows Server 2008 R2 with Terminal Service

Hi,
I have AppCrash with CefSharpSubProcess in Windows Server 2008 R2 with Terminal Service.
I can not disable Data Execution Prevention (DEP) for CefSharpSubProcess.exe.
I have this message : " the execution of data protection must be activated to execute this program. You can not disable the protection of data execution for this program."

I think to activate TSAWARE for CefSharpSubprocess.exe. See : https://support.microsoft.com/en-us/kb/2279689 
Option 3

Thanks