### PR TITLE
Changed from Uri.ToString to Uri.AbsoluteUri

### DIFF
--- a/CefSharp/DefaultResourceHandlerFactory.cs
+++ b/CefSharp/DefaultResourceHandlerFactory.cs
@@ -40,7 +40,7 @@ namespace CefSharp
             Uri uri;
             if (Uri.TryCreate(url, UriKind.Absolute, out uri))
             {
-                Handlers.AddOrUpdate(uri.ToString(), handler, (k, v) => handler);
+                Handlers.AddOrUpdate(uri.AbsoluteUri, handler, (k, v) => handler);
                 return true;
             }
             return false;


### PR DESCRIPTION
Changed from `Uri.ToString` to `Uri.AbsoluteUri`

`Uri.ToString` returns a human-readable URL which isn't encoded, this causes the `Key` in the `ConcurrentDictionary` to not match the Url from `request.Url` in `GetResourceHandler`