### PR TITLE
Disabled manifest generation for exes to allow ClickOnce deployment

### DIFF
--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
@@ -78,7 +78,7 @@
     <AssemblyOriginatorKeyFile>..\CefSharp.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -48,7 +48,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -64,7 +64,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>CefSharp.Wpf.Example.Program</StartupObject>


### PR DESCRIPTION
Right now if you try to deploy one of the CefSharp executables in a ClickOnce deployment it will fail to download with this error:

> Reference in the manifest does not match the identity of the downloaded assembly CefSharp.BrowserSubprocess.exe.

There are ways around it, e.g. you can deploy the files as data files instead, but with this change it should work by default.