### PR TITLE
Pevent merging of repeated values in headerMap when using custom handlers

### DIFF
--- a/CefSharp.Core/Internals/TypeConversion.h
+++ b/CefSharp.Core/Internals/TypeConversion.h
@@ -37,8 +37,10 @@ namespace CefSharp
 
                 for each (String^ key in headers)
                 {
-                    String^ value = headers[key];
-                    result.insert(std::pair<CefString, CefString>(StringUtils::ToNative(key), StringUtils::ToNative(value)));
+                    for each(String^ value in headers->GetValues(key))
+                    {
+                        result.insert(std::pair<CefString, CefString>(StringUtils::ToNative(key), StringUtils::ToNative(value)));
+                    }
                 }
 
                 return result;


### PR DESCRIPTION
The NameValueCollection auto merges (according to MSDN) all the values under the same key, with ",".
This breaks some headers, like the "Set-Cookie"; where the "." has another meanings according to RFC.

as far as i've seen, this issue will be present everytime a customhandler is used.