### PR TITLE
1. Fix for browser subprocess crash with null reference exception. 2. Fix for WPF ChromiumWebBrowser CPU leak because unstopped timers.

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -424,7 +424,17 @@ namespace CefSharp
 
     void CefAppUnmanagedWrapper::OnRenderThreadCreated(CefRefPtr<CefListValue> extraInfo)
     {
+		if (extraInfo == NULL) {
+			LOG(ERROR) << "extraInfo parameter in CefAppUnmanagedWrapper::OnRenderThreadCreated() is NULL";
+			return;
+		}
+
         auto extensionList = extraInfo->GetList(0);
+
+		if (extensionList == NULL) {
+			LOG(ERROR) << "extensionList value in CefAppUnmanagedWrapper::OnRenderThreadCreated() is NULL";
+			return;
+		}
 
         for (size_t i = 0; i < extensionList->GetSize(); i++)
         {

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -470,6 +470,7 @@ namespace CefSharp.Wpf
                     if (tooltipTimer != null)
                     {
                         tooltipTimer.Tick -= OnTooltipTimerTick;
+                        tooltipTimer.Stop();
                     }
 
                     if (CleanupElement != null)
@@ -1894,6 +1895,7 @@ namespace CefSharp.Wpf
                 if (tooltipTimer != null)
                 {
                     tooltipTimer.Tick -= OnTooltipTimerTick;
+                    tooltipTimer.Stop();
                 }
 
                 // TODO: Consider making the delay here configurable.


### PR DESCRIPTION
Our application intensively creates new instances of ChromiumWebBrowser  (WPF). Every 7 seconds or even faster in several parallel processes (usually 2). CefSharp is great but we faced 2 serious problems with it.

**--- 1) CefSharp.BrowserSubprocess sometimes crashes.**

Logs from system event viewer: 
>4/29/2016 10:31:47 AM
Faulting application name: CefSharp.BrowserSubprocess.exe, version: 47.0.3.0, time stamp: 0x56ce5bf5
Application: CefSharp.BrowserSubprocess.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException
Stack:
   at <Module>.CefSharp.CefAppUnmanagedWrapper.OnRenderThreadCreated(CefSharp.CefAppUnmanagedWrapper*, CefRefPtr<CefListValue>*)
   at <Module>.CefExecuteProcess(CefMainArgs*, CefRefPtr<CefApp>*, Void*)
   at CefSharp.CefAppWrapper.Run()
   at CefSharp.BrowserSubprocess.Program.Main(System.String[])

I fixed this by adding checks on NULL for values in CefAppUnmanagedWrapper.cpp file  function CefAppUnmanagedWrapper::OnRenderThreadCreated(...). 
Without looking for reasons of NULL values.

**---2) CPU resource leak  when using ChromiumWebBrowser WPF.** 

As I mentioned we create and destroy ChromiumWebBrowser  instances often. 
We notice that after several hours of application work it consume a lot of CPU time even when all business logic in program was stopped. The load produced by Dispatcher.Invoke() calls. 

Analyse revealed  that problem was in ChromiumWebBrowser class. Namely in running dispatcher timers. Each call of the Load() function creates new timer. Old timer not stopped and continues.  After hundreds of Load() calls CPU load becomes noticeable (2-4%). Thousands of running dispatcher timers can load core by 100%. 
Proposed fix adds Stop timer calls when they are not needed any longer. 

Looking forward to see these fixes in next releases. At least I hope you will find this information helpful to make appropriate updates in code. 