### PR TITLE
Handle URL escaped paths correctly

### DIFF
--- a/CefSharp/SchemeHandler/FolderSchemeHandlerFactory.cs
+++ b/CefSharp/SchemeHandler/FolderSchemeHandlerFactory.cs
@@ -80,7 +80,7 @@ namespace CefSharp.SchemeHandler
                 asbolutePath = defaultPage;
             }
 
-            var filePath = Path.GetFullPath(Path.Combine(rootFolder, asbolutePath));
+            var filePath = WebUtility.UrlDecode(Path.GetFullPath(Path.Combine(rootFolder, asbolutePath)));
 
             //Check the file requested is within the specified path and that the file exists
             if(filePath.StartsWith(rootFolder, StringComparison.OrdinalIgnoreCase) && File.Exists(filePath))


### PR DESCRIPTION
Allows for the FolderSchemeHandler to correctly parse encoded URLs such as URLs containing spaces in requests from the currently loaded page.