### PR TITLE
Fix LifeSpanHandler not Called During Dispose

### DIFF
--- a/CefSharp.WinForms.Example/Handlers/LifeSpanHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/LifeSpanHandler.cs
@@ -112,17 +112,19 @@ namespace CefSharp.WinForms.Example.Handlers
 
         void ILifeSpanHandler.OnAfterCreated(IWebBrowser browserControl, IBrowser browser)
         {
-            
+
         }
 
         bool ILifeSpanHandler.DoClose(IWebBrowser browserControl, IBrowser browser)
         {
-            return false;
+            // We do not want to close the entire application when a tab is closed. Thus we return true here to indicate
+            // that the parent window should not be closed when the browser is closed.
+            return true;
         }
 
         public void OnBeforeClose(IWebBrowser browserControl, IBrowser browser)
         {
-            
+
         }
     }
 }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -300,9 +300,6 @@ namespace CefSharp.WinForms
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
-            // Don't utilize any of the handlers anymore:
-            this.SetHandlersToNull();
-
             Cef.RemoveDisposable(this);
 
             if (disposing)
@@ -339,6 +336,13 @@ namespace CefSharp.WinForms
                 TitleChanged = null;
                 IsBrowserInitializedChanged = null;
             }
+
+            // Don't utilize any of the handlers anymore.
+            // We have to do this after we dispose managedCefBrowserAdapter
+            // otherwise the LifeSpanHandler will not be called properly when the
+            // browser is closed during the disposal process.
+            this.SetHandlersToNull();
+
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
- Make it so that closing a tab in the WinForms example does not close the
  entire application. We need to make sure that the LifeSpanHandler is
  still around when `managedCefBrowserAdapter` is disposed since it is
  going to call `CloseBrowser`. That way, we can implement LifeSpanHandler
  and reject closing the entire application as described in #1574