### PR TITLE
initial vs2017 build support (with vs2015 tooling)

### DIFF
--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -110,14 +110,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\CefSharp.props" />
   <PropertyGroup>
-    <PostBuildEvent>if $(PlatformName) == x86 (
-  "$(DevEnvDir)..\..\VC\bin\editbin" /largeaddressaware /TSAWARE "$(TargetPath)"
-  call "$(DevEnvDir)..\Tools\vsvars32.bat"
-  sn -R "$(TargetPath)" "$(ProjectDir)..\CefSharp.snk"
-) else (
-  "$(DevEnvDir)..\..\VC\bin\amd64\editbin" /TSAWARE "$(TargetPath)"
-)</PostBuildEvent>
+    <PostBuildEvent>$(CefSharpBrowserSubprocessPostBuildEvent)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/CefSharp.props
+++ b/CefSharp.props
@@ -1,12 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <VisualStudioProductVersion>2013</VisualStudioProductVersion>
     <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='14.0'">2015</VisualStudioProductVersion>
+    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='15.0'">2015</VisualStudioProductVersion>
 
     <PlatformToolset>v120</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v140</PlatformToolset>
+    
+    <CefSharpBrowserSubprocessPostBuildEvent>
+      <![CDATA[
+if $(PlatformName) == x86 (
+  "$(DevEnvDir)..\..\VC\bin\editbin" /largeaddressaware /TSAWARE "$(TargetPath)"
+  call "$(DevEnvDir)..\Tools\vsvars32.bat"
+  sn -R "$(TargetPath)" "$(ProjectDir)..\CefSharp.snk"
+) else (
+  "$(DevEnvDir)..\..\VC\bin\amd64\editbin" /TSAWARE "$(TargetPath)"
+)
+]]></CefSharpBrowserSubprocessPostBuildEvent>
+
+    <CefSharpBrowserSubprocessPostBuildEvent Condition="'$(VisualStudioVersion)'=='15.0'">
+      <![CDATA[
+if $(PlatformName) == x86 (
+  call "$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars32.bat"
+  editbin /largeaddressaware /TSAWARE "$(TargetPath)"  
+  sn -R "$(TargetPath)" "$(ProjectDir)..\CefSharp.snk"
+) else (
+  call "$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat"
+  editbin /TSAWARE "$(TargetPath)"
+)
+]]>
+    </CefSharpBrowserSubprocessPostBuildEvent>
   </PropertyGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,3 @@
-image: Visual Studio 2015
-
 environment:
   VisualStudioVersion: 12.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2015
+
 environment:
   VisualStudioVersion: 12.0
 

--- a/build.ps1
+++ b/build.ps1
@@ -274,7 +274,7 @@ function DownloadNuget()
     if(-not (Test-Path $nuget))
     {
         $client = New-Object System.Net.WebClient;
-        $client.DownloadFile('http://nuget.org/nuget.exe', $nuget);
+        $client.DownloadFile('https://dist.nuget.org/win-x86-commandline/latest/nuget.exe', $nuget);
     }
 }
 


### PR DESCRIPTION
This implementation uses VS2017 with the VS2015 toolset (use the VS2017 installer to install this toolset).

I extracted the PostBuild script into the CefSharp.props file and tried to keep the behaviour the same for non-VS2017 (however, I cannot test that without VS2013 and VS2015).

Note though that the CefSharp.Test OffScreenBrowserBasicFacts tests are failing and I am unsure if that is expected (since they were only recently added and I don't see a succesfull appveyor build yet).