### PR TITLE
Prevent VS from always rebuilding projects that reference CefSharp when using AnyCPU configuration

### DIFF
--- a/NuGet/CefSharp.Common.props
+++ b/NuGet/CefSharp.Common.props
@@ -1,29 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Include="CefSharp" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="CefSharp.Core" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Core" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Core" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+      <ItemGroup>
+        <Reference Include="CefSharp">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="CefSharp.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'x64'">
+      <ItemGroup>
+        <Reference Include="CefSharp">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="CefSharp.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Core.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'AnyCPU'">
+      <ItemGroup>
+        <Reference Include="CefSharp">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="CefSharp.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/NuGet/CefSharp.Wpf.props
+++ b/NuGet/CefSharp.Wpf.props
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Wpf.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+	  <ItemGroup>
+		<Reference Include="CefSharp.Wpf">
+		  <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
+		  <Private>True</Private>
+		</Reference>
+	  </ItemGroup>
+	</When>
+    <When Condition="'$(Platform)' == 'x64'">
+	  <ItemGroup>
+		<Reference Include="CefSharp.Wpf">
+		  <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Wpf.dll</HintPath>
+		  <Private>True</Private>
+		</Reference>
+	  </ItemGroup>
+	</When>
+	<When Condition="'$(Platform)' == 'AnyCPU'">
+	  <ItemGroup>
+		<Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'AnyCPU'">
+		  <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
+		  <Private>False</Private>
+		</Reference>
+	  </ItemGroup>
+	</When>
+  </Choose>
 </Project>


### PR DESCRIPTION
Fixed the problem of Visual Studio Ignoring the Condition on the Reference tag [https://stackoverflow.com/questions/28851338/why-the-condition-attribute-doesnt-work-for-the-itemgroup-element]. This will stop VS from always rebuilding projects that reference CefSharp when using AnyCPU configuration