### PR TITLE
V8Serialization - Replace usage of Stack with HashSet

### DIFF
--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -145,7 +145,7 @@ namespace CefSharp
                         SerializeV8SimpleObject(subDict, propertyName, propertyValue, seen);
                     }
                     list->SetDictionary(index, subDict);
-                } 
+                }
                 else
                 {
                     throw gcnew NotSupportedException("Unable to serialize Type");

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -20,12 +20,12 @@ namespace CefSharp
             template<typename TList, typename TIndex>
             void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj)
             {
-                auto seen = gcnew Stack<Object^>();
+                auto seen = gcnew HashSet<Object^>();
                 SerializeV8SimpleObject(list, index, obj, seen);
             }
 
             template<typename TList, typename TIndex>
-            void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, Stack<Object^>^ seen)
+            void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, HashSet<Object^>^ seen)
             {
                 list->SetNull(index);
 
@@ -33,7 +33,7 @@ namespace CefSharp
                 {
                     return;
                 }
-                seen->Push(obj);
+                seen->Add(obj);
 
                 auto type = obj->GetType();
                 Type^ underlyingType = Nullable::GetUnderlyingType(type);
@@ -151,7 +151,7 @@ namespace CefSharp
                     throw gcnew NotSupportedException("Unable to serialize Type");
                 }
 
-                seen->Pop();
+                seen->Remove(obj);
             }
 
             CefTime ConvertDateTimeToCefTime(DateTime dateTime)

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -20,6 +20,9 @@ namespace CefSharp
             template<typename TList, typename TIndex>
             void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj)
             {
+                // Collection of ancestors to currently serialised object.
+                // This enables prevention of endless loops due to cycles in graphs where
+                // a child references one of its ancestors.
                 auto ancestors = gcnew HashSet<Object^>();
                 SerializeV8SimpleObject(list, index, obj, ancestors);
             }

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.h
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.h
@@ -14,7 +14,7 @@ namespace CefSharp
 
             //Serializes data into a given position in a CefListValue or CefDictionaryValue
             template<typename TList, typename TIndex>
-            void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index,Object^ obj);
+            void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj);
 
             template<typename TList, typename TIndex>
             void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, HashSet<Object^>^ seen);

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.h
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.h
@@ -17,7 +17,7 @@ namespace CefSharp
             void SerializeV8Object(const CefRefPtr<TList>& list, const TIndex& index,Object^ obj);
 
             template<typename TList, typename TIndex>
-            void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, Stack<Object^>^ seen);
+            void SerializeV8SimpleObject(const CefRefPtr<TList>& list, const TIndex& index, Object^ obj, HashSet<Object^>^ seen);
 
             template void SerializeV8Object(const CefRefPtr<CefListValue>& list, const int& index, Object^ obj);
             template void SerializeV8Object(const CefRefPtr<CefDictionaryValue>& list, const CefString& index, Object^ obj);


### PR DESCRIPTION
Fixes #2370.

Also rename the local from `seen` to `ancestors` as it is not the set of all seen objects, just those in the chain from current to root.

Added a brief comment to this effect.

In issue 2370 I missed the call to `Pop` and thought this collection had _every_ seen object in it which could be quite bad for performance when calling `Contains`. Given it actually only contains ancestors I doubt the perf gain here is considerable, and I confess that I haven't benchmarked.

I almost didn't file this PR. Feel free to close it. I won't mind.