### PR TITLE
Prevent unhandled exception in PointToScreen when not yet visible

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -83,7 +83,6 @@ namespace CefSharp.Wpf
         /// </summary>
         private int disposeCount;
         /// <summary>
-        /// <summary>
         /// Location of the control on the screen, relative to Top/Left
         /// Used to calculate GetScreenPoint
         /// We're unable to call PointToScreen directly due to treading restrictions
@@ -1547,6 +1546,8 @@ namespace CefSharp.Wpf
                         window.StateChanged += WindowStateChanged;
                         window.LocationChanged += OnWindowLocationChanged;
                     }
+
+                    updateBrowserSecreenLocation();
                 }
             }
             else if (args.OldSource != null)
@@ -1588,11 +1589,19 @@ namespace CefSharp.Wpf
             } 
         }
 
+        private void updateBrowserSecreenLocation()
+        {
+            if (PresentationSource.FromVisual(this) != null)
+            {
+                browserScreenLocation = PointToScreen(new Point());
+            }
+        }
+
         private void OnWindowLocationChanged(object sender, EventArgs e)
         {
             //We maintain a manual reference to the controls screen location
             //(relative to top/left of the screen)
-            browserScreenLocation = PointToScreen(new Point());
+            updateBrowserSecreenLocation();
         }
 
         /// <summary>
@@ -1743,7 +1752,7 @@ namespace CefSharp.Wpf
             tooltipTimer.IsEnabled = false;
 
             //Initial value for screen location
-            browserScreenLocation = PointToScreen(new Point());
+            updateBrowserSecreenLocation();
         }
 
         /// <summary>

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1547,7 +1547,7 @@ namespace CefSharp.Wpf
                         window.LocationChanged += OnWindowLocationChanged;
                     }
 
-                    updateBrowserSecreenLocation();
+                    updateBrowserScreenLocation();
                 }
             }
             else if (args.OldSource != null)
@@ -1589,7 +1589,7 @@ namespace CefSharp.Wpf
             } 
         }
 
-        private void updateBrowserSecreenLocation()
+        private void updateBrowserScreenLocation()
         {
             if (PresentationSource.FromVisual(this) != null)
             {
@@ -1601,7 +1601,7 @@ namespace CefSharp.Wpf
         {
             //We maintain a manual reference to the controls screen location
             //(relative to top/left of the screen)
-            updateBrowserSecreenLocation();
+            updateBrowserScreenLocation();
         }
 
         /// <summary>
@@ -1752,7 +1752,7 @@ namespace CefSharp.Wpf
             tooltipTimer.IsEnabled = false;
 
             //Initial value for screen location
-            updateBrowserSecreenLocation();
+            updateBrowserScreenLocation();
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for #2106.
Checks that the visual is connected to a presentation source before calling PointToScreen()
Updates the browserScreenLocation value when the presentation source changes
Fix compiler warning for XML comment