### PR TITLE
Fix bool, number culture, and string escaping in ExecuteScriptAsync with parameters

### DIFF
--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Text;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Globalization;
 using CefSharp.Internals;
 
 namespace CefSharp
@@ -202,24 +203,23 @@ namespace CefSharp
                 for (int i = 0; i < args.Length; i++)
                 {
                     var obj = args[i];
-                    if(obj == null)
+                    if (obj == null)
                     {
                         stringBuilder.Append("null");
                     }
+                    else if (numberTypes.Contains(obj.GetType()))
+                    {
+                        stringBuilder.Append(Convert.ToString(args[i],CultureInfo.InvariantCulture));
+                    }
+                    else if (obj is bool)
+                    {
+                        stringBuilder.Append(args[i].ToString().ToLowerInvariant());
+                    }
                     else
                     {
-                        var encapsulateInSingleQuotes = !numberTypes.Contains(obj.GetType());
-                        if(encapsulateInSingleQuotes)
-                        {
-                            stringBuilder.Append("'");
-                        }
-
-                        stringBuilder.Append(args[i].ToString());
-
-                        if (encapsulateInSingleQuotes)
-                        {
-                            stringBuilder.Append("'");
-                        }
+                        stringBuilder.Append("'");
+                        stringBuilder.Append(args[i].ToString().Replace("'","\\'"));
+                        stringBuilder.Append("'");
                     }
 
                     stringBuilder.Append(", ");


### PR DESCRIPTION
Tested by running:
```
ExecuteScriptAsync("window.runtest", "hello", "quote'abc", -3000000, 5.5, 8F, 7.66D, true, false, null);
```
window.runtest prints out all arguments and their type.

Old output on most european systems, note booleans and decimal numbers:
```
hello | string
(syntax error due to unescaped quote)
-3000000 | number
5 | number
5 | number
8 | number
7 | number
66 | number
True | string
False | string
null | object
```
New output:
```
hello | string
quote'abc | string
-3000000 | number
5.5 | number
8 | number
7.66 | number
true | boolean
false | boolean
null | object
```
Closes #1728.