### PR TITLE
Backport accessibility support.

### DIFF
--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -226,6 +226,7 @@
     <ClCompile Include="Internals\CefContextMenuParamsWrapper.cpp" />
     <ClCompile Include="Internals\CefFrameWrapper.cpp" />
     <ClCompile Include="Internals\CefSharpBrowserWrapper.cpp" />
+    <ClCompile Include="Internals\CefValueWrapper.cpp" />
     <ClCompile Include="Internals\ClientAdapter.cpp" />
     <ClCompile Include="Internals\CookieVisitor.cpp" />
     <ClCompile Include="Internals\CefRequestWrapper.cpp" />
@@ -249,6 +250,7 @@
   <ItemGroup>
     <ClInclude Include="BrowserSettings.h" />
     <ClInclude Include="Cef.h" />
+    <ClInclude Include="Internals\CefValueWrapper.h" />
     <ClInclude Include="Internals\CefWriteHandlerWrapper.h" />
     <ClInclude Include="Internals\CefImageWrapper.h" />
     <ClInclude Include="Internals\CefDeleteCookiesCallbackAdapter.h" />

--- a/CefSharp.Core/CefSharp.Core.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.vcxproj.filters
@@ -71,6 +71,12 @@
     <ClCompile Include="CookieManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Internals\CefRequestContextHandlerAdapter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Internals\CefValueWrapper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vcclr_local.h">
@@ -269,6 +275,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Internals\CefWriteHandlerWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Internals\CefRequestContextHandlerAdapter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractCefSettings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Internals\CefValueWrapper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CefSharp.Core/Internals/CefValueWrapper.cpp
+++ b/CefSharp.Core/Internals/CefValueWrapper.cpp
@@ -1,0 +1,86 @@
+// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#include "Stdafx.h"
+
+#include "TypeConversion.h"
+#include "CefValueWrapper.h"
+
+bool CefValueWrapper::GetBool()
+{
+    ThrowIfDisposed();
+
+    return _cefValue->GetBool();
+}
+
+double CefValueWrapper::GetDouble()
+{
+    ThrowIfDisposed();
+
+    return _cefValue->GetDouble();
+}
+
+int CefValueWrapper::GetInt()
+{
+    ThrowIfDisposed();
+
+    return _cefValue->GetInt();
+}
+
+String^ CefValueWrapper::GetString()
+{
+    ThrowIfDisposed();
+
+    return StringUtils::ToClr(_cefValue->GetString());
+}
+
+IDictionary<String^, IValue^>^ CefValueWrapper::GetDictionary()
+{
+    ThrowIfDisposed();
+
+    auto dictionary = _cefValue->GetDictionary();
+
+    if (!dictionary.get() || dictionary->GetSize() == 0)
+    {
+        return nullptr;
+    }
+
+    auto result = gcnew Dictionary<String^, IValue^>();
+
+    CefDictionaryValue::KeyList keys;
+    dictionary->GetKeys(keys);
+
+    for (auto i = 0; i < keys.size(); i++)
+    {
+        auto key = keys[i];
+        auto keyValue = StringUtils::ToClr(key);
+        auto valueWrapper = gcnew CefValueWrapper(dictionary->GetValue(keys[i]));
+        
+        result->Add(keyValue, valueWrapper);
+    }
+
+    return result;
+}
+
+IList<IValue^>^ CefValueWrapper::GetList()
+{
+    ThrowIfDisposed();
+
+    auto list = _cefValue->GetList();
+    auto result = gcnew List<IValue^>(list->GetSize());
+    
+    for (auto i = 0; i < list->GetSize(); i++)
+    {
+        result->Add(gcnew CefValueWrapper(list->GetValue(i)));
+    }
+
+    return result;
+}
+
+Object^ CefValueWrapper::GetObject()
+{
+    ThrowIfDisposed();
+
+    return TypeConversion::FromNative(_cefValue.get());
+}

--- a/CefSharp.Core/Internals/CefValueWrapper.h
+++ b/CefSharp.Core/Internals/CefValueWrapper.h
@@ -1,0 +1,58 @@
+// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+
+#include "include\cef_values.h"
+#include "CefWrapper.h"
+
+namespace CefSharp
+{
+    namespace Internals 
+    {
+        private ref class CefValueWrapper : public IValue, public CefWrapper
+        {
+        private:
+            MCefRefPtr<CefValue> _cefValue;
+
+        internal:
+            CefValueWrapper(CefRefPtr<CefValue> &cefValue) : _cefValue(cefValue)
+            {
+            }
+
+            !CefValueWrapper()
+            {
+                _cefValue = NULL;
+            }
+
+            ~CefValueWrapper()
+            {
+                this->!CefValueWrapper();
+
+                _disposed = true;
+            }
+
+        public: 
+            virtual bool GetBool();
+            virtual double GetDouble();
+            virtual int GetInt();
+            virtual String^ GetString();
+            virtual IDictionary<String^, IValue^>^ GetDictionary();
+            virtual IList<IValue^>^ GetList();
+            virtual Object^ GetObject();
+
+            virtual property Enums::ValueType Type
+            {
+                Enums::ValueType get()
+                {
+                    ThrowIfDisposed();
+
+                    return (Enums::ValueType)_cefValue->GetType();
+                }
+            }
+        };
+    }
+}

--- a/CefSharp.Core/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core/Internals/RenderClientAdapter.h
@@ -8,6 +8,7 @@
 #include <msclr/lock.h>
 
 #include "ClientAdapter.h"
+#include "CefValueWrapper.h"
 
 using namespace msclr;
 using namespace CefSharp::Structs;
@@ -17,7 +18,8 @@ namespace CefSharp
     namespace Internals
     {
         private class RenderClientAdapter : public ClientAdapter,
-            public CefRenderHandler
+            public CefRenderHandler,
+            public CefAccessibilityHandler
         {
         private:
             gcroot<IRenderWebBrowser^> _renderWebBrowser;
@@ -36,6 +38,9 @@ namespace CefSharp
 
             // CefClient
             virtual DECL CefRefPtr<CefRenderHandler> GetRenderHandler() OVERRIDE{ return this; };
+
+            // CefRenderHandler
+            virtual DECL CefRefPtr<CefAccessibilityHandler> GetAccessibilityHandler() OVERRIDE { return this; }
 
             // CefRenderHandler
             virtual DECL bool GetScreenInfo(CefRefPtr<CefBrowser> browser, CefScreenInfo& screen_info) OVERRIDE
@@ -166,6 +171,31 @@ namespace CefSharp
                 }
 
                 _renderWebBrowser->OnImeCompositionRangeChanged(Range(selectedRange.from, selectedRange.to), charBounds);
+            }
+
+            //CefAccessibilityHandler
+            virtual DECL void OnAccessibilityLocationChange(CefRefPtr<CefValue> value)
+            {
+                auto handler = _renderWebBrowser->AccessibilityHandler;
+
+                if (handler != nullptr)
+                {
+                    auto valueWrapper = gcnew CefValueWrapper(value);
+
+                    handler->OnAccessibilityLocationChange(valueWrapper);
+                }
+            }
+
+            virtual DECL void OnAccessibilityTreeChange(CefRefPtr<CefValue> value)
+            {
+                auto handler = _renderWebBrowser->AccessibilityHandler;
+
+                if (handler != nullptr)
+                {
+                    auto valueWrapper = gcnew CefValueWrapper(value);
+
+                    handler->OnAccessibilityTreeChange(valueWrapper);
+                }
             }
 
             IMPLEMENT_REFCOUNTING(RenderClientAdapter)

--- a/CefSharp.Core/Internals/TypeConversion.h
+++ b/CefSharp.Core/Internals/TypeConversion.h
@@ -15,6 +15,7 @@
 #include "Serialization\V8Serialization.h"
 
 using namespace System::Collections::Generic;
+using namespace System::Collections::Specialized;
 using namespace CefSharp::Internals::Serialization;
 
 namespace CefSharp
@@ -211,6 +212,11 @@ namespace CefSharp
                 {
                     return FromNative(value->GetDictionary());
                 }
+
+                if (type == CefValueType::VTYPE_LIST)
+                {
+                    return FromNative(value->GetList());
+                }
                 
                 return nullptr;
             }
@@ -236,6 +242,17 @@ namespace CefSharp
                 }
 
                 return dict;
+            }
+
+            static List<Object^>^ FromNative(const CefRefPtr<CefListValue>& list)
+            {
+                auto result = gcnew List<Object^>(list->GetSize());
+                for (auto i = 0; i < list->GetSize(); i++)
+                {
+                    result->Add(DeserializeObject(list, i, nullptr));
+                }
+
+                return result;
             }
         };
     }

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -99,6 +99,14 @@ namespace CefSharp.Example
             settings.MultiThreadedMessageLoop = multiThreadedMessageLoop;
             settings.ExternalMessagePump = !multiThreadedMessageLoop;
 
+            // The following options control accessibility state for all frames.
+            // These options only take effect if accessibility state is not set by IBrowserHost.SetAccessibilityState call.
+            // --force-renderer-accessibility enables browser accessibility.
+            // --disable-renderer-accessibility completely disables browser accessibility.
+            //settings.CefCommandLineArgs.Add("force-renderer-accessibility", "1");
+            //settings.CefCommandLineArgs.Add("disable-renderer-accessibility", "1");
+
+
             //Enables Uncaught exception handler
             settings.UncaughtExceptionStackSize = 10;
 

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -172,6 +172,12 @@ namespace CefSharp.OffScreen
         public IFindHandler FindHandler { get; set; }
 
         /// <summary>
+        /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
+        /// </summary>
+        /// <value>The accessibility handler.</value>
+        public IAccessibilityHandler AccessibilityHandler { get; set; }
+
+        /// <summary>
         /// Event handler that will get called when the resource load for a navigation fails or is canceled.
         /// It's important to note this event is fired on a CEF UI thread, which by default is not the same as your application UI
         /// thread. It is unwise to block on this thread for any length of time as your browser will become unresponsive and/or hang..

--- a/CefSharp.Wpf.Example/Accessibility/AccessibilityHandler.cs
+++ b/CefSharp.Wpf.Example/Accessibility/AccessibilityHandler.cs
@@ -1,0 +1,75 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using CefSharp.Wpf.Example.Accessibility.AutomationPeers;
+using CefSharp.Wpf.Example.Accessibility.Tree;
+using ValueType = CefSharp.Enums.ValueType;
+
+namespace CefSharp.Wpf.Example.Accessibility
+{
+    public class AccessibilityHandler : IAccessibilityHandler
+    {
+        private readonly Dictionary<int, AccessibilityTree> accessibilityTrees;
+
+        public AccessibilityHandler()
+        {
+            accessibilityTrees = new Dictionary<int, AccessibilityTree>();
+        }
+
+        public void OnAccessibilityLocationChange(IValue value)
+        {
+        }
+
+        public void OnAccessibilityTreeChange(IValue value)
+        {
+            if (value.Type != ValueType.List) return;
+
+            foreach (var listValue in value.GetList())
+            {
+                if (listValue.Type == ValueType.Dictionary)
+                {
+                    var eventDictionary = listValue.GetDictionary();
+
+                    var treeId = eventDictionary["ax_tree_id"].GetInt();
+
+                    AccessibilityTree accessibilityTree;
+                    if (accessibilityTrees.ContainsKey(treeId))
+                    {
+                        accessibilityTree = accessibilityTrees[treeId];
+                    }
+                    else
+                    {
+                        accessibilityTree = new AccessibilityTree(treeId);
+                        accessibilityTrees.Add(treeId, accessibilityTree);
+                        OnAccessibilityTreeAdded();
+                    }
+
+                    accessibilityTree.Update(eventDictionary);
+                }
+            }
+        }
+
+        internal AutomationPeer GetAutomationPeer(FrameworkElement chromiumWebBrowser)
+        {
+            return new BrowserAutomationPeer(chromiumWebBrowser, this);
+        }
+
+        internal List<AccessibilityTree> GetAccessibilityTrees()
+        {
+            return accessibilityTrees.Values.ToList();
+        }
+
+        internal event EventHandler AccessibilityTreeAdded;
+
+        protected virtual void OnAccessibilityTreeAdded()
+        {
+            AccessibilityTreeAdded?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Accessibility/AccessibilityTree/AccessibilityNode.cs
+++ b/CefSharp.Wpf.Example/Accessibility/AccessibilityTree/AccessibilityNode.cs
@@ -1,0 +1,141 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace CefSharp.Wpf.Example.Accessibility.Tree
+{
+    public class AccessibilityNode
+    {
+        private readonly AccessibilityTree accessibilityTree;
+
+        private Rect location;
+        private int offsetContainerId = -1;
+        private HashSet<int> childIds;
+        private IDictionary<string, IValue> attributes;
+
+        public AccessibilityNode(
+            IDictionary<string, IValue> node, 
+            AccessibilityTree accessibilityTree)
+        {
+            this.accessibilityTree = accessibilityTree;
+
+            childIds = new HashSet<int>();
+
+            Update(node);
+        }
+
+        public int Id { get; private set; } = -1;
+
+        public string Role { get; private set; }
+
+        public string Name { get; private set; }
+
+        public string Value { get; private set; }
+
+        public string Description { get; private set; }
+
+        public void Update(IDictionary<string, IValue> node)
+        {
+            if (node == null || !node.ContainsKey("id")) return;
+
+            Id = node["id"].GetInt();
+
+            if (node.ContainsKey("role"))
+            {
+                Role = node["role"].GetString();
+            }
+
+            if (node.ContainsKey("child_ids"))
+            {
+                var newChildIds = node["child_ids"].GetList().Select(x => x.GetInt());
+                var children = new HashSet<int>(newChildIds);
+                
+                if (!childIds.SetEquals(children))
+                {
+                    childIds = children;
+                    OnChildenChanged();
+                }
+            }
+
+            if (node.ContainsKey("location"))
+            {
+                var locationDictionary = node["location"].GetDictionary();
+                if (locationDictionary != null)
+                {
+                    location = new Rect(
+                        locationDictionary["x"].GetDouble(), 
+                        locationDictionary["y"].GetDouble(),
+                        locationDictionary["width"].GetDouble(),
+                        locationDictionary["height"].GetDouble());
+                }
+            }
+
+            if (node.ContainsKey("offset_container_id"))
+            {
+                offsetContainerId = node["offset_container_id"].GetInt();
+            }
+
+            if (node.ContainsKey("attributes"))
+            {
+                attributes = node["attributes"].GetDictionary();
+
+                if (attributes != null)
+                {
+                    if (attributes.ContainsKey("name"))
+                    {
+                        Name = attributes["name"].GetString();
+                    }
+                    if (attributes.ContainsKey("value"))
+                    {
+                        Value = attributes["value"].GetString();
+                    }
+                    if (attributes.ContainsKey("description"))
+                    {
+                        Description = attributes["description"].GetString();
+                    }
+                }
+            }
+        }
+
+        public Rect GetLocation()
+        {
+            var result = location;
+            var offsetNode = accessibilityTree.GetNode(offsetContainerId);
+            // Add offset from parent Lcoation
+            if (offsetNode != null)
+            {
+                var offset = offsetNode.GetLocation();
+                result.X += offset.X;
+                result.Y += offset.Y;
+            }
+            return result;
+        }
+
+        public List<AccessibilityNode> GetChildren()
+        {
+            return childIds.Select(x => accessibilityTree.GetNode(x)).ToList();
+        }
+
+        public bool HasFocus()
+        {
+            return Id == accessibilityTree.FocusedNodeId;
+        }
+
+        public event EventHandler ChildenChanged;
+        protected virtual void OnChildenChanged()
+        {
+            ChildenChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public event EventHandler FocusChanged;
+        public virtual void OnFocusChanged()
+        {
+            FocusChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Accessibility/AccessibilityTree/AccessibilityTree.cs
+++ b/CefSharp.Wpf.Example/Accessibility/AccessibilityTree/AccessibilityTree.cs
@@ -1,0 +1,212 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CefSharp.Wpf.Example.Accessibility.Tree
+{
+    public class AccessibilityTree
+    {
+        private readonly Dictionary<int, AccessibilityNode> accessibilityNodeMap;
+
+        public AccessibilityTree(int id)
+        {
+            accessibilityNodeMap = new Dictionary<int, AccessibilityNode>();
+
+            Id = id;
+            RootNodeId = -1;
+            FocusedNodeId = -1;
+        }
+
+        public int Id { get; }
+
+        public int RootNodeId { get; private set; }
+
+        public int FocusedNodeId { get; private set; }
+
+        public void Update(IDictionary<string, IValue> eventDictionary)
+        {
+            if (eventDictionary == null) return;
+            if (!eventDictionary.ContainsKey("event_type")) return;
+
+            var eventType = eventDictionary["event_type"].GetString();
+
+            if (eventType == "layoutComplete")
+            {
+                UpdateLayout(eventDictionary);
+            }
+
+            if (eventType == "focus")
+            {
+                UpdateFocus(eventDictionary);
+            }
+        }
+
+        private void UpdateLayout(IDictionary<string, IValue> eventDictionary)
+        {
+            if (!eventDictionary.ContainsKey("update")) return;
+
+            var update = eventDictionary["update"].GetDictionary();
+            if (update == null) return;
+
+            var rootNodeChanged = false;
+
+            // If a node is to be cleared
+            if (update.ContainsKey("node_id_to_clear"))
+            {
+                var nodeIdToClear = update["node_id_to_clear"].GetInt();
+
+                // reset root node if that is to be cleared
+                if (nodeIdToClear == RootNodeId)
+                {
+                    RootNodeId = -1;
+                }
+
+                var node = GetNode(nodeIdToClear);
+                RemoveNode(node);
+            }
+
+            if (update.ContainsKey("root_id"))
+            {
+                var newRootNodeId = update["root_id"].GetInt();
+
+                if (RootNodeId != newRootNodeId)
+                {
+                    RootNodeId = newRootNodeId;
+                    rootNodeChanged = true;
+                }
+            }
+
+            UpdateNodes(update);
+
+            if (rootNodeChanged)
+            {
+                OnRootNodeChanged();
+            }
+        }
+
+        private void RemoveNode(AccessibilityNode node)
+        {
+            if (node == null) return;
+
+            foreach (var child in node.GetChildren())
+            {
+                RemoveNode(child);
+            }
+
+            accessibilityNodeMap.Remove(node.Id);
+        }
+
+        private void UpdateFocus(IDictionary<string, IValue> eventDictionary)
+        {
+            var focusedNodeChanged = false;
+
+            if (eventDictionary.ContainsKey("id"))
+            {
+                var newFocusedNodeId = eventDictionary["id"].GetInt();
+                
+                if (FocusedNodeId != newFocusedNodeId)
+                {
+                    FocusedNodeId = newFocusedNodeId;
+                    focusedNodeChanged = true;
+                }
+            }
+
+            if (eventDictionary.ContainsKey("update"))
+            {
+                var update = eventDictionary["update"].GetDictionary();
+                UpdateNodes(update);
+            }
+            
+            if (focusedNodeChanged)
+            {
+                var focusedNode = GetFocusedNode();
+                focusedNode?.OnFocusChanged();
+            }
+        }
+
+        private void UpdateNodes(IDictionary<string, IValue> update)
+        {
+            if (update == null) return;
+            if (!update.ContainsKey("nodes")) return;
+
+            var nodes = update["nodes"].GetList();
+
+            foreach (var node in nodes)
+            {
+                var nodeDictionary = node.GetDictionary();
+                if (nodeDictionary != null)
+                {
+                    var nodeId = nodeDictionary["id"].GetInt();
+                    var accessibilityNode = GetNode(nodeId);
+                    
+                    // Create if it is a new one
+                    if (accessibilityNode != null)
+                    {
+                        accessibilityNode.Update(nodeDictionary);
+                    }
+                    else
+                    {
+                        accessibilityNode = new AccessibilityNode(nodeDictionary, this);
+                        accessibilityNodeMap[nodeId] = accessibilityNode;
+                    }
+                }
+            }
+        }
+
+        public AccessibilityNode GetRootNode()
+        {
+            return GetNode(RootNodeId);
+        }
+
+        public AccessibilityNode GetFocusedNode()
+        {
+            return GetNode(FocusedNodeId);
+        }
+
+        internal AccessibilityNode GetNode(int nodeId)
+        {
+            if (accessibilityNodeMap.ContainsKey(nodeId))
+            {
+                return accessibilityNodeMap[nodeId];
+            }
+
+            return null;
+        }
+
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+
+            PrintNode(GetRootNode(), 0, result);
+
+            return result.ToString();
+        }
+
+        private static void PrintNode(AccessibilityNode node, int level, StringBuilder result)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            result.Append(new string('\t', level));
+            result.AppendLine($"{node.Role}[{node.Id}] {node.Name} {node.Value} {(node.HasFocus() ? "<--" : "")}");
+
+            foreach (var child in node.GetChildren())
+            {
+                PrintNode(child, level + 1, result);
+            }
+        }
+
+        public event EventHandler RootNodeChanged;
+
+        protected virtual void OnRootNodeChanged()
+        {
+            RootNodeChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Accessibility/AutomationPeers/AccessibilityNodeAutomationPeer.cs
+++ b/CefSharp.Wpf.Example/Accessibility/AutomationPeers/AccessibilityNodeAutomationPeer.cs
@@ -1,0 +1,217 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using CefSharp.Wpf.Example.Accessibility.Tree;
+
+namespace CefSharp.Wpf.Example.Accessibility.AutomationPeers
+{
+    public class AccessibilityNodeAutomationPeer : AutomationPeer
+    {
+        // Mapping implemented according to the following link
+        // https://docs.microsoft.com/en-us/windows/desktop/winauto/uiauto-ariaspecification
+        // 'Custom' control type is used for unsupported control types
+        private static readonly Dictionary<string, AutomationControlType> ControlTypeMapping = new Dictionary<string, AutomationControlType>
+        {
+            {"alert", AutomationControlType.Text},
+            {"application", AutomationControlType.Pane},
+            {"buttonDropDown", AutomationControlType.ComboBox}, // No mapping for this one in the reference
+            {"popUpButton", AutomationControlType.Button}, // No mapping for this one in the reference
+            {"checkBox", AutomationControlType.CheckBox},
+            {"comboBox", AutomationControlType.ComboBox},
+            {"dialog", AutomationControlType.Pane},
+            {"genericContainer", AutomationControlType.Group},
+            {"group", AutomationControlType.Group},
+            {"image", AutomationControlType.Image},
+            {"link", AutomationControlType.Hyperlink},
+            {"locationBar", AutomationControlType.Group},
+            {"menuBar", AutomationControlType.MenuBar},
+            {"menuItem", AutomationControlType.MenuItem},
+            {"menuListPopup", AutomationControlType.Menu},
+            {"tree", AutomationControlType.Tree},
+            {"treeItem", AutomationControlType.TreeItem},
+            {"tab", AutomationControlType.TabItem},
+            {"tabList", AutomationControlType.Tab},
+            {"pane", AutomationControlType.Pane},
+            {"progressIndicator", AutomationControlType.ProgressBar},
+            {"button", AutomationControlType.Button},
+            {"radioButton", AutomationControlType.RadioButton},
+            {"scrollBar", AutomationControlType.ScrollBar},
+            {"splitter", AutomationControlType.Separator},
+            {"slider", AutomationControlType.Slider},
+            {"staticText", AutomationControlType.Text},
+            {"textField", AutomationControlType.Edit},
+            {"titleBar", AutomationControlType.Pane}, // No mapping for this one in the reference
+            {"toolbar", AutomationControlType.ToolBar},
+            {"webView", AutomationControlType.Group},
+            {"window", AutomationControlType.Window},
+            {"client", AutomationControlType.Calendar}
+        };
+
+        private readonly FrameworkElement owner;
+        private readonly AccessibilityNode accessibilityNode;
+
+        public AccessibilityNodeAutomationPeer(FrameworkElement owner, AccessibilityNode accessibilityNode)
+        {
+            this.owner = owner;
+            this.accessibilityNode = accessibilityNode;
+
+            accessibilityNode.ChildenChanged += AccessibilityNodeOnChildenChanged;
+            accessibilityNode.FocusChanged += AccessibilityNodeOnFocusChanged;
+        }
+
+        private void AccessibilityNodeOnChildenChanged(object sender, EventArgs e)
+        {
+            RaiseAutomationEvent(AutomationEvents.StructureChanged);
+        }
+
+        private void AccessibilityNodeOnFocusChanged(object sender, System.EventArgs e)
+        {
+            RaiseAutomationEvent(AutomationEvents.AutomationFocusChanged);
+        }
+
+        protected override List<AutomationPeer> GetChildrenCore()
+        {
+            var accessibilityNodes = accessibilityNode.GetChildren();
+
+            return accessibilityNodes
+                .Select(x => new AccessibilityNodeAutomationPeer(owner, x))
+                .Cast<AutomationPeer>()
+                .ToList();
+        }
+
+        public override object GetPattern(PatternInterface patternInterface)
+        {
+            return null;
+        }
+
+        protected override Rect GetBoundingRectangleCore()
+        {
+            var location = accessibilityNode.GetLocation();
+
+            var topLeft = owner.PointToScreen(location.TopLeft);
+            var bottomRight = owner.PointToScreen(location.BottomRight);
+
+            var result = new Rect(topLeft, bottomRight);
+
+            return result;
+        }
+
+        protected override bool IsOffscreenCore()
+        {
+            return false;
+        }
+
+        protected override AutomationOrientation GetOrientationCore()
+        {
+            return AutomationOrientation.None;
+        }
+
+        protected override string GetItemTypeCore()
+        {
+            return accessibilityNode.Role;
+        }
+
+        protected override string GetClassNameCore()
+        {
+            return string.Empty;
+        }
+
+        protected override string GetItemStatusCore()
+        {
+            return string.Empty;
+        }
+
+        protected override bool IsRequiredForFormCore()
+        {
+            return false;
+        }
+
+        protected override bool IsKeyboardFocusableCore()
+        {
+            return true;
+        }
+
+        protected override bool HasKeyboardFocusCore()
+        {
+            return accessibilityNode.HasFocus();
+        }
+
+        protected override bool IsEnabledCore()
+        {
+            return true;
+        }
+
+        protected override bool IsPasswordCore()
+        {
+            return false;
+        }
+
+        protected override string GetAutomationIdCore()
+        {
+            return accessibilityNode.Id.ToString();
+        }
+
+        protected override string GetNameCore()
+        {
+            return accessibilityNode.Name;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            var role = accessibilityNode.Role;
+
+            if (ControlTypeMapping.ContainsKey(role))
+            {
+                return ControlTypeMapping[role];
+            }
+
+            return AutomationControlType.Custom;
+        }
+
+        protected override bool IsContentElementCore()
+        {
+            return true;
+        }
+
+        protected override bool IsControlElementCore()
+        {
+            return true;
+        }
+
+        protected override AutomationPeer GetLabeledByCore()
+        {
+            return null;
+        }
+
+        protected override string GetHelpTextCore()
+        {
+            return string.Empty;
+        }
+
+        protected override string GetAcceleratorKeyCore()
+        {
+            return string.Empty;
+        }
+
+        protected override string GetAccessKeyCore()
+        {
+            return string.Empty;
+        }
+
+        protected override Point GetClickablePointCore()
+        {
+            var axLocation = accessibilityNode.GetLocation();
+            return new Point(axLocation.X, axLocation.Y);
+        }
+
+        protected override void SetFocusCore()
+        {
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Accessibility/AutomationPeers/AccessibilityTreeAutomationPeer.cs
+++ b/CefSharp.Wpf.Example/Accessibility/AutomationPeers/AccessibilityTreeAutomationPeer.cs
@@ -1,0 +1,46 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using CefSharp.Wpf.Example.Accessibility.Tree;
+
+namespace CefSharp.Wpf.Example.Accessibility.AutomationPeers
+{
+    public class AccessibilityTreeAutomationPeer : FrameworkElementAutomationPeer
+    {
+        private readonly FrameworkElement owner;
+        private readonly AccessibilityTree accessibilityTree;
+
+        public AccessibilityTreeAutomationPeer(
+            FrameworkElement owner, 
+            AccessibilityTree accessibilityTree) : base(owner)
+        {
+            this.owner = owner;
+            this.accessibilityTree = accessibilityTree;
+            this.accessibilityTree.RootNodeChanged += AccessibilityTreeRootNodeChanged;
+        }
+
+        private void AccessibilityTreeRootNodeChanged(object sender, System.EventArgs e)
+        {
+            RaiseAutomationEvent(AutomationEvents.StructureChanged);
+        }
+
+        protected override List<AutomationPeer> GetChildrenCore()
+        {
+            var rootNode = accessibilityTree.GetRootNode();
+
+            if (rootNode == null)
+            {
+                return new List<AutomationPeer>(0);
+            }
+
+            return new List<AutomationPeer>(1)
+            {
+                new AccessibilityNodeAutomationPeer(owner, rootNode)
+            };
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Accessibility/AutomationPeers/BrowserAutomationPeer.cs
+++ b/CefSharp.Wpf.Example/Accessibility/AutomationPeers/BrowserAutomationPeer.cs
@@ -1,0 +1,56 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+
+namespace CefSharp.Wpf.Example.Accessibility.AutomationPeers
+{
+    public class BrowserAutomationPeer : FrameworkElementAutomationPeer
+    {
+        private readonly FrameworkElement owner;
+        private readonly AccessibilityHandler accessibilityHandler;
+
+        public BrowserAutomationPeer(
+            FrameworkElement owner, 
+            AccessibilityHandler accessibilityHandler) : base(owner)
+        {
+
+            this.owner = owner;
+            this.accessibilityHandler = accessibilityHandler;
+
+            this.accessibilityHandler.AccessibilityTreeAdded += AccessibilityHandlerAccessibilityTreeAdded;
+        }
+
+        private void AccessibilityHandlerAccessibilityTreeAdded(object sender, EventArgs e)
+        {
+            RaiseAutomationEvent(AutomationEvents.StructureChanged);
+        }
+
+        protected override List<AutomationPeer> GetChildrenCore()
+        {
+            var roots = accessibilityHandler.GetAccessibilityTrees();
+
+            var result = roots
+                .Select(x => new AccessibilityTreeAutomationPeer(owner, x))
+                .Cast<AutomationPeer>()
+                .ToList();
+
+            return result;
+        }
+
+        protected override string GetNameCore()
+        {
+            return "Chromium Web Browser";
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Group;
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Accessibility/ChromiumWebBrowserWithAccessibilitySupport.cs
+++ b/CefSharp.Wpf.Example/Accessibility/ChromiumWebBrowserWithAccessibilitySupport.cs
@@ -1,0 +1,22 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Windows.Automation.Peers;
+
+namespace CefSharp.Wpf.Example.Accessibility
+{
+    public class ChromiumWebBrowserWithAccessibilitySupport : ChromiumWebBrowser
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            if (AccessibilityHandler is AccessibilityHandler accessibilityHandler)
+            {
+                var automationPeer = accessibilityHandler.GetAutomationPeer(this);
+                return automationPeer;
+            }
+
+            return base.OnCreateAutomationPeer();
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -106,9 +106,17 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Compile Include="Accessibility\ChromiumWebBrowserWithAccessibilitySupport.cs" />
+    <Compile Include="Accessibility\AccessibilityHandler.cs" />
+    <Compile Include="Accessibility\AutomationPeers\AccessibilityNodeAutomationPeer.cs" />
+    <Compile Include="Accessibility\AutomationPeers\AccessibilityTreeAutomationPeer.cs" />
+    <Compile Include="Accessibility\AutomationPeers\BrowserAutomationPeer.cs" />
+    <Compile Include="Accessibility\AccessibilityTree\AccessibilityNode.cs" />
+    <Compile Include="Accessibility\AccessibilityTree\AccessibilityTree.cs" />
     <Compile Include="Controls\CefSharpCommands.cs" />
     <Compile Include="Controls\ChromiumWebBrowserWithScreenshotSupport.cs" />
     <Compile Include="Controls\NonReloadingTabControl.cs" />
+    <Compile Include="Controls\TabControlAutomationPeer.cs" />
     <Compile Include="Handlers\DisplayHandler.cs" />
     <Compile Include="Handlers\DragHandler.cs" />
     <Compile Include="Handlers\MenuHandler.cs" />

--- a/CefSharp.Wpf.Example/Controls/NonReloadingTabControl.cs
+++ b/CefSharp.Wpf.Example/Controls/NonReloadingTabControl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 
@@ -164,6 +165,11 @@ namespace CefSharp.Wpf.Example.Controls
             var item = selectedItem as TabItem ?? ItemContainerGenerator.ContainerFromIndex(SelectedIndex) as TabItem;
 
             return item;
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new TabControlAutomationPeer(this);
         }
     }
 }

--- a/CefSharp.Wpf.Example/Controls/TabControlAutomationPeer.cs
+++ b/CefSharp.Wpf.Example/Controls/TabControlAutomationPeer.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Media;
+
+namespace CefSharp.Wpf.Example.Controls
+{
+    /// <summary>
+    /// Default TabControl's AutomationPeer doesn’t know anything about the controls within it, since they’re loaded dynamically.
+    /// The purpose of this class is to fix this behavior.
+    /// </summary>
+    /// <remarks>
+    /// Taken from https://www.colinsalmcorner.com/post/genericautomationpeer--helping-the-coded-ui-framework-find-your-custom-controls
+    /// </remarks>
+    public class TabControlAutomationPeer : UIElementAutomationPeer
+    {
+        public TabControlAutomationPeer(UIElement owner) : base(owner)
+        {
+        }
+
+        protected override List<AutomationPeer> GetChildrenCore()
+        {
+            var list = base.GetChildrenCore();
+            list.AddRange(GetChildPeers(Owner));
+            return list;
+        }
+
+        private List<AutomationPeer> GetChildPeers(UIElement element)
+        {
+            var list = new List<AutomationPeer>();
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+            {
+                if (VisualTreeHelper.GetChild(element, i) is UIElement child)
+                {
+                    var childPeer = CreatePeerForElement(child);
+                    if (childPeer != null)
+                    {
+                        list.Add(childPeer);
+                    }
+                    else
+                    {
+                        list.AddRange(GetChildPeers(child));
+                    }
+                }
+            }
+
+            return list;
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -13,6 +13,7 @@ using CefSharp.Wpf.Example.ViewModels;
 using System.IO;
 using CefSharp.Example.ModelBinding;
 using System.Diagnostics;
+using CefSharp.Wpf.Example.Accessibility;
 
 namespace CefSharp.Wpf.Example.Views
 {
@@ -88,6 +89,7 @@ namespace CefSharp.Wpf.Example.Views
             browser.DisplayHandler = new DisplayHandler();
             browser.LifeSpanHandler = new LifespanHandler();
             browser.MenuHandler = new MenuHandler();
+            browser.AccessibilityHandler = new AccessibilityHandler();
             var downloadHandler = new DownloadHandler();
             downloadHandler.OnBeforeDownloadFired += OnBeforeDownloadFired;
             downloadHandler.OnDownloadUpdatedFired += OnDownloadUpdatedFired;

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -222,6 +222,12 @@ namespace CefSharp.Wpf
         public IFindHandler FindHandler { get; set; }
 
         /// <summary>
+        /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
+        /// </summary>
+        /// <value>The accessibility handler.</value>
+        public IAccessibilityHandler AccessibilityHandler { get; set; }
+
+        /// <summary>
         /// Event handler for receiving Javascript console messages being sent from web pages.
         /// It's important to note this event is fired on a CEF UI thread, which by default is not the same as your application UI
         /// thread. It is unwise to block on this thread for any length of time as your browser will become unresponsive and/or hang..

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -96,12 +96,15 @@
     <Compile Include="Callback\TaskResolveCallback.cs" />
     <Compile Include="CdmRegistration.cs" />
     <Compile Include="Enums\AlphaType.cs" />
+    <Compile Include="Enums\ValueType.cs" />
     <Compile Include="Enums\ColorType.cs" />
     <Compile Include="Event\JavascriptBindingCompleteEventArgs.cs" />
     <Compile Include="Event\JavascriptBindingEventArgs.cs" />
     <Compile Include="Event\JavascriptBindingMultipleCompleteEventArgs.cs" />
     <Compile Include="Handler\DefaultRequestHandler.cs" />
     <Compile Include="Enums\UrlRequestFlags.cs" />
+    <Compile Include="Handler\IAccessibilityHandler.cs" />
+    <Compile Include="IValue.cs" />
     <Compile Include="IImage.cs" />
     <Compile Include="IJavascriptObjectRepository.cs" />
     <Compile Include="Internals\ByteArrayResourceHandler.cs" />

--- a/CefSharp/Enums/ValueType.cs
+++ b/CefSharp/Enums/ValueType.cs
@@ -1,0 +1,22 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.Enums
+{
+    /// <summary>
+    /// Value types supported by <see cref="IValue"/>
+    /// </summary>
+    public enum ValueType
+    {
+        Invalid = 0,
+        Null = 1,
+        Bool = 2,
+        Int = 3,
+        Double = 4,
+        String = 5,
+        Binary = 6,
+        Dictionary = 7,
+        List = 8,
+    }
+}

--- a/CefSharp/Handler/IAccessibilityHandler.cs
+++ b/CefSharp/Handler/IAccessibilityHandler.cs
@@ -1,0 +1,26 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Implement this interface to receive accessibility notification when accessibility events have been registered. 
+    /// It's important to note that the methods of this interface are called on a CEF UI thread,
+    /// which by default is not the same as your application UI thread.
+    /// </summary>
+    public interface IAccessibilityHandler
+    {
+        /// <summary>
+        /// Called after renderer process sends accessibility location changes to the browser process.
+        /// </summary>
+        /// <param name="value">Updated location info.</param>
+        void OnAccessibilityLocationChange(IValue value);
+
+        /// <summary>
+        /// Called after renderer process sends accessibility tree changes to the browser process.
+        /// </summary>
+        /// <param name="value">Updated tree info.</param>
+        void OnAccessibilityTreeChange(IValue value);
+    }
+}

--- a/CefSharp/IValue.cs
+++ b/CefSharp/IValue.cs
@@ -1,0 +1,80 @@
+﻿// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Generic;
+using ValueType = CefSharp.Enums.ValueType;
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Interface representing CefValue.
+    /// </summary>
+    public interface IValue : IDisposable
+    {
+        /// <summary>
+        /// Returns the underlying value type.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value type.
+        /// </returns>
+        ValueType Type { get; }
+
+        /// <summary>
+        /// Returns the underlying value as type bool.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value as type bool.
+        /// </returns>
+        bool GetBool();
+
+        /// <summary>
+        /// Returns the underlying value as type double.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value as type double.
+        /// </returns>
+        double GetDouble();
+
+        /// <summary>
+        /// Returns the underlying value as type int.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value as type int.
+        /// </returns>
+        int GetInt();
+
+        /// <summary>
+        /// Returns the underlying value as type string.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value as type string.
+        /// </returns>
+        string GetString();
+
+        /// <summary>
+        /// Returns the underlying value as type dictionary.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value as type dictionary.
+        /// </returns>
+        IDictionary<string, IValue> GetDictionary();
+
+        /// <summary>
+        /// Returns the underlying value as type list.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value as type list.
+        /// </returns>
+        IList<IValue> GetList();
+
+        /// <summary>
+        /// Returns the underlying value converted to a managed object.
+        /// </summary>
+        /// <returns>
+        /// Returns the underlying value converted to a managed object.
+        /// </returns>
+        object GetObject();
+    }
+}

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -186,7 +186,7 @@ namespace CefSharp
         /// </summary>
         /// <value>The find handler.</value>
         IFindHandler FindHandler { get; set; }
-
+ 
         /// <summary>
         /// A flag that indicates whether the WebBrowser is initialized (true) or not (false).
         /// </summary>

--- a/CefSharp/Internals/IRenderWebBrowser.cs
+++ b/CefSharp/Internals/IRenderWebBrowser.cs
@@ -11,6 +11,12 @@ namespace CefSharp.Internals
     public interface IRenderWebBrowser : IWebBrowserInternal
     {
         /// <summary>
+        /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
+        /// </summary>
+        /// <value>The accessibility handler.</value>
+        IAccessibilityHandler AccessibilityHandler { get; set; }
+
+        /// <summary>
         /// Called to allow the client to return a ScreenInfo object with appropriate values.
         /// If null is returned then the rectangle from GetViewRect will be used.
         /// If the rectangle is still empty or invalid popups may not be drawn correctly. 


### PR DESCRIPTION
* Add AccessibilityHander.

Implement CefAccessibilityHandler. Add IAccessibilityHandler interface. Add AccessibilityHandler field to IWebBrowser.

* Pull request fixes.

Replaces tabs with spaces; move CefAccessibilityHandler implementation to RenderClientAdapter; add missing comments.

* Add CefValueWrapper.

Add ICefValue interface; pass ICefValue to IAccessibilityHandler.

* Pull request fixes.

Rename CefValue to Value and CefValueType to ValueType; add CefValueWrapper::GetObject() method; remove stub code in AccessibilityHandler; fix comment on IAccessibilityHandler.

* Pull request fixes.

Fix comments for IValue; remove redundant global namespace reference for CefValueType.
Add basic UI automation support.

Add AccessibilityHandler to process CEF accessibility events. Add AccessibilityTree and AccessibilityNode classes for storing accessibility tree information. Add BrowserAutomationPeer, AccessibilityTreeAutomationPeer, AccessibilityNodeAutomationPeer to pass accessibility tree to UI Automation clients. Add ChromiumWebBrowserWithAccessibilitySupport to support UI automation. Add TabControlAutomationPeer to support UI automation.