### PR TITLE
Split CefFileDialogMode into CefFileDialogMode and CefFileDialogFlags

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -1019,7 +1019,19 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             auto callbackWrapper = gcnew CefFileDialogCallbackWrapper(callback);
 
-            return handler->OnFileDialog(_browserControl, browserWrapper, (CefFileDialogMode)mode, StringUtils::ToClr(title), StringUtils::ToClr(default_file_path), StringUtils::ToClr(accept_filters), selected_accept_filter, callbackWrapper);
+            auto dialogMode = mode & FileDialogMode::FILE_DIALOG_TYPE_MASK;
+            auto dialogFlags = mode & ~FileDialogMode::FILE_DIALOG_TYPE_MASK;
+
+            return handler->OnFileDialog(
+                _browserControl,
+                browserWrapper,
+                (CefFileDialogMode)dialogMode,
+                (CefFileDialogFlags)dialogFlags,
+                StringUtils::ToClr(title),
+                StringUtils::ToClr(default_file_path),
+                StringUtils::ToClr(accept_filters),
+                selected_accept_filter,
+                callbackWrapper);
         }
 
         bool ClientAdapter::OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, DragOperationsMask mask)

--- a/CefSharp.Example/TempFileDialogHandler.cs
+++ b/CefSharp.Example/TempFileDialogHandler.cs
@@ -9,10 +9,10 @@ namespace CefSharp.Example
 {
     public class TempFileDialogHandler : IDialogHandler
     {
-        public bool OnFileDialog(IWebBrowser browserControl, IBrowser browser, CefFileDialogMode mode, string title, string defaultFilePath, List<string> acceptFilters, int selectedAcceptFilter, IFileDialogCallback callback)
+        public bool OnFileDialog(IWebBrowser browserControl, IBrowser browser, CefFileDialogMode mode, CefFileDialogFlags flags, string title, string defaultFilePath, List<string> acceptFilters, int selectedAcceptFilter, IFileDialogCallback callback)
         {
             callback.Continue(selectedAcceptFilter, new List<string> { Path.GetRandomFileName() });
-            
+
             return true;
         }
     }

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Callback\TaskPrintToPdfCallback.cs" />
     <Compile Include="Callback\TaskResolveCallback.cs" />
     <Compile Include="CdmRegistration.cs" />
+    <Compile Include="Enums\CefFileDialogFlags.cs" />
     <Compile Include="Event\JavascriptBindingEventArgs.cs" />
     <Compile Include="Handler\DefaultRequestHandler.cs" />
     <Compile Include="Enums\UrlRequestFlags.cs" />

--- a/CefSharp/Enums/CefFileDialogFlags.cs
+++ b/CefSharp/Enums/CefFileDialogFlags.cs
@@ -1,0 +1,21 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+
+namespace CefSharp
+{
+    [Flags]
+    public enum CefFileDialogFlags
+    {
+        /// <summary>
+        /// Prompt to overwrite if the user selects an existing file with the Save dialog.
+        /// </summary>
+        OverwritePrompt = 0x01000000,
+        /// <summary>
+        /// Do not display read-only files.
+        /// </summary>
+        HideReadOnly = 0x02000000,
+    }
+}

--- a/CefSharp/Enums/CefFileDialogMode.cs
+++ b/CefSharp/Enums/CefFileDialogMode.cs
@@ -1,21 +1,18 @@
-﻿// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
-
-using System;
 
 namespace CefSharp
 {
     /// <summary>
     /// CefFileDialogMode (Based on cef_file_dialog_mode_t)
     /// </summary>
-    [Flags]
     public enum CefFileDialogMode
     {
         /// <summary>
         /// Requires that the file exists before allowing the user to pick it.
         /// </summary>
-        Open = 0,
+        Open,
         /// <summary>
         /// Like Open, but allows picking multiple files to open.
         /// </summary>
@@ -27,18 +24,6 @@ namespace CefSharp
         /// <summary>
         /// Allows picking a nonexistent file, and prompts to overwrite if the file already exists.
         /// </summary>
-        Save,
-        /// <summary>
-        /// General mask defining the bits used for the type values.
-        /// </summary>
-        TypeMask = 0xFF,
-        /// <summary>
-        /// Prompt to overwrite if the user selects an existing file with the Save dialog.
-        /// </summary>
-        OverwritePrompt = 0x01000000,
-        /// <summary>
-        /// Do not display read-only files.
-        /// </summary>
-        HideReadOnly = 0x02000000,
+        Save
     }
 }

--- a/CefSharp/Handler/IDialogHandler.cs
+++ b/CefSharp/Handler/IDialogHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
@@ -25,6 +25,7 @@ namespace CefSharp
         /// <param name="browserControl">the browser control</param>
         /// <param name="browser">the browser object</param>
         /// <param name="mode">represents the type of dialog to display</param>
+        /// <param name="flags">further specifies behavior dialog should exhibit</param>
         /// <param name="title">the title to be used for the dialog. It may be empty to show the default title ("Open" or "Save" 
         /// depending on the mode).</param>
         /// <param name="defaultFilePath">is the path with optional directory and/or file name component that
@@ -36,6 +37,15 @@ namespace CefSharp
         /// <param name="selectedAcceptFilter">is the 0-based index of the filter that should be selected by default.</param>
         /// <param name="callback">Callback interface for asynchronous continuation of file dialog requests.</param>
         /// <returns>To display a custom dialog return true. To display the default dialog return false.</returns>
-        bool OnFileDialog(IWebBrowser browserControl, IBrowser browser, CefFileDialogMode mode, string title, string defaultFilePath, List<string> acceptFilters, int selectedAcceptFilter, IFileDialogCallback callback);
+        bool OnFileDialog(
+            IWebBrowser browserControl,
+            IBrowser browser,
+            CefFileDialogMode mode,
+            CefFileDialogFlags flags,
+            string title,
+            string defaultFilePath,
+            List<string> acceptFilters,
+            int selectedAcceptFilter,
+            IFileDialogCallback callback);
     }
 }


### PR DESCRIPTION
Resolves #2277 by splitting the enum.

In CEF, `cef_file_dialog_mode_t` is a mix of flags and non-flags. In the .NET managed world, a combination like that rather unusual. As such, my suggestion is to split the enum into `CefFileDialogMode` and `CefFileDialogFlags`.