### PR TITLE
 Fix non-thread-safety of TrySetResultAsync

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -507,7 +507,7 @@ namespace CefSharp.OffScreen
             // Try our luck and see if there is already a screenshot, to save us creating a new thread for nothing.
             var screenshot = ScreenshotOrNull(blend);
 
-            var completionSource = new TaskCompletionSource<Bitmap>();
+            var completionSource = new AsyncTaskCompletionSource<Bitmap>();
 
             if (screenshot == null || ignoreExistingScreenshot)
             {

--- a/CefSharp.Test/Framework/AsyncExtensionFacts.cs
+++ b/CefSharp.Test/Framework/AsyncExtensionFacts.cs
@@ -36,22 +36,25 @@ namespace CefSharp.Test.Framework
         [Fact]
         public async Task TaskDeleteCookiesCallbackOnComplete()
         {
-            const int numberOfCookiesDeleted = 10;
-
-            var callback = new TaskDeleteCookiesCallback();
-
-            //Execute OnComplete on seperate Thread as in practice will be called on the CEF IO Thread.
-            Task.Delay(100).ContinueWith(x =>
+            for (var i = 0; i < 100; i++)
             {
-                var c = (IDeleteCookiesCallback)callback;
+                const int numberOfCookiesDeleted = 10;
 
-                c.OnComplete(numberOfCookiesDeleted);
-                c.Dispose();
-            }, TaskScheduler.Default);
+                var callback = new TaskDeleteCookiesCallback();
 
-            var result = await callback.Task;
+                //Execute OnComplete on seperate Thread as in practice will be called on the CEF IO Thread.
+                Task.Delay(100).ContinueWith(x =>
+                {
+                    var c = (IDeleteCookiesCallback)callback;
 
-            Assert.Equal(numberOfCookiesDeleted, result);
+                    c.OnComplete(numberOfCookiesDeleted);
+                    c.Dispose();
+                }, TaskScheduler.Default);
+
+                var result = await callback.Task;
+
+                Assert.Equal(numberOfCookiesDeleted, result);
+            }
         }
 
         [Fact]

--- a/CefSharp/Callback/TaskCompletionCallback.cs
+++ b/CefSharp/Callback/TaskCompletionCallback.cs
@@ -10,11 +10,11 @@ namespace CefSharp
 {
     public class TaskCompletionCallback : ICompletionCallback
     {
-        private readonly TaskCompletionSource<bool> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<bool> taskCompletionSource;
 
         public TaskCompletionCallback()
         {
-            taskCompletionSource = new TaskCompletionSource<bool>();
+            taskCompletionSource = new AsyncTaskCompletionSource<bool>();
         }
 
         void ICompletionCallback.OnComplete()

--- a/CefSharp/Callback/TaskDeleteCookiesCallback.cs
+++ b/CefSharp/Callback/TaskDeleteCookiesCallback.cs
@@ -15,12 +15,12 @@ namespace CefSharp
     {
         public const int InvalidNoOfCookiesDeleted = -1;
 
-        private readonly TaskCompletionSource<int> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<int> taskCompletionSource;
         private volatile bool isDisposed;
 
         public TaskDeleteCookiesCallback()
         {
-            taskCompletionSource = new TaskCompletionSource<int>();
+            taskCompletionSource = new AsyncTaskCompletionSource<int>();
         }
 
         void IDeleteCookiesCallback.OnComplete(int numDeleted)

--- a/CefSharp/Callback/TaskPrintToPdfCallback.cs
+++ b/CefSharp/Callback/TaskPrintToPdfCallback.cs
@@ -10,7 +10,7 @@ namespace CefSharp
 {
     public sealed class TaskPrintToPdfCallback : IPrintToPdfCallback
     {
-        private readonly TaskCompletionSource<bool> taskCompletionSource = new TaskCompletionSource<bool>();
+        private readonly AsyncTaskCompletionSource<bool> taskCompletionSource = new AsyncTaskCompletionSource<bool>();
 
         public Task<bool> Task
         {

--- a/CefSharp/Callback/TaskRegisterCdmCallback.cs
+++ b/CefSharp/Callback/TaskRegisterCdmCallback.cs
@@ -13,11 +13,11 @@ namespace CefSharp
     /// </summary>
     public class TaskRegisterCdmCallback: IRegisterCdmCallback
     {
-        private readonly TaskCompletionSource<CdmRegistration> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<CdmRegistration> taskCompletionSource;
 
         public TaskRegisterCdmCallback()
         {
-            taskCompletionSource = new TaskCompletionSource<CdmRegistration>();
+            taskCompletionSource = new AsyncTaskCompletionSource<CdmRegistration>();
         }
 
         void IRegisterCdmCallback.OnRegistrationComplete(CdmRegistration registration)

--- a/CefSharp/Callback/TaskResolveCallback.cs
+++ b/CefSharp/Callback/TaskResolveCallback.cs
@@ -10,11 +10,11 @@ namespace CefSharp
 {
     public class TaskResolveCallback : IResolveCallback
     {
-        private readonly TaskCompletionSource<ResolveCallbackResult> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<ResolveCallbackResult> taskCompletionSource;
 
         public TaskResolveCallback()
         {
-            taskCompletionSource = new TaskCompletionSource<ResolveCallbackResult>();
+            taskCompletionSource = new AsyncTaskCompletionSource<ResolveCallbackResult>();
         }
 
         public void OnResolveCompleted(CefErrorCode result, IList<string> resolvedIpAddresses)

--- a/CefSharp/Callback/TaskSetCookieCallback.cs
+++ b/CefSharp/Callback/TaskSetCookieCallback.cs
@@ -13,12 +13,12 @@ namespace CefSharp
     /// </summary>
     public class TaskSetCookieCallback : ISetCookieCallback
     {
-        private readonly TaskCompletionSource<bool> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<bool> taskCompletionSource;
         private volatile bool isDisposed;
 
         public TaskSetCookieCallback()
         {
-            taskCompletionSource = new TaskCompletionSource<bool>();
+            taskCompletionSource = new AsyncTaskCompletionSource<bool>();
         }
 
         void ISetCookieCallback.OnComplete(bool success)

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="AsyncExtensions.cs" />
     <Compile Include="BindingOptions.cs" />
+    <Compile Include="Internals\AsyncTaskCompletionSource.cs" />
     <Compile Include="Callback\IAuthCallback.cs" />
     <Compile Include="Callback\IBeforeDownloadCallback.cs" />
     <Compile Include="Callback\ICallback.cs" />

--- a/CefSharp/Internals/AsyncTaskCompletionSource.cs
+++ b/CefSharp/Internals/AsyncTaskCompletionSource.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Wraps <see cref="TaskCompletionSource{T}"/> by providing a way to set its result in an async fashion.
+    /// This prevents the Task Continuation being executed sync on the same thread, which may be required when
+    /// continuations must not run on CEF UI threads.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class AsyncTaskCompletionSource<T>
+    {
+        private readonly TaskCompletionSource<T> tcs = new TaskCompletionSource<T>();
+        private int resultSet = 0;
+
+        /// <summary>
+        /// Gets the <see cref="Task{TResult}"/> created by this <see cref="AsyncTaskCompletionSource{T}"/>
+        /// </summary>
+        /// <seealso cref="TaskCompletionSource{TResult}.Task"/>
+        public Task<T> Task => tcs.Task;
+
+        /// <summary>
+        /// Set the TaskCompletionSource in an async fashion. This prevents the Task Continuation being executed sync on the same thread
+        /// This is required otherwise contintinuations will happen on CEF UI threads
+        /// </summary>
+        /// <param name="result">result</param>
+        public void TrySetResultAsync(T result)
+        {
+            if (Interlocked.Exchange(ref resultSet, 1) == 0)
+                System.Threading.Tasks.Task.Factory.StartNew(() => tcs.TrySetResult(result), CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+        }
+    }
+}

--- a/CefSharp/Internals/AsyncTaskCompletionSource.cs
+++ b/CefSharp/Internals/AsyncTaskCompletionSource.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,14 +26,15 @@ namespace CefSharp
         public Task<T> Task => tcs.Task;
 
         /// <summary>
-        /// Set the TaskCompletionSource in an async fashion. This prevents the Task Continuation being executed sync on the same thread
-        /// This is required otherwise contintinuations will happen on CEF UI threads
+        /// Set the TaskCompletionSource in an async fashion. This prevents the Task Continuation being executed
+        /// sync on the same thread. This is required otherwise contintinuations will happen on CEF UI threads.
         /// </summary>
         /// <param name="result">result</param>
         public void TrySetResultAsync(T result)
         {
             if (Interlocked.Exchange(ref resultSet, 1) == 0)
-                System.Threading.Tasks.Task.Factory.StartNew(() => tcs.TrySetResult(result), CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+                System.Threading.Tasks.Task.Factory.StartNew(() => tcs.TrySetResult(result),
+                    CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
         }
     }
 }

--- a/CefSharp/Internals/TaskExtensions.cs
+++ b/CefSharp/Internals/TaskExtensions.cs
@@ -89,8 +89,14 @@ namespace CefSharp.Internals
         }
 
         /// <summary>
+        /// <para>
         /// Set the TaskCompletionSource in an async fashion. This prevents the Task Continuation being executed sync on the same thread
-        /// This is required otherwise contintinuations will happen on CEF UI threads
+        /// This is required otherwise contintinuations will happen on CEF UI threads.
+        /// </para>
+        /// <para>
+        /// USAGE WARNING: if this method is called twice on the same task completion source, the result it not deterministic.
+        /// Use it with care, or use <see cref="AsyncTaskCompletionSource{T}"/>.
+        /// </para>
         /// </summary>
         /// <typeparam name="TResult">Generic param</typeparam>
         /// <param name="taskCompletionSource">tcs</param>

--- a/CefSharp/Visitor/TaskCookieVisitor.cs
+++ b/CefSharp/Visitor/TaskCookieVisitor.cs
@@ -15,7 +15,7 @@ namespace CefSharp
     /// </summary>
     public class TaskCookieVisitor : ICookieVisitor
     {
-        private readonly TaskCompletionSource<List<Cookie>> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<List<Cookie>> taskCompletionSource;
         private List<Cookie> list;
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace CefSharp
         /// </summary>
         public TaskCookieVisitor()
         {
-            taskCompletionSource = new TaskCompletionSource<List<Cookie>>();
+            taskCompletionSource = new AsyncTaskCompletionSource<List<Cookie>>();
             list = new List<Cookie>();
         }
 

--- a/CefSharp/Visitor/TaskNavigationEntryVisitor.cs
+++ b/CefSharp/Visitor/TaskNavigationEntryVisitor.cs
@@ -15,7 +15,7 @@ namespace CefSharp
     /// </summary>
     public class TaskNavigationEntryVisitor : INavigationEntryVisitor
     {
-        private TaskCompletionSource<List<NavigationEntry>> taskCompletionSource;
+        private AsyncTaskCompletionSource<List<NavigationEntry>> taskCompletionSource;
         private List<NavigationEntry> list;
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace CefSharp
         /// </summary>
         public TaskNavigationEntryVisitor()
         {
-            taskCompletionSource = new TaskCompletionSource<List<NavigationEntry>>();
+            taskCompletionSource = new AsyncTaskCompletionSource<List<NavigationEntry>>();
             list = new List<NavigationEntry>();
         }
 

--- a/CefSharp/Visitor/TaskStringVisitor.cs
+++ b/CefSharp/Visitor/TaskStringVisitor.cs
@@ -14,14 +14,14 @@ namespace CefSharp
     /// </summary>
     public class TaskStringVisitor : IStringVisitor
     {
-        private readonly TaskCompletionSource<string> taskCompletionSource;
+        private readonly AsyncTaskCompletionSource<string> taskCompletionSource;
 
         /// <summary>
         /// Default constructor
         /// </summary>
         public TaskStringVisitor()
         {
-            taskCompletionSource = new TaskCompletionSource<string>();
+            taskCompletionSource = new AsyncTaskCompletionSource<string>();
         }
 
         /// <summary>

--- a/CefSharp/Visitor/TaskWebPluginInfoVisitor.cs
+++ b/CefSharp/Visitor/TaskWebPluginInfoVisitor.cs
@@ -11,12 +11,12 @@ namespace CefSharp
 {
     public class TaskWebPluginInfoVisitor : IWebPluginInfoVisitor
     {
-        private TaskCompletionSource<List<WebPluginInfo>> taskCompletionSource;
+        private AsyncTaskCompletionSource<List<WebPluginInfo>> taskCompletionSource;
         private List<WebPluginInfo> list;
 
         public TaskWebPluginInfoVisitor()
         {
-            taskCompletionSource = new TaskCompletionSource<List<WebPluginInfo>>();
+            taskCompletionSource = new AsyncTaskCompletionSource<List<WebPluginInfo>>();
             list = new List<WebPluginInfo>();
         }
 


### PR DESCRIPTION
The extension method `TaskExtensions.TrySetResultAsync` has non-deterministic results when called twice on the same instance, even on the same thread: it creates one task for each call, which may not run in their creation order.
This PR adds a wrapper class around `TaskCompletionSource` (`AsyncTaskCompletionSource`), that takes care of calling `TrySetResult` in an async fashion while ensuring that only the first call is executed. I would really recommend using it instead of `TaskCompletionSource` each time `TaskExtensions.TrySetResultAsync` is used (even if it is called only once in any logical workflow), because this non-determinism can cause very subtle and hard-to-track bugs.

This PR also updates the test case that could be violated with the previous behavior (but that was hard to trigger with only one test).