### PR TITLE
Fix NRE when returning null from a scheme handler factory

### DIFF
--- a/CefSharp.Core/SchemeHandlerFactoryWrapper.h
+++ b/CefSharp.Core/SchemeHandlerFactoryWrapper.h
@@ -39,6 +39,11 @@ namespace CefSharp
 
             auto handler = _factory->Create(%browserWrapper, %frameWrapper, StringUtils::ToClr(schemeName), %requestWrapper);
 
+            if (handler == nullptr)
+            {
+                return NULL;
+            }
+
             if (handler->GetType() == ResourceHandler::typeid)
             {
                 auto resourceHandler = static_cast<ResourceHandler^>(handler);


### PR DESCRIPTION
Regression in 49.0 release.  Prevented use of default CEF handler when
using a custom scheme handler.