### PR TITLE
Release window event handlers on Dispose

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -41,6 +41,10 @@ namespace CefSharp.Wpf
         /// </summary>
         private HwndSource source;
         /// <summary>
+        /// The source window bound to window related EventHandlers
+        /// </summary>
+        private Window sourceWindow;
+        /// <summary>
         /// The tooltip timer
         /// </summary>
         private DispatcherTimer tooltipTimer;
@@ -556,6 +560,12 @@ namespace CefSharp.Wpf
                     }
 
                     PresentationSource.RemoveSourceChangedHandler(this, PresentationSourceChangedHandler);
+                    // Release window event listeners if SourceChanged event wasn't received before disposal
+                    if (sourceWindow != null)
+                    {
+                        sourceWindow.StateChanged -= WindowStateChanged;
+                        sourceWindow.LocationChanged -= OnWindowLocationChanged;
+                    }
 
                     // Release internal event listeners:
                     Loaded -= OnLoaded;
@@ -1583,6 +1593,7 @@ namespace CefSharp.Wpf
                     {
                         window.StateChanged += WindowStateChanged;
                         window.LocationChanged += OnWindowLocationChanged;
+                        sourceWindow = window;
                     }
 
                     browserScreenLocation = GetBrowserScreenLocation();
@@ -1597,6 +1608,7 @@ namespace CefSharp.Wpf
                 {
                     window.StateChanged -= WindowStateChanged;
                     window.LocationChanged -= OnWindowLocationChanged;
+                    sourceWindow = null;
                 }
             }
         }


### PR DESCRIPTION
Make sure event handlers related to `Window`, e.g. `WindowStateChanged`, is released during Dispose.