### PR TITLE
Refactoring - Move CefCookie conversion to TypeConversion

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -571,49 +571,7 @@ namespace CefSharp
             CefFrameWrapper frameWrapper(frame);
             CefRequestWrapper requestWrapper(request);
 
-            auto cookie = gcnew Cookie();
-            auto cookieName = StringUtils::ToClr(cefCookie.name);
-
-            //TODO: This code is duplicated in ResourceHandlerWrapper
-            if (!String::IsNullOrEmpty(cookieName))
-            {
-                cookie->Name = StringUtils::ToClr(cefCookie.name);
-                cookie->Value = StringUtils::ToClr(cefCookie.value);
-                cookie->Domain = StringUtils::ToClr(cefCookie.domain);
-                cookie->Path = StringUtils::ToClr(cefCookie.path);
-                cookie->Secure = cefCookie.secure == 1;
-                cookie->HttpOnly = cefCookie.httponly == 1;
-
-                if (cefCookie.has_expires)
-                {
-                    auto expires = cefCookie.expires;
-                    cookie->Expires = DateTimeUtils::FromCefTime(expires.year,
-                        expires.month,
-                        expires.day_of_month,
-                        expires.hour,
-                        expires.minute,
-                        expires.second,
-                        expires.millisecond);
-                }
-
-                auto creation = cefCookie.creation;
-                cookie->Creation = DateTimeUtils::FromCefTime(creation.year,
-                    creation.month,
-                    creation.day_of_month,
-                    creation.hour,
-                    creation.minute,
-                    creation.second,
-                    creation.millisecond);
-
-                auto lastAccess = cefCookie.last_access;
-                cookie->LastAccess = DateTimeUtils::FromCefTime(lastAccess.year,
-                    lastAccess.month,
-                    lastAccess.day_of_month,
-                    lastAccess.hour,
-                    lastAccess.minute,
-                    lastAccess.second,
-                    lastAccess.millisecond);
-            }
+            auto cookie = TypeConversion::FromNative(cefCookie);
 
             return handler->CanSetCookie(_browserControl, browserWrapper, %frameWrapper, %requestWrapper, cookie);
         }

--- a/CefSharp.Core/Internals/CookieVisitor.cpp
+++ b/CefSharp.Core/Internals/CookieVisitor.cpp
@@ -4,54 +4,13 @@
 
 #include "Stdafx.h"
 #include "CookieVisitor.h"
+#include "TypeConversion.h"
 
 namespace CefSharp
 {
     bool CookieVisitor::Visit(const CefCookie& cefCookie, int count, int total, bool& deleteCookie)
     {
-        auto cookie = gcnew Cookie();
-        String^ cookieName = StringUtils::ToClr(cefCookie.name);
-
-        if (!String::IsNullOrEmpty(cookieName))
-        {
-            cookie->Name = StringUtils::ToClr(cefCookie.name);
-            cookie->Value = StringUtils::ToClr(cefCookie.value);
-            cookie->Domain = StringUtils::ToClr(cefCookie.domain);
-            cookie->Path = StringUtils::ToClr(cefCookie.path);
-            cookie->Secure = cefCookie.secure == 1;
-            cookie->HttpOnly = cefCookie.httponly == 1;
-
-            if (cefCookie.has_expires)
-            {
-                auto expires = cefCookie.expires;
-                cookie->Expires = DateTimeUtils::FromCefTime(expires.year,
-                    expires.month,
-                    expires.day_of_month,
-                    expires.hour,
-                    expires.minute,
-                    expires.second,
-                    expires.millisecond);
-            }
-
-
-            auto creation = cefCookie.creation;
-            cookie->Creation = DateTimeUtils::FromCefTime(creation.year,
-                creation.month,
-                creation.day_of_month,
-                creation.hour,
-                creation.minute,
-                creation.second,
-                creation.millisecond);
-
-            auto lastAccess = cefCookie.last_access;
-            cookie->LastAccess = DateTimeUtils::FromCefTime(lastAccess.year,
-                lastAccess.month,
-                lastAccess.day_of_month,
-                lastAccess.hour,
-                lastAccess.minute,
-                lastAccess.second,
-                lastAccess.millisecond);
-        }
+        auto cookie = TypeConversion::FromNative(cefCookie);
 
         return _visitor->Visit(cookie, count, total, deleteCookie);
     }

--- a/CefSharp.Core/Internals/TypeConversion.h
+++ b/CefSharp.Core/Internals/TypeConversion.h
@@ -254,6 +254,43 @@ namespace CefSharp
 
                 return result;
             }
+
+            // Copied from CefSharp.BrowserSubprocess.Core\TypeUtils.h since it can't be included
+            static DateTime ConvertCefTimeToDateTime(CefTime time)
+            {
+                return DateTimeUtils::FromCefTime(time.year,
+                    time.month,
+                    time.day_of_month,
+                    time.hour,
+                    time.minute,
+                    time.second,
+                    time.millisecond);
+            }
+
+            static Cookie^ FromNative(const CefCookie& cefCookie)
+            {
+                auto cookie = gcnew Cookie();
+                auto cookieName = StringUtils::ToClr(cefCookie.name);
+
+                if (!String::IsNullOrEmpty(cookieName))
+                {
+                    cookie->Name = cookieName;
+                    cookie->Value = StringUtils::ToClr(cefCookie.value);
+                    cookie->Domain = StringUtils::ToClr(cefCookie.domain);
+                    cookie->Path = StringUtils::ToClr(cefCookie.path);
+                    cookie->Secure = cefCookie.secure == 1;
+                    cookie->HttpOnly = cefCookie.httponly == 1;
+                    cookie->Creation = ConvertCefTimeToDateTime(cefCookie.creation);
+                    cookie->LastAccess = ConvertCefTimeToDateTime(cefCookie.last_access);
+
+                    if (cefCookie.has_expires)
+                    {
+                        cookie->Expires = ConvertCefTimeToDateTime(cefCookie.expires);
+                    }
+                }
+
+                return cookie;
+            }
         };
     }
 }

--- a/CefSharp.Core/ResourceHandlerWrapper.cpp
+++ b/CefSharp.Core/ResourceHandlerWrapper.cpp
@@ -7,6 +7,7 @@
 #include "Internals/CefRequestWrapper.h"
 #include "Internals/CefResponseWrapper.h"
 #include "Internals/CefCallbackWrapper.h"
+#include "Internals/TypeConversion.h"
 #include "ResourceHandlerWrapper.h"
 
 using namespace System::Runtime::InteropServices;
@@ -64,49 +65,6 @@ namespace CefSharp
 
     Cookie^ ResourceHandlerWrapper::GetCookie(const CefCookie& cefCookie)
     {
-        auto cookie = gcnew Cookie();
-        String^ cookieName = StringUtils::ToClr(cefCookie.name);
-
-        if (!String::IsNullOrEmpty(cookieName))
-        {
-            cookie->Name = StringUtils::ToClr(cefCookie.name);
-            cookie->Value = StringUtils::ToClr(cefCookie.value);
-            cookie->Domain = StringUtils::ToClr(cefCookie.domain);
-            cookie->Path = StringUtils::ToClr(cefCookie.path);
-            cookie->Secure = cefCookie.secure == 1;
-            cookie->HttpOnly = cefCookie.httponly == 1;
-
-            if (cefCookie.has_expires)
-            {
-                auto expires = cefCookie.expires;
-                cookie->Expires = DateTimeUtils::FromCefTime(expires.year,
-                    expires.month,
-                    expires.day_of_month,
-                    expires.hour,
-                    expires.minute,
-                    expires.second,
-                    expires.millisecond);
-            }
-
-            auto creation = cefCookie.creation;
-            cookie->Creation = DateTimeUtils::FromCefTime(creation.year,
-                creation.month,
-                creation.day_of_month,
-                creation.hour,
-                creation.minute,
-                creation.second,
-                creation.millisecond);
-
-            auto lastAccess = cefCookie.last_access;
-            cookie->LastAccess = DateTimeUtils::FromCefTime(lastAccess.year,
-                lastAccess.month,
-                lastAccess.day_of_month,
-                lastAccess.hour,
-                lastAccess.minute,
-                lastAccess.second,
-                lastAccess.millisecond);
-        }
-
-        return cookie;
+        return TypeConversion::FromNative(cefCookie);
     }
 }


### PR DESCRIPTION
- Moved conversion of `CefCookie` -> `Cookie` to `CefSharp.Core\Internals\TypeConversion.h`
- Copied `ConvertCefTimeToDateTime` from `CefSharp.BrowserSubprocess.Core\TypeUtils.h` to `CefSharp.Core\Internals\TypeConversion.h` as including the file caused errors

The conversion of cookies was duplicated in
- `CefSharp.Core\Internals\ClientAdapter.cpp`
- `CefSharp.Core\Internals\CookieVisitor.cpp`
- `CefSharp.Core\ResourceHandlerWrapper.cpp`