### PR TITLE
Example LifespanHandler.OnAfterCreated fix eperimental code rare crash

### DIFF
--- a/CefSharp.Wpf.Example/Handlers/LifespanHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/LifespanHandler.cs
@@ -77,7 +77,7 @@ namespace CefSharp.Wpf.Example.Handlers
         void ILifeSpanHandler.OnAfterCreated(IWebBrowser browserControl, IBrowser browser)
         {
             //NOTE: This is experimental
-            //if(browser.IsPopup)
+            //if(!browser.IsDisposed && browser.IsPopup)
             //{ 
             //	var chromiumWebBrowser = (ChromiumWebBrowser)browserControl;
 


### PR DESCRIPTION
I want to have my own Window (styled) for the CefSharp popups. So, I've copied the `LifespanHandler` and uncommented the code to my app. I've got a rare crash from my users that browser is disposed in the `OnAfterCreated` method.