### PR TITLE
Remove CaretBrowsing from IBrowserSettings to match latest CEF master

### DIFF
--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -212,16 +212,6 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Controls whether the caret position will be drawn. Also configurable using
-        /// the "enable-caret-browsing" command-line switch.
-        /// </summary>
-        virtual property CefState CaretBrowsing
-        {
-            CefState get() { return (CefState)_browserSettings->caret_browsing; }
-            void set(CefState value) { _browserSettings->caret_browsing = (cef_state_t)value; }
-        }
-
-        /// <summary>
         /// Controls whether any plugins will be loaded. Also configurable using the
         /// "disable-plugins" command-line switch.
         /// </summary>

--- a/CefSharp/IBrowserSettings.cs
+++ b/CefSharp/IBrowserSettings.cs
@@ -107,12 +107,6 @@ namespace CefSharp
         CefState JavascriptDomPaste { get; set; }
 
         /// <summary>
-        /// Controls whether the caret position will be drawn. Also configurable using
-        /// the "enable-caret-browsing" command-line switch.
-        /// </summary>
-        CefState CaretBrowsing { get; set; }
-
-        /// <summary>
         /// Controls whether any plugins will be loaded. Also configurable using the
         /// "disable-plugins" command-line switch.
         /// </summary>


### PR DESCRIPTION
CEF commit SHA-1 was cdcdfa99913a01f3617a0d25a2e2f2ed145987bd.

I was building against the latest CEF and noticed encountered the following error:
C2039: 'caret_browsing': is not a member of 'CefStructBase<CefBrowserSettingsTraits>'	CefSharp.Core	c:\code\cefsharp\cefsharp\cefsharp.core\BrowserSettings.h	220	

All l had to do was remove that property from the I/BrowserSettings type, and everything worked fine.
