### PR TITLE
Fixing NullReferenceException that gets thrown from ControlExtensions…

### DIFF
--- a/CefSharp.WinForms/Internals/ControlExtensions.cs
+++ b/CefSharp.WinForms/Internals/ControlExtensions.cs
@@ -53,7 +53,13 @@ namespace CefSharp.WinForms.Internals
         /// <returns>true if the control is the currently active control</returns>
         public static bool IsActiveControl(this Control control)
         {
-            Control activeControl = control.FindForm().ActiveControl;
+            Form form = control.FindForm();
+            if (form == null)
+            {
+                return false;
+            }
+
+            Control activeControl = form.ActiveControl;
             while (activeControl != null
                    && (activeControl is ContainerControl)
                    && !Object.ReferenceEquals(control, activeControl))


### PR DESCRIPTION
this was fixed in https://github.com/cefsharp/CefSharp/pull/1132/commits/a99a04964421ab4c7587b5e07de821e973067a3e but hasnt been pulled into 51.