### PR TITLE
fix: VisitUrlCookiesAsync NullReferenceException #1928

### DIFF
--- a/CefSharp.OffScreen.Example/Program.cs
+++ b/CefSharp.OffScreen.Example/Program.cs
@@ -82,6 +82,12 @@ namespace CefSharp.OffScreen.Example
 
                 var onUi = Cef.CurrentlyOnThread(CefThreadIds.TID_UI);
 
+                var completionHandler = new TaskCompletionHandler();
+                var cookieManager = browser.RequestContext.GetDefaultCookieManager(completionHandler);
+                await completionHandler.Task;
+                //Get cookies by Url
+                var cookes = await cookieManager.VisitUrlCookiesAsync(TestUrl, false);
+
                 // For Google.com pre-pupulate the search text box
                 await browser.EvaluateScriptAsync("document.getElementById('lst-ib').value = 'CefSharp Was Here!'");
 

--- a/CefSharp/TaskCookieVisitor.cs
+++ b/CefSharp/TaskCookieVisitor.cs
@@ -42,12 +42,12 @@ namespace CefSharp
 
         void IDisposable.Dispose()
         {
-            if(list != null && list.Count == 0)
+            if(list.Count == 0)
             {
                 //Set the result on the ThreadPool so the Task continuation is not run on the CEF UI Thread
                 taskCompletionSource.TrySetResultAsync(list);
             }
-		}
+        }
 
         /// <summary>
         /// Task that can be awaited for the result to be retrieved async

--- a/CefSharp/TaskCookieVisitor.cs
+++ b/CefSharp/TaskCookieVisitor.cs
@@ -15,8 +15,8 @@ namespace CefSharp
     /// </summary>
     public class TaskCookieVisitor : ICookieVisitor
     {
-        private TaskCompletionSource<List<Cookie>> taskCompletionSource;
-        private List<Cookie> list;
+        private readonly TaskCompletionSource<List<Cookie>> taskCompletionSource;
+        private readonly List<Cookie> list;
 
         /// <summary>
         /// Default constructor
@@ -47,10 +47,7 @@ namespace CefSharp
                 //Set the result on the ThreadPool so the Task continuation is not run on the CEF UI Thread
                 taskCompletionSource.TrySetResultAsync(list);
             }
-
-            list = null;
-            taskCompletionSource = null;
-        }
+		}
 
         /// <summary>
         /// Task that can be awaited for the result to be retrieved async


### PR DESCRIPTION
The error contained in TaskCookieVisitor class. 
Method Dispose set taskCompletionSource=null, and then property Task called by an external code.