### PR TITLE
Fixed crash in Writable Bitmap Factory when browser is resized

### DIFF
--- a/CefSharp.Wpf/Rendering/WritableBitmapFactory.cs
+++ b/CefSharp.Wpf/Rendering/WritableBitmapFactory.cs
@@ -115,6 +115,11 @@ namespace CefSharp.Wpf.Rendering
             {
                 lock (lockObject)
                 {
+                    if (backBufferHandle.IsInvalid) 
+                    {
+                        return; // bailout, the handle was recreated
+                    }
+
                     if (createNewBitmap)
                     {
                         if (image.Source != null)


### PR DESCRIPTION
When resizing the browser CreateOrUpdateBitmap from WritableBitmapFactory throws exception when using an invalid image handle.
Fixed that problem preventing the bitmap update to occur with invalid image handles. The update will eventually occur later with the freshly created handle.