### PR TITLE
Serialize any Enumerable (List<T>) type to V8 object properly

### DIFF
--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright Â© 2010-2017 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2010-2017 The CefSharp Authors. All rights reserved.
+// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 

--- a/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core/Internals/Serialization/V8Serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2010-2017 The CefSharp Authors. All rights reserved.
+// Copyright ï¿½ 2010-2017 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
@@ -102,18 +102,6 @@ namespace CefSharp
                 {
                     SetCefTime(list, index, ConvertDateTimeToCefTime(safe_cast<DateTime>(obj)));
                 }
-                else if (type->IsArray)
-                {
-                    auto subList = CefListValue::Create();
-                    Array^ managedArray = (Array^)obj;
-                    for (int i = 0; i < managedArray->Length; i++)
-                    {
-                        Object^ arrObj;
-                        arrObj = managedArray->GetValue(i);
-                        SerializeV8SimpleObject(subList, i, arrObj, ancestors);
-                    }
-                    list->SetList(index, subList);
-                }
                 // Serialize dictionary to CefDictionary (key,value pairs)
                 else if (System::Collections::IDictionary::typeid->IsAssignableFrom(type))
                 {
@@ -125,6 +113,19 @@ namespace CefSharp
                         SerializeV8SimpleObject(subDict, fieldName, kvp.Value, ancestors);
                     }
                     list->SetDictionary(index, subDict);
+                }
+                else if (System::Collections::IEnumerable::typeid->IsAssignableFrom(type))
+                {
+                    auto subList = CefListValue::Create();
+                    auto enumerable = (System::Collections::IEnumerable^) obj;
+
+                    int i = 0;
+                    for each (Object^ arrObj in enumerable)
+                    {
+                        SerializeV8SimpleObject(subList, i, arrObj, ancestors);
+                        i++;
+                    }
+                    list->SetList(index, subList);
                 }
                 // Serialize class/structs to CefDictionary (key,value pairs)
                 else if (!type->IsPrimitive && !type->IsEnum)

--- a/CefSharp.Example/AsyncBoundObject.cs
+++ b/CefSharp.Example/AsyncBoundObject.cs
@@ -100,6 +100,26 @@ namespace CefSharp.Example
             return builder.ToString();
         }
 
+        public List<string> MethodReturnsList()
+        {
+            return new List<string>()
+            {
+                "Element 0 - First",
+                "Element 1",
+                "Element 2 - Last",
+            };
+        }
+
+        public List<List<string>> MethodReturnsListOfLists()
+        {
+            return new List<List<string>>()
+            {
+                new List<string>() {"Element 0, 0", "Element 0, 1" },
+                new List<string>() {"Element 1, 0", "Element 1, 1" },
+                new List<string>() {"Element 2, 0", "Element 2, 1" },
+            };
+        }
+
         public Dictionary<string, int> MethodReturnsDictionary1()
         {
             return new Dictionary<string, int>()

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -24,6 +24,29 @@
         <script type="text/javascript">
         (async () =>
         {
+            // Verify that two objects are completely equal
+            function deepEqual(x, y)
+            {
+                if ((typeof x == "object" && x != null) && (typeof y == "object" && y != null))
+                {
+                    for (var prop in x)
+                    {
+                        if (prop in y && (Object.keys(x).length === Object.keys(y).length))
+                        {
+                            return deepEqual(x[prop], y[prop]);
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    return x === y;
+                }
+            }
+
             await CefSharp.BindObjectAsync("boundAsync", "bound");
 
             QUnit.test( "BindObjectAsync Second call", function( assert )
@@ -327,23 +350,8 @@
                 });
             });
 
-            QUnit.test("Async call (methodReturnList):", function (assert) {
-                function deepEqual(x, y) {
-                    if ((typeof x == "object" && x != null) && (typeof y == "object" && y != null)) {
-                        for (var prop in x) {
-                            if (prop in y && (Object.keys(x).length === Object.keys(y).length)) {
-                                return deepEqual(x[prop], y[prop]);
-                            }
-                            else {
-                                return false;
-                            }
-                        }
-                    }
-                    else {
-                        return x === y;
-                    }
-                }
-
+            QUnit.test("Async call (methodReturnList):", function (assert)
+            {
                 const list1 = 
                     [
                         "Element 0 - First",
@@ -372,28 +380,6 @@
 
             QUnit.test("Async call (methodReturnsDictionary):", function (assert)
             {
-                function deepEqual(x, y)
-                {
-                    if ((typeof x == "object" && x !=null) && (typeof y == "object" && y !=null))
-                    {
-                        for (var prop in x)
-                        {
-                            if (prop in y && (Object.keys(x).length === Object.keys(y).length))
-                            {
-                                return deepEqual(x[prop], y[prop]);
-                            }
-                            else
-                            {
-                                return false;
-                            }
-                        }
-                    }
-                    else
-                    { 
-                        return x === y;
-                    }
-                }
-
                 const dict1 =
                 {
                     "five": 5,

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -327,7 +327,50 @@
                 });
             });
 
-            QUnit.test( "Async call (methodReturnsDictionary):", function( assert )
+            QUnit.test("Async call (methodReturnList):", function (assert) {
+                function deepEqual(x, y) {
+                    if ((typeof x == "object" && x != null) && (typeof y == "object" && y != null)) {
+                        for (var prop in x) {
+                            if (prop in y && (Object.keys(x).length === Object.keys(y).length)) {
+                                return deepEqual(x[prop], y[prop]);
+                            }
+                            else {
+                                return false;
+                            }
+                        }
+                    }
+                    else {
+                        return x === y;
+                    }
+                }
+
+                const list1 = 
+                    [
+                        "Element 0 - First",
+                        "Element 1",
+                        "Element 2 - Last"
+                    ];
+
+                const list2 =
+                    [
+                        ["Element 0, 0", "Element 0, 1"],
+                        ["Element 1, 0", "Element 1, 1"],
+                        ["Element 2, 0", "Element 2, 1"]
+                    ];
+
+                var asyncCallback = assert.async();
+                Promise.all([
+                    boundAsync.methodReturnsList(),
+                    boundAsync.methodReturnsListOfLists(),
+                ]).then(function (results) {
+                    assert.ok(deepEqual(results[0], list1), "Call to bound.MethodReturnsList() resulted in : " + JSON.stringify(results[0]));
+                    assert.ok(deepEqual(results[1], list2), "Call to bound.MethodReturnsListOfLists() resulted in : " + JSON.stringify(results[1]));
+                    asyncCallback();
+                });
+
+            });
+
+            QUnit.test("Async call (methodReturnsDictionary):", function (assert)
             {
                 function deepEqual(x, y)
                 {


### PR DESCRIPTION
#2392 
Handle any enumarable, not just arrays when serializing (e.g. when calling
`IJavascriptCallback.ExecuteAsync`).
Otherwise, `System.Reflection.TargetParameterCountException` is thrown during serialization