### PR TITLE
Offscreen popup (dropdown list) merge with the background browser.

### DIFF
--- a/CefSharp.OffScreen/CefSharp.OffScreen.csproj
+++ b/CefSharp.OffScreen/CefSharp.OffScreen.csproj
@@ -75,6 +75,7 @@
     <Compile Include="BitmapFactory.cs" />
     <Compile Include="ChromiumWebBrowser.cs" />
     <Compile Include="GdiBitmapInfo.cs" />
+    <Compile Include="PopupBlending.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -738,8 +738,7 @@ namespace CefSharp.OffScreen
                 }
                 else if (BackGroundImage == null)
                 {
-                    throw new InvalidOperationException(string.Format("Background image was empty. Should not happen in {0} mode.",
-                        nameof(PopupBlending.Blend)));
+                    throw new InvalidOperationException("Background image was empty. Should not happen in Blend mode.");
                 }
             }
             TriggerNewScreenshot();

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -738,9 +738,8 @@ namespace CefSharp.OffScreen
                 }
                 else if (BackGroundImage == null)
                 {
-                    throw new InvalidOperationException(
-                        $"Background image was empty. Should not happen in {nameof(PopupBlending.Blend)} mode."
-                    );
+                    throw new InvalidOperationException(string.Format("Background image was empty. Should not happen in {0} mode.",
+                        nameof(PopupBlending.Blend)));
                 }
             }
             TriggerNewScreenshot();

--- a/CefSharp.OffScreen/PopupBlending.cs
+++ b/CefSharp.OffScreen/PopupBlending.cs
@@ -1,0 +1,21 @@
+﻿// Copyright © 2010-2016 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.OffScreen
+{
+    /// <summary>
+    /// Represents the popup blending in the background bitmap.
+    /// </summary>
+    public enum PopupBlending
+    {
+        /// <summary>
+        /// The background and popup should be blended.
+        /// </summary>
+        Blend,
+        /// <summary>
+        /// The background and popup should be kept separated.
+        /// </summary>
+        Separate
+    }
+}


### PR DESCRIPTION
Created to have the possibility to merge the dropdown list (select tag) popup menu with the full browser to get one single bitmap containing the whole page.

There are two commits :
-  4078663 : Simply improve what can be overriden and implement a few functions for the popup informations.  This allows a better local implementation of the InvokeRenderAsync function.

-  b20ddb7 : Implementation of a InvokeRenderAsync which does the blending of popup/background image. Added a configuration to know between split and merge of the background image and popup. Also modified what happens on popup opening/closing to match the rest of the modifications.

First review contributor : ejerome


No issue opened as seen with amaitland on Gitter.