### PR TITLE
WPF - Made GetViewRect always round up

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -535,8 +535,8 @@ namespace CefSharp.Wpf
         {
             var viewRect = new ViewRect
             {
-                Width = (int)ActualWidth,
-                Height = (int)ActualHeight
+                Width = (int)Math.Ceiling(ActualWidth),
+                Height = (int)Math.Ceiling(ActualHeight)
             };
 
             return viewRect;


### PR DESCRIPTION
See https://github.com/cefsharp/CefSharp/issues/1889#issuecomment-281741492

- Made GetViewRect always round up to prevent the image from being smaller than the control