### PR TITLE
Fix DefaultBinder conversions from Dictionary<string,object>

### DIFF
--- a/CefSharp/ModelBinding/DefaultBinder.cs
+++ b/CefSharp/ModelBinding/DefaultBinder.cs
@@ -72,6 +72,10 @@ namespace CefSharp.ModelBinding
                 {
                     throw new ArgumentException("When modelType is an enumerable it must specify the type.", "modelType");
                 }
+            } 
+            else if (modelType.IsGenericObject())
+            {
+                return obj;
             }
 
             var bindingContext = this.CreateBindingContext(obj, modelType, genericType);
@@ -92,7 +96,7 @@ namespace CefSharp.ModelBinding
 
                     if (val != null)
                     {
-                        if (val.GetType() == typeof(Dictionary<string, object>))
+                        if (val.GetType().IsGenericObject())
                         {
                             var subModel = Bind(val, genericType);
                             model.Add(subModel);
@@ -144,10 +148,8 @@ namespace CefSharp.ModelBinding
                 return;
             }
 
-            Type dictionaryType = typeof(Dictionary<string, object>);
-
             //If the type is a dictionary and the PropertyType isn't then we'll bind.
-            if (obj.GetType() == dictionaryType && modelProperty.PropertyType != dictionaryType)
+            if (obj.GetType().IsGenericObject() && !modelProperty.PropertyType.IsGenericObject())
             {
                 //We have a sub dictionary, attempt to bind it to the class
                 var model = Bind(obj, modelProperty.PropertyType);
@@ -190,7 +192,7 @@ namespace CefSharp.ModelBinding
 
         protected virtual object GetValue(string propertyName, BindingContext context)
         {
-            if (context.Object.GetType() == typeof(Dictionary<string, object>))
+            if (context.Object.GetType().IsGenericObject())
             {
                 var dictionary = (Dictionary<string, object>)context.Object;
                 if (dictionary.ContainsKey(propertyName))

--- a/CefSharp/ModelBinding/ModelBindingExtensions.cs
+++ b/CefSharp/ModelBinding/ModelBindingExtensions.cs
@@ -74,7 +74,8 @@ namespace CefSharp.ModelBinding
         /// </summary>
         /// <param name="source">source type</param>
         /// <returns>return true if is a generic js object</returns>
-        public static bool IsGenericObject(this Type source) {
+        public static bool IsGenericObject(this Type source) 
+        {
             return source == typeof(Dictionary<string, object>);
         }
 

--- a/CefSharp/ModelBinding/ModelBindingExtensions.cs
+++ b/CefSharp/ModelBinding/ModelBindingExtensions.cs
@@ -56,7 +56,6 @@ namespace CefSharp.ModelBinding
         /// <returns><see langword="true" /> if the type is an array, otherwise <see langword="false" />.</returns>
         public static bool IsArray(this Type source)
         {
-
             return source.GetTypeInfo().BaseType == typeof(Array);
         }
 
@@ -67,7 +66,7 @@ namespace CefSharp.ModelBinding
         /// <returns>return if collection, array or enumerable</returns>
         public static bool IsCollectionOrArray(this Type source)
         {
-            return source.IsCollection() || source.IsArray() || source.IsEnumerable();
+            return source != typeof(Dictionary<string, object>) && (source.IsCollection() || source.IsArray() || source.IsEnumerable());
         }
 
         /// <summary>
@@ -94,7 +93,7 @@ namespace CefSharp.ModelBinding
         /// </summary>
         /// <param name="source">The type to check.</param>
         /// <returns><see langword="true" /> if the type is an collection, otherwise <see langword="false" />.</returns>
-        public static bool IsCollection(this Type source)
+        private static bool IsCollection(this Type source)
         {
             var collectionType = typeof(ICollection<>);
 

--- a/CefSharp/ModelBinding/ModelBindingExtensions.cs
+++ b/CefSharp/ModelBinding/ModelBindingExtensions.cs
@@ -66,7 +66,16 @@ namespace CefSharp.ModelBinding
         /// <returns>return if collection, array or enumerable</returns>
         public static bool IsCollectionOrArray(this Type source)
         {
-            return source != typeof(Dictionary<string, object>) && (source.IsCollection() || source.IsArray() || source.IsEnumerable());
+            return !source.IsGenericObject() && (source.IsCollection() || source.IsArray() || source.IsEnumerable());
+        }
+
+        /// <summary>
+        /// The type is a generic javascript object (dictionary)
+        /// </summary>
+        /// <param name="source">source type</param>
+        /// <returns>return true if is a generic js object</returns>
+        public static bool IsGenericObject(this Type source) {
+            return source == typeof(Dictionary<string, object>);
         }
 
         /// <summary>


### PR DESCRIPTION
The following example will work and not crash:

binder = new DefaultBinder(new DefaultFieldNameConverter());
obj = new Dictionary<string, object> { { "key", "value" } };
binder.Bind(new [] {  obj }, typeof(Dictionary<string, object>[])); => returns [ obj ]
binder.Bind(obj, typeof(Dictionary<string, object>)); => returns obj

1) Dictionaries were wrongly considered collections.
2) Some conversions involving Dictionaries caused NullReferenceExceptions to be thrown