### PR TITLE
Made it possible to register a "one-time use" ResourceHandler

### DIFF
--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -199,6 +199,7 @@
     <Compile Include="PdfPrintSettings.cs" />
     <Compile Include="ICookieManager.cs" />
     <Compile Include="IMenuModel.cs" />
+    <Compile Include="ResourceFactoryItem.cs" />
     <Compile Include="Structs\ViewRect.cs" />
     <Compile Include="ISslInfo.cs" />
     <Compile Include="Structs\KeyEvent.cs" />

--- a/CefSharp/ResourceFactoryItem.cs
+++ b/CefSharp/ResourceFactoryItem.cs
@@ -1,0 +1,27 @@
+﻿// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+    public class ResourceFactoryItem
+    {
+        /// <summary>
+        /// The handler for a specific Url
+        /// </summary>
+        public IResourceHandler Handler { get; private set; }
+
+        /// <summary>
+        /// Whether or not the handler should be used once (false) or until manually unregistered (true)
+        /// </summary>
+        public bool Persist { get; private set; }
+
+        /// <param name="handler">The handler for a specific Url</param>
+        /// <param name="persist">Whether or not the handler should be used once (false) or until manually unregistered (true)</param>
+        public ResourceFactoryItem(IResourceHandler handler, bool persist)
+        {
+            Handler = handler;
+            Persist = persist;
+        }
+    }
+}

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -309,7 +309,7 @@ namespace CefSharp
                 throw new Exception("LoadHtml can only be used with the default IResourceHandlerFactory(DefaultResourceHandlerFactory) implementation");
             }
 
-            if (resourceHandler.RegisterHandler(url, ResourceHandler.FromString(html, encoding, true)))
+            if (resourceHandler.RegisterHandler(url, ResourceHandler.FromString(html, encoding, true), false))
             {
                 browser.Load(url);
                 return true;


### PR DESCRIPTION
- Added a `ResourceFactoryItem` class
- Added a overload to `RegisterHandler` that takes a bool representing whether or not the handler should be used only once
- Made `GetResourceHandler` remove the `ResourceFactoryItem` if it was specified as a `one-time use` handler
- Made LoadHtml register a `one-time use` handler