### PR TITLE
Build.ps1 - Automated more tasks relating to updating CefSharp version and copyright year

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,14 +18,18 @@ charset                  = utf-8
 end_of_line              = crlf
 trim_trailing_whitespace = true
 
+# Powershell files (build.ps1)
+[*.ps1]
+charset = utf-8-bom
+
 # Xml config files
 [*.{props,targets,config,nuspec,manifest}]
-indent_size              = 2
+indent_size = 2
 
 # C++ Files
 [*.{cpp,h,in}]
-curly_bracket_next_line  = true
-indent_brace_style       = Allman
+curly_bracket_next_line = true
+indent_brace_style      = Allman
 
 [*.cs]
 # Capitalization styles
@@ -56,7 +60,7 @@ dotnet_style_qualification_for_property                                        =
 dotnet_style_qualification_for_method                                          = false : suggestion
 dotnet_style_qualification_for_event                                           = false : suggestion
 
-# Prefer using var 
+# Prefer using var
 csharp_style_var_for_built_in_types                                            = true : none
 csharp_style_var_when_type_is_apparent                                         = true : suggestion
 csharp_style_var_elsewhere                                                     = true : suggestion

--- a/CefSharp.BrowserSubprocess.Core/Resource.rc
+++ b/CefSharp.BrowserSubprocess.Core/Resource.rc
@@ -17,7 +17,7 @@ BEGIN
         BEGIN
             VALUE "FileDescription", "CefSharp.BrowserSubprocess.Core"
             VALUE "FileVersion", "71.0.0"
-            VALUE "LegalCopyright", "Copyright © 2010-2018 The CefSharp Authors"
+            VALUE "LegalCopyright", "Copyright © 2019 The CefSharp Authors"
             VALUE "ProductName", "CefSharp"
             VALUE "ProductVersion", "71.0.0"
         END

--- a/CefSharp.Core/Resource.rc
+++ b/CefSharp.Core/Resource.rc
@@ -17,7 +17,7 @@ BEGIN
         BEGIN
             VALUE "FileDescription", "CefSharp.Core"
             VALUE "FileVersion", "71.0.0"
-            VALUE "LegalCopyright", "Copyright © 2010-2018 The CefSharp Authors"
+            VALUE "LegalCopyright", "Copyright © 2019 The CefSharp Authors"
             VALUE "ProductName", "CefSharp"
             VALUE "ProductVersion", "71.0.0"
         END

--- a/CefSharp.shfbproj
+++ b/CefSharp.shfbproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
@@ -31,7 +31,7 @@
       <DocumentationSource sourceFile="CefSharp\CefSharp.csproj" />
       <DocumentationSource sourceFile="CefSharp.Core\CefSharp.Core.vcxproj" />
     </DocumentationSources>
-    <HelpFileVersion>67.0.0</HelpFileVersion>
+    <HelpFileVersion>71.0.0</HelpFileVersion>
     <MaximumGroupParts>2</MaximumGroupParts>
     <NamespaceGrouping>False</NamespaceGrouping>
     <SyntaxFilters>C#, Managed C++</SyntaxFilters>
@@ -57,7 +57,7 @@
       <Filter entryType="Namespace" fullName="CefSharp.Internals" isExposed="False" xmlns="" />
     </ApiFilter>
     <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
-    <HeaderText>Version 67.0.0</HeaderText>
+    <HeaderText>Version 71.0.0</HeaderText>
     <CopyrightHref>https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE</CopyrightHref>
     <NamespaceSummaries>
       <NamespaceSummaryItem name="CefSharp" isDocumented="True">Interfaces, enums, structs and classes that make up the core API interface</NamespaceSummaryItem>

--- a/CefSharp/Properties/AssemblyInfo.cs
+++ b/CefSharp/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ namespace CefSharp
         public const string AssemblyProduct = "CefSharp";
         public const string AssemblyVersion = "71.0.0";
         public const string AssemblyFileVersion = "71.0.0.0";
-        public const string AssemblyCopyright = "Copyright © 2010-2018 The CefSharp Authors";
+        public const string AssemblyCopyright = "Copyright © 2019 The CefSharp Authors";
         public const string CefSharpCoreProject = "CefSharp.Core, PublicKey=" + PublicKey;
         public const string CefSharpBrowserSubprocessProject = "CefSharp.BrowserSubprocess, PublicKey=" + PublicKey;
         public const string CefSharpBrowserSubprocessCoreProject = "CefSharp.BrowserSubprocess.Core, PublicKey=" + PublicKey;

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-// Copyright © 2017 The CefSharp Authors. All rights reserved.
+// Copyright © The CefSharp Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-// Copyright © 2010-2018 The CefSharp Authors. All rights reserved.
+// Copyright © 2017 The CefSharp Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/NuGet/CefSharp.Common.nuspec
+++ b/NuGet/CefSharp.Common.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component ('Core' and common 'Element' components, needed by both WPF and WinForms).</description>
     <tags>chrome browser</tags>
-    <copyright>Copyright © 2010-2018 The CefSharp Authors</copyright>
+    <copyright>Copyright © The CefSharp Authors</copyright>
     <dependencies>
       <dependency id="cef.redist.x86" version="[$RedistVersion$]" />
       <dependency id="cef.redist.x64" version="[$RedistVersion$]" />

--- a/NuGet/CefSharp.OffScreen.nuspec
+++ b/NuGet/CefSharp.OffScreen.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component (OffScreen control).</description>
     <tags>osr chrome browser</tags>
-    <copyright>Copyright © 2010-2018 The CefSharp Authors</copyright>
+    <copyright>Copyright © The CefSharp Authors</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">
         <dependency id="CefSharp.Common" version="[$version$]" />

--- a/NuGet/CefSharp.WinForms.nuspec
+++ b/NuGet/CefSharp.WinForms.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component (WinForms control).</description>
     <tags>winforms chrome browser</tags>
-    <copyright>Copyright © 2010-2018 The CefSharp Authors</copyright>
+    <copyright>Copyright The CefSharp Authors</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">
         <dependency id="CefSharp.Common" version="[$version$]" />

--- a/NuGet/CefSharp.Wpf.nuspec
+++ b/NuGet/CefSharp.Wpf.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component (WPF control).</description>
     <tags>wpf chrome browser</tags>
-    <copyright>Copyright © 2010-2018 The CefSharp Authors</copyright>
+    <copyright>Copyright © The CefSharp Authors</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">
         <dependency id="CefSharp.Common" version="[$version$]" />

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [ValidateSet("vs2015", "vs2017", "nupkg-only", "gitlink")]
     [Parameter(Position = 0)] 
     [string] $Target = "vs2015",
@@ -345,10 +345,14 @@ function WriteAssemblyVersion
     $Filename = Join-Path $WorkingDir CefSharp\Properties\AssemblyInfo.cs
     $Regex = 'public const string AssemblyVersion = "(.*)"';
     $Regex2 = 'public const string AssemblyFileVersion = "(.*)"'
+    $Regex3 = 'public const string AssemblyCopyright = "Copyright © .* The CefSharp Authors"'
     
     $AssemblyInfo = Get-Content -Encoding UTF8 $Filename
+    $CurrentYear = Get-Date -Format yyyy
+    
     $NewString = $AssemblyInfo -replace $Regex, "public const string AssemblyVersion = ""$AssemblyVersion"""
     $NewString = $NewString -replace $Regex2, "public const string AssemblyFileVersion = ""$AssemblyVersion.0"""
+    $NewString = $NewString -replace $Regex3, "public const string AssemblyCopyright = ""Copyright © $CurrentYear The CefSharp Authors"""
     
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
@@ -371,10 +375,14 @@ function WriteVersionToResourceFile($resourceFile)
     $Filename = Join-Path $WorkingDir $resourceFile
     $Regex1 = 'VERSION .*';
     $Regex2 = 'Version", ".*?"';
+    $Regex3 = 'Copyright © .* The CefSharp Authors'
     
     $ResourceData = Get-Content -Encoding UTF8 $Filename
+    $CurrentYear = Get-Date -Format yyyy
+    
     $NewString = $ResourceData -replace $Regex1, "VERSION $AssemblyVersion"
     $NewString = $NewString -replace $Regex2, "Version"", ""$AssemblyVersion"""
+    $NewString = $NewString -replace $Regex3, "Copyright © $CurrentYear The CefSharp Authors"
     
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)

--- a/build.ps1
+++ b/build.ps1
@@ -346,7 +346,7 @@ function WriteAssemblyVersion
     $Regex = 'public const string AssemblyVersion = "(.*)"';
     $Regex2 = 'public const string AssemblyFileVersion = "(.*)"'
     
-    $AssemblyInfo = Get-Content $Filename
+    $AssemblyInfo = Get-Content -Encoding UTF8 $Filename
     $NewString = $AssemblyInfo -replace $Regex, "public const string AssemblyVersion = ""$AssemblyVersion"""
     $NewString = $NewString -replace $Regex2, "public const string AssemblyFileVersion = ""$AssemblyVersion.0"""
     
@@ -358,7 +358,7 @@ function WriteVersionToManifest($manifest)
     $Filename = Join-Path $WorkingDir $manifest
     $Regex = 'assemblyIdentity version="(.*?)"';
     
-    $ManifestData = Get-Content $Filename
+    $ManifestData = Get-Content -Encoding UTF8 $Filename
     $NewString = $ManifestData -replace $Regex, "assemblyIdentity version=""$AssemblyVersion.0"""
     
     $NewString | Set-Content $Filename -Encoding UTF8
@@ -370,7 +370,7 @@ function WriteVersionToResourceFile($resourceFile)
     $Regex1 = 'VERSION .*';
     $Regex2 = 'Version", ".*?"';
     
-    $ResourceData = Get-Content $Filename
+    $ResourceData = Get-Content -Encoding UTF8 $Filename
     $NewString = $ResourceData -replace $Regex1, "VERSION $AssemblyVersion"
     $NewString = $NewString -replace $Regex2, "Version"", ""$AssemblyVersion"""
     

--- a/build.ps1
+++ b/build.ps1
@@ -350,7 +350,8 @@ function WriteAssemblyVersion
     $NewString = $AssemblyInfo -replace $Regex, "public const string AssemblyVersion = ""$AssemblyVersion"""
     $NewString = $NewString -replace $Regex2, "public const string AssemblyFileVersion = ""$AssemblyVersion.0"""
     
-    $NewString | Set-Content $Filename -Encoding UTF8
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
 }
 
 function WriteVersionToManifest($manifest)
@@ -361,7 +362,8 @@ function WriteVersionToManifest($manifest)
     $ManifestData = Get-Content -Encoding UTF8 $Filename
     $NewString = $ManifestData -replace $Regex, "assemblyIdentity version=""$AssemblyVersion.0"""
     
-    $NewString | Set-Content $Filename -Encoding UTF8
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
 }
 
 function WriteVersionToResourceFile($resourceFile)
@@ -374,7 +376,9 @@ function WriteVersionToResourceFile($resourceFile)
     $NewString = $ResourceData -replace $Regex1, "VERSION $AssemblyVersion"
     $NewString = $NewString -replace $Regex2, "Version"", ""$AssemblyVersion"""
     
-    $NewString | Set-Content $Filename -Encoding UTF8
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
+}
 
 function WriteVersionToShfbproj
 {

--- a/build.ps1
+++ b/build.ps1
@@ -375,6 +375,19 @@ function WriteVersionToResourceFile($resourceFile)
     $NewString = $NewString -replace $Regex2, "Version"", ""$AssemblyVersion"""
     
     $NewString | Set-Content $Filename -Encoding UTF8
+
+function WriteVersionToShfbproj
+{
+    $Filename = Join-Path $WorkingDir CefSharp.shfbproj
+    $Regex1 = '<HelpFileVersion>.*<\/HelpFileVersion>';
+    $Regex2 = '<HeaderText>Version .*<\/HeaderText>';
+    
+    $ShfbprojData = Get-Content -Encoding UTF8 $Filename
+    $NewString = $ShfbprojData -replace $Regex1, "<HelpFileVersion>$AssemblyVersion</HelpFileVersion>"
+    $NewString = $NewString -replace $Regex2, "<HeaderText>Version $AssemblyVersion</HeaderText>"
+    
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
 }
 
 Write-Diagnostic "CEF Redist Version = $RedistVersion"
@@ -384,6 +397,7 @@ DownloadNuget
 NugetPackageRestore
 
 WriteAssemblyVersion
+WriteVersionToShfbproj
 
 WriteVersionToManifest "CefSharp.BrowserSubprocess\app.manifest"
 WriteVersionToManifest "CefSharp.OffScreen.Example\app.manifest"

--- a/build.ps1
+++ b/build.ps1
@@ -402,6 +402,18 @@ function WriteVersionToShfbproj
     [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
 }
 
+function WriteVersionToAppveyor
+{
+    $Filename = Join-Path $WorkingDir appveyor.yml
+    $Regex1 = 'version: .*-CI{build}';
+    
+    $AppveyorData = Get-Content -Encoding UTF8 $Filename
+    $NewString = $AppveyorData -replace $Regex1, "version: $AssemblyVersion-CI{build}"
+    
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
+}
+
 Write-Diagnostic "CEF Redist Version = $RedistVersion"
 
 DownloadNuget
@@ -410,6 +422,7 @@ NugetPackageRestore
 
 WriteAssemblyVersion
 WriteVersionToShfbproj
+WriteVersionToAppveyor
 
 WriteVersionToManifest "CefSharp.BrowserSubprocess\app.manifest"
 WriteVersionToManifest "CefSharp.OffScreen.Example\app.manifest"


### PR DESCRIPTION
build.ps1 changes:
- Updates the version number in `CefSharp.shfbproj`
- Updates the version number in `appveyor.yml`
- Updates copyright year on compiled files to the current year, same as CEF does
- Specifies `utf-8` as the encoding when reading files
- Saves files as UTF-8 without BOM
- build.ps1 is now saved as `utf-8-bom`, otherwise it breaks on windows when containing non-ASCII characters (©)

Editorconfig:
- Specified `utf-8-bom` for `*.ps1` files

Maintenance:
- LICENSE: Removed the copyright year as it's not needed
- NuGet: Removed the copyright year on the `nuspec` files as it's not needed

Was going to make build.ps1 update the year on LICENSE and NuGet as well, but the years for NuGet were unnecessary and LICENSE should only change year when it's updated.