### PR TITLE
Configure directory where msbuild will copy CefSharp files

### DIFF
--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -4,20 +4,24 @@
     <Error Text="$(MSBuildThisFileName) will work out of the box if you specify platform (x86 / x64). For AnyCPU Support see https://github.com/cefsharp/CefSharp/issues/1714" />
   </Target>
 
+  <PropertyGroup>
+    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">$(TargetDir)</CefSharpTargetDir>
+  </PropertyGroup>
+
   <Target Name="CefSharpCopyLibs86" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'x86'">
     <ItemGroup>
       <CefSharpBinaries Include="$(MSBuildThisFileDirectory)..\CefSharp\x86\*.*" />
     </ItemGroup>
 
     <Message Importance="high" Text="Copying cef.redist x86 binaries" />
-    <Copy SourceFiles="@(CefBinaries32)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefBinaries32)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x86 pak files" />
-    <Copy SourceFiles="@(CefPakFiles32)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefPakFiles32)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x86 locales " />
-    <Copy SourceFiles="@(CefLocales32)" DestinationFolder="$(TargetDir)\locales" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefLocales32)" DestinationFolder="$(CefSharpTargetDir)\locales" SkipUnchangedFiles="true" />
 
-    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)" />
-    <Copy SourceFiles="@(CefSharpBinaries)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(CefSharpTargetDir)" />
+    <Copy SourceFiles="@(CefSharpBinaries)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CefSharpCopyLibsWin32" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'Win32'">
@@ -25,14 +29,14 @@
       <CefSharpBinaries Include="$(MSBuildThisFileDirectory)..\CefSharp\x86\*.*" />
     </ItemGroup>
     <Message Importance="high" Text="Copying cef.redist x86 binaries" />
-    <Copy SourceFiles="@(CefBinaries32)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefBinaries32)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x86 pak files" />
-    <Copy SourceFiles="@(CefPakFiles32)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefPakFiles32)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x86 locales " />
-    <Copy SourceFiles="@(CefLocales32)" DestinationFolder="$(TargetDir)\locales" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefLocales32)" DestinationFolder="$(CefSharpTargetDir)\locales" SkipUnchangedFiles="true" />
 
-    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)" />
-    <Copy SourceFiles="@(CefSharpBinaries)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(CefSharpTargetDir)" />
+    <Copy SourceFiles="@(CefSharpBinaries)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CefSharpCopyLibs64" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'x64'">
@@ -40,14 +44,14 @@
       <CefSharpBinaries Include="$(MSBuildThisFileDirectory)..\CefSharp\x64\*.*" />
     </ItemGroup>
     <Message Importance="high" Text="Copying cef.redist x64 binaries" />
-    <Copy SourceFiles="@(CefBinaries64)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefBinaries64)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x64 pak files" />
-    <Copy SourceFiles="@(CefPakFiles64)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefPakFiles64)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x64 locales " />
-    <Copy SourceFiles="@(CefLocales64)" DestinationFolder="$(TargetDir)\locales" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefLocales64)" DestinationFolder="$(CefSharpTargetDir)\locales" SkipUnchangedFiles="true" />
 
-    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)" />
-    <Copy SourceFiles="@(CefSharpBinaries)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(CefSharpTargetDir)" />
+    <Copy SourceFiles="@(CefSharpBinaries)" DestinationFolder="$(CefSharpTargetDir)" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CefSharpCopyLibsAnyCPU" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'AnyCPU'">
@@ -56,22 +60,22 @@
       <CefSharpBinaries64 Include="$(MSBuildThisFileDirectory)..\CefSharp\x64\*.*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(CefBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefBinaries32)" DestinationFolder="$(CefSharpTargetDir)\x86" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x86 pak files" />
-    <Copy SourceFiles="@(CefPakFiles32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefPakFiles32)" DestinationFolder="$(CefSharpTargetDir)\x86" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x86 locales " />
-    <Copy SourceFiles="@(CefLocales32)" DestinationFolder="$(TargetDir)\x86\locales" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefLocales32)" DestinationFolder="$(CefSharpTargetDir)\x86\locales" SkipUnchangedFiles="true" />
 
     <Message Importance="high" Text="Copying cef.redist x64 binaries" />
-    <Copy SourceFiles="@(CefBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefBinaries64)" DestinationFolder="$(CefSharpTargetDir)\x64" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x64 pak files" />
-    <Copy SourceFiles="@(CefPakFiles64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefPakFiles64)" DestinationFolder="$(CefSharpTargetDir)\x64" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="Copying cef.redist x64 locales " />
-    <Copy SourceFiles="@(CefLocales64)" DestinationFolder="$(TargetDir)\x64\locales" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CefLocales64)" DestinationFolder="$(CefSharpTargetDir)\x64\locales" SkipUnchangedFiles="true" />
 
-    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
-    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
-    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(CefSharpTargetDir)\x86" />
+    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(CefSharpTargetDir)\x86" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(CefSharpTargetDir)\x64" />
+    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(CefSharpTargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -71,7 +71,7 @@
 
     <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
     <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)" />
+    <Message Importance="high" Text="-- CefSharp.Common.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
     <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.OffScreen.targets
+++ b/NuGet/CefSharp.OffScreen.targets
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">$(TargetDir)</CefSharpTargetDir>
+  </PropertyGroup>
+  
   <Target Name="CefSharpCopyOffScreenAnyCPU" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'AnyCPU'">
     <ItemGroup>
       <CefSharpBinaries32 Include="$(MSBuildThisFileDirectory)..\CefSharp\x86\*.*" />
       <CefSharpBinaries64 Include="$(MSBuildThisFileDirectory)..\CefSharp\x64\*.*" />
     </ItemGroup>
 
-    <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
-    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
-    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(CefSharpTargetDir)\x86" />
+    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(CefSharpTargetDir)\x86" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(CefSharpTargetDir)\x64" />
+    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(CefSharpTargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.OffScreen.targets
+++ b/NuGet/CefSharp.OffScreen.targets
@@ -8,7 +8,7 @@
 
     <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
     <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)" />
+    <Message Importance="high" Text="-- CefSharp.OffScreen.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
     <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.WinForms.targets
+++ b/NuGet/CefSharp.WinForms.targets
@@ -8,7 +8,7 @@
 
     <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
     <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)" />
+    <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
     <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.WinForms.targets
+++ b/NuGet/CefSharp.WinForms.targets
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">$(TargetDir)</CefSharpTargetDir>
+  </PropertyGroup>
+  
   <Target Name="CefSharpCopyWinFormsAnyCPU" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'AnyCPU'">
     <ItemGroup>
       <CefSharpBinaries32 Include="$(MSBuildThisFileDirectory)..\CefSharp\x86\*.*" />
       <CefSharpBinaries64 Include="$(MSBuildThisFileDirectory)..\CefSharp\x64\*.*" />
     </ItemGroup>
 
-    <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
-    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
-    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(CefSharpTargetDir)\x86" />
+    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(CefSharpTargetDir)\x86" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.WinForms.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(CefSharpTargetDir)\x64" />
+    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(CefSharpTargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.Wpf.targets
+++ b/NuGet/CefSharp.Wpf.targets
@@ -8,7 +8,7 @@
 
     <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
     <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)" />
+    <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
     <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NuGet/CefSharp.Wpf.targets
+++ b/NuGet/CefSharp.Wpf.targets
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">$(TargetDir)</CefSharpTargetDir>
+  </PropertyGroup>
+  
   <Target Name="CefSharpCopyWpfAnyCPU" BeforeTargets="AfterBuild" Condition="'$(Platform)' == 'AnyCPU'">
     <ItemGroup>
       <CefSharpBinaries32 Include="$(MSBuildThisFileDirectory)..\CefSharp\x86\*.*" />
       <CefSharpBinaries64 Include="$(MSBuildThisFileDirectory)..\CefSharp\x64\*.*" />
     </ItemGroup>
 
-    <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(TargetDir)\x86" />
-    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(TargetDir)\x86" SkipUnchangedFiles="true" />
-    <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(TargetDir)\x64" />
-    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(TargetDir)\x64" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x86 to $(CefSharpTargetDir)\x86" />
+    <Copy SourceFiles="@(CefSharpBinaries32)" DestinationFolder="$(CefSharpTargetDir)\x86" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="-- CefSharp.Wpf.targets: Copying files from $(MSBuildThisFileDirectory)..\CefSharp\x64 to $(CefSharpTargetDir)\x64" />
+    <Copy SourceFiles="@(CefSharpBinaries64)" DestinationFolder="$(CefSharpTargetDir)\x64" SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
During build process msbuild copies CefSharp files to `$(TargetDir)`
Sometimes it is not suitable, and instead of override `$(TargetDir)` globally another property has been introduced. It's name is `$(CefSharpTargetDir)`
It is possible to override this property in `csproj` file
```xml
<PropertyGroup>
  <CefSharpTargetDir>C:\MyProjectOutDir\Cef</CefSharpTargetDir>
</PropertyGroup>
```

If this property should depend on `$(TargetDir)` don't forget to override property after importing `Microsoft.CSharp.targets` (`$(TargetDir)` is defined there)
```xml
<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
<PropertyGroup>
  <CefSharpTargetDir>$(TargetDir)\Cef</CefSharpTargetDir>
</PropertyGroup>
```

Also, `$(TargetDir)` is used by default if `$(CefSharpTargetDir)` was not specified in `csproj` file