### PR TITLE
Visual Studio 2017 build (#2179)

### DIFF
--- a/CefSharp.props
+++ b/CefSharp.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <VisualStudioProductVersion>2013</VisualStudioProductVersion>
     <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='14.0'">2015</VisualStudioProductVersion>
-    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='15.0'">2015</VisualStudioProductVersion>
+    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='15.0'">2017</VisualStudioProductVersion>
 
     <PlatformToolset>v120</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>


### PR DESCRIPTION
VisualStudioProductVersion was pointing to 2015, and 2015 version of cef.sdk library package was linked.