### PR TITLE
Fixed issue with separate window using WPF.ChromiumWebBrowser

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -400,7 +400,10 @@ namespace CefSharp.Wpf
 
                 if (app != null)
                 {
-                    app.Exit += OnApplicationExit;
+                    app.Dispatcher.Invoke(() =>
+                    {
+                        app.Exit += OnApplicationExit;
+                    });
                 }
             }
         }


### PR DESCRIPTION
Application.Exit is dispatched
Otherwise if we try to create browser and put it into separate window
with separate dispatcher thread we have unhandled exception in static
constructor