### PR TITLE
WinForms: Prevent designer from setting default values

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -73,7 +73,7 @@ namespace CefSharp.WinForms
         /// Gets or sets the request context.
         /// </summary>
         /// <value>The request context.</value>
-        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(null)]
         public IRequestContext RequestContext
         {
             get { return requestContext; }
@@ -137,7 +137,7 @@ namespace CefSharp.WinForms
         /// Implement <see cref="IRequestHandler" /> and assign to handle events related to browser requests.
         /// </summary>
         /// <value>The request handler.</value>
-        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(null)]
         public IRequestHandler RequestHandler { get; set; }
         /// <summary>
         /// Implement <see cref="IDownloadHandler" /> and assign to handle events related to downloading files.
@@ -173,7 +173,7 @@ namespace CefSharp.WinForms
         /// Implement <see cref="IRenderProcessMessageHandler" /> and assign to handle messages from the render process.
         /// </summary>
         /// <value>The render process message handler.</value>
-        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(null)]
         public IRenderProcessMessageHandler RenderProcessMessageHandler { get; set; }
         /// <summary>
         /// Implement <see cref="IFindHandler" /> to handle events related to find results.
@@ -203,7 +203,7 @@ namespace CefSharp.WinForms
         /// Implement <see cref="IResourceHandlerFactory" /> and control the loading of resources
         /// </summary>
         /// <value>The resource handler factory.</value>
-        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(null)]
         public IResourceHandlerFactory ResourceHandlerFactory { get; set; }
         /// <summary>
         /// Implement <see cref="IGeolocationHandler" /> and assign to handle requests for permission to use geolocation.


### PR DESCRIPTION
This PR solves the issue described in https://github.com/cefsharp/CefSharp/issues/2206#issuecomment-362769476

The changes in this PR prevents the designer from setting the default value of specific properties which caused it to attempt to load `CefSharp.Core` causing an exception to be thrown