### PR TITLE
Fix for browser subprocess crash with null reference exception.

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -424,7 +424,17 @@ namespace CefSharp
 
     void CefAppUnmanagedWrapper::OnRenderThreadCreated(CefRefPtr<CefListValue> extraInfo)
     {
+		if (extraInfo == NULL) {
+			LOG(ERROR) << "extraInfo parameter in CefAppUnmanagedWrapper::OnRenderThreadCreated() is NULL";
+			return;
+		}
+
         auto extensionList = extraInfo->GetList(0);
+
+		if (extensionList == NULL) {
+			LOG(ERROR) << "extensionList value in CefAppUnmanagedWrapper::OnRenderThreadCreated() is NULL";
+			return;
+		}
 
         for (size_t i = 0; i < extensionList->GetSize(); i++)
         {

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -470,6 +470,7 @@ namespace CefSharp.Wpf
                     if (tooltipTimer != null)
                     {
                         tooltipTimer.Tick -= OnTooltipTimerTick;
+                        tooltipTimer.Stop();
                     }
 
                     if (CleanupElement != null)
@@ -1894,6 +1895,7 @@ namespace CefSharp.Wpf
                 if (tooltipTimer != null)
                 {
                     tooltipTimer.Tick -= OnTooltipTimerTick;
+                    tooltipTimer.Stop();
                 }
 
                 // TODO: Consider making the delay here configurable.


### PR DESCRIPTION
 CefSharp.BrowserSubprocess.exe sometimes crashes.

Logs from system event viewer:

> 4/29/2016 10:31:47 AM
> Faulting application name: CefSharp.BrowserSubprocess.exe, version: 47.0.3.0, time stamp: 0x56ce5bf5
> Application: CefSharp.BrowserSubprocess.exe
> Framework Version: v4.0.30319
> Description: The process was terminated due to an unhandled exception.
> Exception Info: System.NullReferenceException
> Stack:
> at >.CefSharp.CefAppUnmanagedWrapper.OnRenderThreadCreated(CefSharp.CefAppUnmanagedWrapper, CefRefPtr)
> at .CefExecuteProcess(CefMainArgs, CefRefPtr, Void*)
> at CefSharp.CefAppWrapper.Run()
> at CefSharp.BrowserSubprocess.Program.Main(System.String[])

I fixed this by adding checks on NULL for values in CefAppUnmanagedWrapper.cpp file function CefAppUnmanagedWrapper::OnRenderThreadCreated(...). 
Without looking for reasons of NULL values.
