### PR TITLE
[DO NOT MERGE] Use experimental cef.sdk and cef.redist packages

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -230,6 +230,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props'))" />
+    <Error Condition="!Exists('..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props'))" />
   </Target>
 </Project>

--- a/CefSharp.BrowserSubprocess.Core/packages.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="3.3202.1686" targetFramework="native" />
+  <package id="cef.sdk" version="3.3202.1690-proprietary-codecs" targetFramework="native" />
 </packages>

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -336,6 +336,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.sdk.3.3202.1686\build\cef.sdk.props'))" />
+    <Error Condition="!Exists('..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.sdk.3.3202.1690-proprietary-codecs\build\cef.sdk.props'))" />
   </Target>
 </Project>

--- a/CefSharp.Core/packages.config
+++ b/CefSharp.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="3.3202.1686" targetFramework="native" />
+  <package id="cef.sdk" version="3.3202.1690-proprietary-codecs" targetFramework="native" />
 </packages>

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
@@ -102,7 +102,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets'))" />
-    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets'))" />
   </Target>
-  <Import Project="..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" />
+  <Import Project="..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" />
 </Project>

--- a/CefSharp.OffScreen.Example/packages.config
+++ b/CefSharp.OffScreen.Example/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="cef.redist.x64" version="3.3202.1686" targetFramework="net452" />
-  <package id="cef.redist.x86" version="3.3202.1686" targetFramework="net452" />
+  <package id="cef.redist.x86" version="3.3202.1690-proprietary-codecs" targetFramework="net452" />
 </packages>

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -153,7 +153,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets'))" />
-    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets'))" />
   </Target>
-  <Import Project="..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" />
+  <Import Project="..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" />
 </Project>

--- a/CefSharp.Test/packages.config
+++ b/CefSharp.Test/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="cef.redist.x64" version="3.3202.1686" targetFramework="net452" />
-  <package id="cef.redist.x86" version="3.3202.1686" targetFramework="net452" />
+  <package id="cef.redist.x86" version="3.3202.1690-proprietary-codecs" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -192,7 +192,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets'))" />
-    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets'))" />
   </Target>
-  <Import Project="..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" />
+  <Import Project="..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" />
 </Project>

--- a/CefSharp.WinForms.Example/packages.config
+++ b/CefSharp.WinForms.Example/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="cef.redist.x64" version="3.3202.1686" targetFramework="net452" />
-  <package id="cef.redist.x86" version="3.3202.1686" targetFramework="net452" />
+  <package id="cef.redist.x86" version="3.3202.1690-proprietary-codecs" targetFramework="net452" />
 </packages>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -194,7 +194,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x64.3.3202.1686\build\cef.redist.x64.targets'))" />
-    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets'))" />
   </Target>
-  <Import Project="..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1686\build\cef.redist.x86.targets')" />
+  <Import Project="..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.3202.1690-proprietary-codecs\build\cef.redist.x86.targets')" />
 </Project>

--- a/CefSharp.Wpf.Example/packages.config
+++ b/CefSharp.Wpf.Example/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="cef.redist.x64" version="3.3202.1686" targetFramework="net452" />
-  <package id="cef.redist.x86" version="3.3202.1686" targetFramework="net452" />
+  <package id="cef.redist.x86" version="3.3202.1690-proprietary-codecs" targetFramework="net452" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="MvvmLightLibs" version="5.1.1.0" targetFramework="net45" />
 </packages>

--- a/NuGet/CefSharp.Common.nuspec
+++ b/NuGet/CefSharp.Common.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright © 2010-2017 The CefSharp Authors</copyright>
     <dependencies>
       <dependency id="cef.redist.x86" version="[$RedistVersion$]" />
-      <dependency id="cef.redist.x64" version="[$RedistVersion$]" />
+      <!-- <dependency id="cef.redist.x64" version="[$RedistVersion$]" /> -->
     </dependencies>
   </metadata>
   <files>
@@ -24,32 +24,32 @@
     <file src="..\CefSharp.Core\bin\Win32\Release\CefSharp.Core.dll" target="CefSharp\x86"/>
     <file src="..\CefSharp.Core\bin\Win32\Release\CefSharp.Core.xml" target="CefSharp\x86"/>
     <file src="..\CefSharp.Core\bin\Win32\Release\CefSharp.Core.pdb" target="CefSharp\x86"/>
-  
-    <file src="..\CefSharp.Core\bin\x64\Release\CefSharp.Core.dll" target="CefSharp\x64"/>
+
+    <!-- <file src="..\CefSharp.Core\bin\x64\Release\CefSharp.Core.dll" target="CefSharp\x64"/>
     <file src="..\CefSharp.Core\bin\x64\Release\CefSharp.Core.xml" target="CefSharp\x64"/>
-    <file src="..\CefSharp.Core\bin\x64\Release\CefSharp.Core.pdb" target="CefSharp\x64"/>
-  
+    <file src="..\CefSharp.Core\bin\x64\Release\CefSharp.Core.pdb" target="CefSharp\x64"/> -->
+
     <file src="..\CefSharp\bin\x86\Release\CefSharp.dll" target="CefSharp\x86"/>
     <file src="..\CefSharp\bin\x86\Release\CefSharp.xml" target="CefSharp\x86"/>
     <file src="..\CefSharp\bin\x86\Release\CefSharp.pdb" target="CefSharp\x86"/>
-  
-    <file src="..\CefSharp\bin\x64\Release\CefSharp.dll" target="CefSharp\x64"/>
+
+    <!-- <file src="..\CefSharp\bin\x64\Release\CefSharp.dll" target="CefSharp\x64"/>
     <file src="..\CefSharp\bin\x64\Release\CefSharp.xml" target="CefSharp\x64"/>
-    <file src="..\CefSharp\bin\x64\Release\CefSharp.pdb" target="CefSharp\x64"/>
-  
+    <file src="..\CefSharp\bin\x64\Release\CefSharp.pdb" target="CefSharp\x64"/> -->
+
     <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x86"/>
     <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.Core.pdb" target="CefSharp\x86"/>
     <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.exe" target="CefSharp\x86"/>
     <file src="..\CefSharp.BrowserSubprocess\bin\x86\Release\CefSharp.BrowserSubprocess.pdb" target="CefSharp\x86"/>
-  
-    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x64"/>
+
+    <!-- <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.Core.dll" target="CefSharp\x64"/>
     <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.Core.pdb" target="CefSharp\x64"/>
     <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.exe" target="CefSharp\x64"/>
-    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.pdb" target="CefSharp\x64"/>
+    <file src="..\CefSharp.BrowserSubprocess\bin\x64\Release\CefSharp.BrowserSubprocess.pdb" target="CefSharp\x64"/> -->
 
     <file src="CefSharp.Common.props" target="build" />
     <file src="CefSharp.Common.targets" target="build" />
-  
+
     <file src="..\CefSharp\**\*.cs" target="src\CefSharp" />
     <file src="..\CefSharp.Core\**\*.h" target="src\CefSharp.Core" />
     <file src="..\CefSharp.Core\**\*.cpp" target="src\CefSharp.Core" />

--- a/NuGet/CefSharp.OffScreen.nuspec
+++ b/NuGet/CefSharp.OffScreen.nuspec
@@ -28,9 +28,9 @@
     <file src="..\CefSharp.OffScreen\bin\x86\Release\CefSharp.OffScreen.xml" target="CefSharp\x86" />
     <file src="..\CefSharp.OffScreen\bin\x86\Release\CefSharp.OffScreen.pdb" target="CefSharp\x86" />
 
-    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.dll" target="CefSharp\x64" />
+    <!-- <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.dll" target="CefSharp\x64" />
     <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.xml" target="CefSharp\x64" />
-    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.pdb" target="CefSharp\x64" />    
+    <file src="..\CefSharp.OffScreen\bin\x64\Release\CefSharp.OffScreen.pdb" target="CefSharp\x64" />     -->
 
     <file src="CefSharp.OffScreen.props" target="build" />
     <file src="CefSharp.OffScreen.targets" target="build" />

--- a/NuGet/CefSharp.WinForms.nuspec
+++ b/NuGet/CefSharp.WinForms.nuspec
@@ -28,9 +28,9 @@
     <file src="..\CefSharp.WinForms\bin\x86\Release\CefSharp.WinForms.xml" target="CefSharp\x86" />
     <file src="..\CefSharp.WinForms\bin\x86\Release\CefSharp.WinForms.pdb" target="CefSharp\x86" />
 
-    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.dll" target="CefSharp\x64" />
+    <!-- <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.dll" target="CefSharp\x64" />
     <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.xml" target="CefSharp\x64" />
-    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.pdb" target="CefSharp\x64" />
+    <file src="..\CefSharp.WinForms\bin\x64\Release\CefSharp.WinForms.pdb" target="CefSharp\x64" /> -->
 
     <file src="CefSharp.WinForms.props" target="build" />
     <file src="CefSharp.WinForms.targets" target="build" />

--- a/NuGet/CefSharp.Wpf.nuspec
+++ b/NuGet/CefSharp.Wpf.nuspec
@@ -28,9 +28,9 @@
     <file src="..\CefSharp.Wpf\bin\x86\Release\CefSharp.Wpf.xml" target="CefSharp\x86" />
     <file src="..\CefSharp.Wpf\bin\x86\Release\CefSharp.Wpf.pdb" target="CefSharp\x86" />
 
-    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.xml" target="CefSharp\x64" />
+    <!-- <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.xml" target="CefSharp\x64" />
     <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.dll" target="CefSharp\x64" />
-    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.pdb" target="CefSharp\x64" />
+    <file src="..\CefSharp.Wpf\bin\x64\Release\CefSharp.Wpf.pdb" target="CefSharp\x64" /> -->
 
     <file src="CefSharp.Wpf.props" target="build" />
     <file src="CefSharp.Wpf.targets" target="build" />

--- a/build.ps1
+++ b/build.ps1
@@ -1,11 +1,11 @@
 param(
     [ValidateSet("vs2013", "vs2015", "nupkg-only", "gitlink")]
-    [Parameter(Position = 0)] 
+    [Parameter(Position = 0)]
     [string] $Target = "vs2013",
     [Parameter(Position = 1)]
     [string] $Version = "59.0.0",
     [Parameter(Position = 2)]
-    [string] $AssemblyVersion = "59.0.0"   
+    [string] $AssemblyVersion = "59.0.0"
 )
 
 $WorkingDir = split-path -parent $MyInvocation.MyCommand.Definition
@@ -16,7 +16,7 @@ $CefSln = Join-Path $WorkingDir 'CefSharp3.sln'
 $CefSharpCorePackagesXml = [xml](Get-Content (Join-Path $WorkingDir 'CefSharp.Core\Packages.config'))
 $RedistVersion = $CefSharpCorePackagesXml.SelectSingleNode("//packages/package[@id='cef.sdk']/@version").value
 
-function Write-Diagnostic 
+function Write-Diagnostic
 {
     param(
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
@@ -28,42 +28,45 @@ function Write-Diagnostic
     Write-Host
 }
 
-if (Test-Path Env:\APPVEYOR_BUILD_VERSION)
-{
-    $Version = $env:APPVEYOR_BUILD_VERSION
-}
+# if (Test-Path Env:\APPVEYOR_BUILD_VERSION)
+# {
+#     $Version = $env:APPVEYOR_BUILD_VERSION
+# }
+
+# Temporary hack since we need this to be right in both the Version and the Dependencies for the packages to be really installable.
+$Version = '62.0.0-proprietary-codecs2'
 
 if ($env:APPVEYOR_REPO_TAG -eq "True")
 {
     $Version = "$env:APPVEYOR_REPO_TAG_NAME".Substring(1)  # trim leading "v"
-    Write-Diagnostic "Setting version based on tag to $Version"    
+    Write-Diagnostic "Setting version based on tag to $Version"
 }
 
 # https://github.com/jbake/Powershell_scripts/blob/master/Invoke-BatchFile.ps1
-function Invoke-BatchFile 
+function Invoke-BatchFile
 {
    param(
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-        [string]$Path, 
+        [string]$Path,
         [Parameter(Position = 1, Mandatory = $true, ValueFromPipeline = $true)]
         [string]$Parameters
    )
 
-   $tempFile = [IO.Path]::GetTempFileName()  
+   $tempFile = [IO.Path]::GetTempFileName()
 
-   cmd.exe /c " `"$Path`" $Parameters && set > `"$tempFile`" " 
+   cmd.exe /c " `"$Path`" $Parameters && set > `"$tempFile`" "
 
-   Get-Content $tempFile | Foreach-Object {   
-       if ($_ -match "^(.*?)=(.*)$")  
-       { 
-           Set-Content "env:\$($matches[1])" $matches[2]  
-       } 
-   }  
+   Get-Content $tempFile | Foreach-Object {
+       if ($_ -match "^(.*?)=(.*)$")
+       {
+           Set-Content "env:\$($matches[1])" $matches[2]
+       }
+   }
 
    Remove-Item $tempFile
 }
 
-function Die 
+function Die
 {
     param(
         [Parameter(Position = 0, ValueFromPipeline = $true)]
@@ -71,11 +74,11 @@ function Die
     )
 
     Write-Host
-    Write-Error $Message 
+    Write-Error $Message
     exit 1
 }
 
-function Warn 
+function Warn
 {
     param(
         [Parameter(Position = 0, ValueFromPipeline = $true)]
@@ -87,7 +90,7 @@ function Warn
     Write-Host
 }
 
-function TernaryReturn 
+function TernaryReturn
 {
     param(
         [Parameter(Position = 0, ValueFromPipeline = $true)]
@@ -101,20 +104,20 @@ function TernaryReturn
     if($Yes) {
         return $Value
     }
-    
+
     $Value2
 }
 
-function Msvs 
+function Msvs
 {
     param(
         [ValidateSet('v120', 'v140')]
         [Parameter(Position = 0, ValueFromPipeline = $true)]
-        [string] $Toolchain, 
+        [string] $Toolchain,
 
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         [ValidateSet('Debug', 'Release')]
-        [string] $Configuration, 
+        [string] $Configuration,
 
         [Parameter(Position = 2, ValueFromPipeline = $true)]
         [ValidateSet('x86', 'x64')]
@@ -185,10 +188,10 @@ function Msvs
     $Process = New-Object System.Diagnostics.Process
     $Process.StartInfo = $startInfo
     $Process.Start()
-    
+
     $stdout = $Process.StandardOutput.ReadToEnd()
     $stderr = $Process.StandardError.ReadToEnd()
-    
+
     $Process.WaitForExit()
 
     if($Process.ExitCode -ne 0)
@@ -199,7 +202,7 @@ function Msvs
     }
 }
 
-function VSX 
+function VSX
 {
     param(
         [ValidateSet('v120', 'v140')]
@@ -220,7 +223,9 @@ function VSX
     Write-Diagnostic "Starting to build targeting toolchain $Toolchain"
 
     Msvs "$Toolchain" 'Release' 'x86'
-    Msvs "$Toolchain" 'Release' 'x64'
+
+    # TODO: reenable if/when we have x64 packages we can use.
+    # Msvs "$Toolchain" 'Release' 'x64'
 
     Write-Diagnostic "Finished build targeting toolchain $Toolchain"
 }
@@ -242,11 +247,11 @@ function Nupkg
 {
     if (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER)
     {
-        Write-Diagnostic "Pr Number: $env:APPVEYOR_PULL_REQUEST_NUMBER"
+        Write-Diagnostic "PR Number: $env:APPVEYOR_PULL_REQUEST_NUMBER"
         Write-Diagnostic "Skipping Nupkg"
         return
     }
-    
+
     $nuget = Join-Path $WorkingDir .\nuget\NuGet.exe
     if(-not (Test-Path $nuget)) {
         Die "Please install nuget. More information available at: http://docs.nuget.org/docs/start-here/installing-nuget"
@@ -281,10 +286,10 @@ function DownloadNuget()
 function UpdateSymbolsWithGitLink()
 {
     $gitlink = "GitLink.exe"
-    
+
     #Check for GitLink
-    if ((Get-Command $gitlink -ErrorAction SilentlyContinue) -eq $null) 
-    { 
+    if ((Get-Command $gitlink -ErrorAction SilentlyContinue) -eq $null)
+    {
         #Download if not on path and not in Nuget folder (TODO: change to different folder)
         $gitlink = Join-Path $WorkingDir .\nuget\GitLink.exe
         if(-not (Test-Path $gitlink))
@@ -294,9 +299,9 @@ function UpdateSymbolsWithGitLink()
             $client.DownloadFile('https://github.com/GitTools/GitLink/releases/download/2.3.0/GitLink.exe', $gitlink);
         }
     }
-    
+
     Write-Diagnostic "GitLink working dir : $WorkingDir"
-    
+
     # Run GitLink in the workingDir
     . $gitlink $WorkingDir -f CefSharp3.sln -u https://github.com/CefSharp/CefSharp -c Release -p x64 -ignore CefSharp.Example,CefSharp.Wpf.Example,CefSharp.OffScreen.Example,CefSharp.WinForms.Example
     . $gitlink $WorkingDir -f CefSharp3.sln -u https://github.com/CefSharp/CefSharp -c Release -p x86 -ignore CefSharp.Example,CefSharp.Wpf.Example,CefSharp.OffScreen.Example,CefSharp.WinForms.Example
@@ -309,11 +314,11 @@ function WriteAssemblyVersion
     $Filename = Join-Path $WorkingDir CefSharp\Properties\AssemblyInfo.cs
     $Regex = 'public const string AssemblyVersion = "(.*)"';
     $Regex2 = 'public const string AssemblyFileVersion = "(.*)"'
-    
+
     $AssemblyInfo = Get-Content $Filename
     $NewString = $AssemblyInfo -replace $Regex, "public const string AssemblyVersion = ""$AssemblyVersion"""
     $NewString = $NewString -replace $Regex2, "public const string AssemblyFileVersion = ""$AssemblyVersion.0"""
-    
+
     $NewString | Set-Content $Filename -Encoding UTF8
 }
 
@@ -321,10 +326,10 @@ function WriteVersionToManifest($manifest)
 {
     $Filename = Join-Path $WorkingDir $manifest
     $Regex = 'assemblyIdentity version="(.*?)"';
-    
+
     $ManifestData = Get-Content $Filename
     $NewString = $ManifestData -replace $Regex, "assemblyIdentity version=""$AssemblyVersion.0"""
-    
+
     $NewString | Set-Content $Filename -Encoding UTF8
 }
 
@@ -333,11 +338,11 @@ function WriteVersionToResourceFile($resourceFile)
     $Filename = Join-Path $WorkingDir $resourceFile
     $Regex1 = 'VERSION .*';
     $Regex2 = 'Version", ".*?"';
-    
+
     $ResourceData = Get-Content $Filename
     $NewString = $ResourceData -replace $Regex1, "VERSION $AssemblyVersion"
     $NewString = $NewString -replace $Regex2, "Version"", ""$AssemblyVersion"""
-    
+
     $NewString | Set-Content $Filename -Encoding UTF8
 }
 


### PR DESCRIPTION
These packages are custom-built by me, and includes proprietary codecs. The legal status of using these packages is questionable, so use them at your own risk.

They were built using this build script, and these Chromium flags:

```bat
set CEF_USE_GN=1
set GN_DEFINES=is_official_build=true proprietary_codecs=true ffmpeg_branding=Chrome
set GYP_DEFINES=buildtype=Official
set GYP_MSVS_VERSION=2015
set CEF_ARCHIVE_FORMAT=tar.bz2
set DEPOT_TOOLS_UPDATE=0

python ..\automate\automate-git.py --download-dir=. --depot-tools-dir=..\depot_tools --minimal-distrib --client-distrib --branch=3202 --force-build --no-debug-build
```

See https://github.com/cefsharp/cef-binary/pull/62 for the CEF version being used here.

This is a temporary workaround for #1479. Once CEF 63 has landed, we should make an official CefSharp version based on that; this is definitely just for the time being. **You may run into legal trouble if you use these packages**, especially in certain jurisdictions.

The unofficial packages are here: https://www.myget.org/feed/Packages/perlun