### PR TITLE
anonymous function callback inside an object parameter

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptMethodHandler.cpp
@@ -14,14 +14,7 @@ namespace CefSharp
 
         for (std::vector<CefRefPtr<CefV8Value>>::size_type i = 0; i != arguments.size(); i++)
         {
-            if (arguments[i]->IsFunction())
-            {
-                parameter[i] = _callbackRegistry->Register(CefV8Context::GetCurrentContext(), arguments[i]);
-            }
-            else
-            {
-                parameter[i] = TypeUtils::ConvertFromCef(arguments[i]);
-            }
+            parameter[i] = TypeUtils::ConvertFromCef(arguments[i], _callbackRegistry);
         }
 
         try

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPropertyHandler.h
@@ -50,7 +50,7 @@ namespace CefSharp
         {
             //System::Diagnostics::Debugger::Break();
             auto propertyName = StringUtils::ToClr(name);
-            auto managedValue = TypeUtils::ConvertFromCef(value);
+            auto managedValue = TypeUtils::ConvertFromCef(value, nullptr);
             auto response = _setter->Invoke(propertyName, managedValue);
             if(!response->Success)
             {

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -148,7 +148,11 @@ namespace CefSharp
         throw gcnew Exception(String::Format("Cannot convert '{0}' object from CLR to CEF.", type->FullName));
     }
 
-    Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj)
+	Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj) {
+		return TypeUtils::ConvertFromCef(obj, nullptr);
+	}
+
+	Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry)
     {
         if (obj->IsNull() || obj->IsUndefined())
         {
@@ -182,7 +186,7 @@ namespace CefSharp
                         auto data = obj->GetValue(keys[i]);
                         if (data != nullptr)
                         {
-                            auto p_data = TypeUtils::ConvertFromCef(data);
+                            auto p_data = TypeUtils::ConvertFromCef(data, callbackRegistry);
 
                             array->Add(p_data);
                         }
@@ -194,6 +198,16 @@ namespace CefSharp
 
             return nullptr;
         }
+
+		if (obj->IsFunction())
+		{
+			if (callbackRegistry != nullptr)
+			{
+				return callbackRegistry->Register(CefV8Context::GetCurrentContext(), obj);
+			}
+
+			return nullptr;
+		}
 
         if (obj->IsObject())
         {
@@ -214,7 +228,7 @@ namespace CefSharp
                             CefRefPtr<CefV8Value> data = obj->GetValue(keys[i]);
                             if (data != nullptr)
                             {
-                                Object^ p_data = TypeUtils::ConvertFromCef(data);
+                                Object^ p_data = TypeUtils::ConvertFromCef(data, callbackRegistry);
 
                                 result->Add(p_keyStr, p_data);
                             }

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -148,7 +148,7 @@ namespace CefSharp
         throw gcnew Exception(String::Format("Cannot convert '{0}' object from CLR to CEF.", type->FullName));
     }
 
-	Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry)
+    Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry)
     {
         if (obj->IsNull() || obj->IsUndefined())
         {
@@ -197,12 +197,10 @@ namespace CefSharp
 
         if (obj->IsFunction())
         {
-            if (callbackRegistry != nullptr)
-            {
-                return callbackRegistry->Register(CefV8Context::GetCurrentContext(), obj);
-            }
+            if (callbackRegistry == nullptr)
+                return nullptr;
 
-            return nullptr;
+            return callbackRegistry->Register(CefV8Context::GetCurrentContext(), obj);
         }
 
         if (obj->IsObject())

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.cpp
@@ -148,10 +148,6 @@ namespace CefSharp
         throw gcnew Exception(String::Format("Cannot convert '{0}' object from CLR to CEF.", type->FullName));
     }
 
-	Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj) {
-		return TypeUtils::ConvertFromCef(obj, nullptr);
-	}
-
 	Object^ TypeUtils::ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry)
     {
         if (obj->IsNull() || obj->IsUndefined())
@@ -199,15 +195,15 @@ namespace CefSharp
             return nullptr;
         }
 
-		if (obj->IsFunction())
-		{
-			if (callbackRegistry != nullptr)
-			{
-				return callbackRegistry->Register(CefV8Context::GetCurrentContext(), obj);
-			}
+        if (obj->IsFunction())
+        {
+            if (callbackRegistry != nullptr)
+            {
+                return callbackRegistry->Register(CefV8Context::GetCurrentContext(), obj);
+            }
 
-			return nullptr;
-		}
+            return nullptr;
+        }
 
         if (obj->IsObject())
         {

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.h
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.h
@@ -25,22 +25,15 @@ namespace CefSharp
         static CefRefPtr<CefV8Value> ConvertToCef(Object^ obj, Type^ type);
 
         /// <summary>
-        /// Converts a Chromium V8 value to a (managed) .NET object.
+        /// Converts a Chromium V8 value to a (managed) .NET object
+        /// using a JavascriptCallbackRegistry param to convert any
+        /// anonymous function to IJavascriptCallback, if callbackRegistry
+        /// is nullptr will use nullptr to each anonymous function instead.
         /// </summary>
         /// <param name="obj">The V8 value that should be converted.</param>
+        /// <param name="callbackRegistry">Instance of JavascriptCallbackRegistry to manage IJavascriptCallback instances.</param>
         /// <returns>A corresponding .NET object.</returns>
-		static Object^ ConvertFromCef(CefRefPtr<CefV8Value> obj);
-
-		/// <summary>
-		/// Converts a Chromium V8 value to a (managed) .NET object.
-		/// using a JavascriptCallbackRegistry param to convert any
-		/// anonymous function to IJavascriptCallback, if callbackRegistry
-		/// is nullptr will use nullptr to each anonymous function instead.
-		/// </summary>
-		/// <param name="obj">The V8 value that should be converted.</param>
-		/// <param name="callbackRegistry">Instance of JavascriptCallbackRegistry to manage IJavascriptCallback instances.</param>
-		/// <returns>A corresponding .NET object.</returns>
-		static Object^ ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry);
+        static Object^ ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry);
 
         /// <summary>
         /// Converts a Chromium V8 CefTime (Date) to a (managed) .NET DateTime.

--- a/CefSharp.BrowserSubprocess.Core/TypeUtils.h
+++ b/CefSharp.BrowserSubprocess.Core/TypeUtils.h
@@ -6,6 +6,7 @@
 
 #include "Stdafx.h"
 #include "include/cef_v8.h"
+#include "JavascriptCallbackRegistry.h"
 
 using namespace System;
 
@@ -28,7 +29,18 @@ namespace CefSharp
         /// </summary>
         /// <param name="obj">The V8 value that should be converted.</param>
         /// <returns>A corresponding .NET object.</returns>
-        static Object^ ConvertFromCef(CefRefPtr<CefV8Value> obj);
+		static Object^ ConvertFromCef(CefRefPtr<CefV8Value> obj);
+
+		/// <summary>
+		/// Converts a Chromium V8 value to a (managed) .NET object.
+		/// using a JavascriptCallbackRegistry param to convert any
+		/// anonymous function to IJavascriptCallback, if callbackRegistry
+		/// is nullptr will use nullptr to each anonymous function instead.
+		/// </summary>
+		/// <param name="obj">The V8 value that should be converted.</param>
+		/// <param name="callbackRegistry">Instance of JavascriptCallbackRegistry to manage IJavascriptCallback instances.</param>
+		/// <returns>A corresponding .NET object.</returns>
+		static Object^ ConvertFromCef(CefRefPtr<CefV8Value> obj, JavascriptCallbackRegistry^ callbackRegistry);
 
         /// <summary>
         /// Converts a Chromium V8 CefTime (Date) to a (managed) .NET DateTime.

--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -3,7 +3,10 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace CefSharp.Example
@@ -62,6 +65,51 @@ namespace CefSharp.Example
                     await javascriptCallback.ExecuteAsync(response);
                 }
             });
+        }
+
+        public string TestCallbackFromObject(object obj)
+        {
+            IJavascriptCallback javascriptCallback = null;
+
+            if (obj != null && obj is IDictionary)
+            {
+                Dictionary<string, object> d = new Dictionary<string, object>((IDictionary<string, object>) obj);
+
+                object objCallback = null;
+
+                if (d.TryGetValue("callback", out objCallback))
+                {
+                    if (objCallback is IJavascriptCallback)
+                    {
+                        javascriptCallback = (IJavascriptCallback)objCallback;
+                    }
+                    else
+                    {
+                        return "callback property is not a function";
+                    }
+                }
+                else
+                {
+                    return "callback property not found";
+                }
+            }
+
+            const int taskDelay = 1500;
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(taskDelay);
+
+                if (javascriptCallback != null)
+                {
+                    using (javascriptCallback)
+                    {
+                        await javascriptCallback.ExecuteAsync("message from C#");
+                    }
+                }
+            });
+
+            return "waiting for callback execution...";
         }
 
         public int EchoMyProperty()

--- a/CefSharp.Example/BoundObject.cs
+++ b/CefSharp.Example/BoundObject.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace CefSharp.Example

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -141,6 +141,29 @@
         </p>
 
         <p>
+            Javscript Callback Test using object as parameter
+            <br />
+            <script type="text/javascript">
+                function objectCallback(s)
+                {
+                    var result = document.getElementById('cbobjresult');
+                    result.innerText += "Callback: " + s + "" + Date();
+                }
+
+                function testCallbackWithObject()
+                {
+                    bound.testCallbackFromObject({ callback: objectCallback });
+
+                    var result = document.getElementById('cbobjresult');
+                    result.innerText = "The function has returned: " + Date() + "\n ...Waiting for callback response...";
+                }
+            </script>
+            <button onclick="testCallbackWithObject()">Test Callback with object param</button>
+            <br />
+            <span id="cbobjresult"></span>
+        </p>
+
+        <p>
             Result of calling bound.repeat("hi ", 5) =
             <script type="text/javascript">
                 var result = bound.repeat("hi ", 5);


### PR DESCRIPTION
I added support to use anonymous function as callback inside an object.
So it is possible to do next:

```javascript
bound.testCallbackFromObject({
  foo: "bar",
  callback: function(text) {
    console.log(text);
  }
});
```

It is possible to merge this feature to the project?

This is my first pull request :)