### PR TITLE
Allow calling managed methods from objects bound with RegisterAsyncJsObject that return arrays of structs

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -406,38 +406,42 @@ namespace CefSharp
                 if (rootObjectWrapper->TryGetAndRemoveMethodCallback(callbackId, callback))
                 {
 
-                    auto frame = browser->GetFrame(frameId);
-                    if (frame.get())
+                    try 
                     {
-                        auto context = frame->GetV8Context();
+                        auto frame = browser->GetFrame(frameId);
+                        if (frame.get())
+                        {
+                            auto context = frame->GetV8Context();
 
-                        if (context.get() && context->Enter())
-                        {
-                            try
+                            if (context.get() && context->Enter())
                             {
-                                auto success = argList->GetBool(2);
-                                if (success)
+                                try
                                 {
-                                    callback->Success(DeserializeV8Object(argList, 3));
+                                    auto success = argList->GetBool(2);
+                                    if (success)
+                                    {
+                                        callback->Success(DeserializeV8Object(argList, 3));
+                                    }
+                                    else
+                                    {
+                                        callback->Fail(argList->GetString(3));
+                                    }
                                 }
-                                else
+                                finally
                                 {
-                                    callback->Fail(argList->GetString(3));
+                                    context->Exit();
                                 }
-                                //dispose
-                                delete callback;
                             }
-                            finally
+                            else
                             {
-                                context->Exit();
+                                callback->Fail("Unable to Enter Context");
                             }
                         }
-                        else
-                        {
-                            callback->Fail("Unable to Enter Context");
-                            //dispose
-                            delete callback;
-                        }
+                    }
+                    finally
+                    {
+                        //dispose
+                        delete callback;
                     }
                 }
             }

--- a/CefSharp.Example/AsyncBoundObject.cs
+++ b/CefSharp.Example/AsyncBoundObject.cs
@@ -8,7 +8,8 @@ using System.Threading;
 
 namespace CefSharp.Example
 {
-    public struct JsObject {
+    public struct JsObject 
+    {
         public string Value;
     }
 
@@ -38,8 +39,10 @@ namespace CefSharp.Example
             Thread.Sleep(1000);
         }
 
-        public JsObject[] ObjectArray(string name) {
-            return new[] {
+        public JsObject[] ObjectArray(string name)
+        {
+            return new[] 
+            {
                 new JsObject() { Value = "Item1" },
                 new JsObject() { Value = "Item2" }
             };

--- a/CefSharp.Example/AsyncBoundObject.cs
+++ b/CefSharp.Example/AsyncBoundObject.cs
@@ -8,6 +8,10 @@ using System.Threading;
 
 namespace CefSharp.Example
 {
+    public struct JsObject {
+        public string Value;
+    }
+
     public class AsyncBoundObject
     {
         //We expect an exception here, so tell VS to ignore
@@ -32,6 +36,13 @@ namespace CefSharp.Example
         public void DoSomething()
         {
             Thread.Sleep(1000);
+        }
+
+        public JsObject[] ObjectArray(string name) {
+            return new[] {
+                new JsObject() { Value = "Item1" },
+                new JsObject() { Value = "Item2" }
+            };
         }
     }
 }

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -83,9 +83,11 @@
                     });
                 }
 
-                function asyncObjectArray() {
+                function asyncObjectArray()
+                {
                     var call = "Async call (ObjectArray): " + Date();
-                    boundAsync.objectArray('CefSharp').then(function (res) {
+                    boundAsync.objectArray('CefSharp').then(function (res)
+                    {
                         var end = "Result: [ " + res.map(function (item) { return item.Value }) + " ] (" + Date() + ")";
                         writeAsyncResult(call, end);
                     });

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -82,11 +82,21 @@
                         writeAsyncResult(call, end);
                     });
                 }
+
+                function asyncObjectArray() {
+                    var call = "Async call (ObjectArray): " + Date();
+                    boundAsync.objectArray('CefSharp').then(function (res) {
+                        var end = "Result: [ " + res.map(function (item) { return item.Value }) + " ] (" + Date() + ")";
+                        writeAsyncResult(call, end);
+                    });
+                }
             
                 asyncError();
                 asyncDivOk();
                 asyncDivFail();
                 asyncDoSomething();
+                asyncHello();
+                asyncObjectArray();
             </script>
         </p>
         <p>

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -191,7 +191,7 @@ namespace CefSharp.Internals
                 }
                 catch (Exception e)
                 {
-                    throw new InvalidOperationException("Could not execute method: " + name + "(" + String.Join(", ", parameters) + ")" + " - Missing Parameters: " + missingParams, e);
+                    throw new InvalidOperationException("Could not execute method: " + name + "(" + String.Join(", ", parameters) + ") " + (missingParams > 0 ? "- Missing Parameters: " + missingParams : ""), e);
                 }
 
                 if(result != null && IsComplexType(result.GetType()))
@@ -397,7 +397,7 @@ namespace CefSharp.Internals
                 baseType = Nullable.GetUnderlyingType(type);
             }
 
-            if (baseType == null || baseType.Namespace.StartsWith("System"))
+            if (baseType == null || baseType.IsArray || baseType.Namespace.StartsWith("System"))
             {
                 return false;
             }


### PR DESCRIPTION
**Problem:**
It was not possible to call .Net methods from JS that return arrays of structs.

Fix:
IsComplexType from JavascriptObjectRepository returns false for arrays.

Notes:
This PR requires [1979](https://github.com/cefsharp/CefSharp/pull/1979)