### PR TITLE
Improved dispose pattern in ChromiumWebBrowser

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -53,7 +53,7 @@ namespace CefSharp.OffScreen
         /// <summary>
         /// Gets a value indicating whether this instance is disposed.
         /// </summary>
-        /// <value><c>true</c> if this instance is disposed; otherwise, <c>false</c>.</value>
+        /// <value><see langword="true" /> if this instance is disposed; otherwise, <see langword="false" />.</value>
         public bool IsDisposed
         {
             get

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -330,7 +330,7 @@ namespace CefSharp.OffScreen
         }
 
         /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// Releases all resources used by the <see cref="ChromiumWebBrowser"/> object
         /// </summary>
         public void Dispose()
         {
@@ -339,9 +339,9 @@ namespace CefSharp.OffScreen
         }
 
         /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
+        /// Releases unmanaged and - optionally - managed resources for the <see cref="ChromiumWebBrowser"/>
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
@@ -359,24 +359,24 @@ namespace CefSharp.OffScreen
                     managedCefBrowserAdapter.Dispose();
                     managedCefBrowserAdapter = null;
                 }
+
+                // Don't reference event listeners any longer:
+                AddressChanged = null;
+                BrowserInitialized = null;
+                ConsoleMessage = null;
+                FrameLoadEnd = null;
+                FrameLoadStart = null;
+                LoadError = null;
+                LoadingStateChanged = null;
+                Paint = null;
+                StatusMessage = null;
+                TitleChanged = null;
+
+                // Release reference to handlers, make sure this is done after we dispose managedCefBrowserAdapter
+                // otherwise the ILifeSpanHandler.DoClose will not be invoked. (More important in the WinForms version,
+                // we do it here for consistency)
+                this.SetHandlersToNull();
             }
-
-            // Don't reference event listeners any longer:
-            AddressChanged = null;
-            BrowserInitialized = null;
-            ConsoleMessage = null;
-            FrameLoadEnd = null;
-            FrameLoadStart = null;
-            LoadError = null;
-            LoadingStateChanged = null;
-            Paint = null;
-            StatusMessage = null;
-            TitleChanged = null;
-
-            // Release reference to handlers, make sure this is done after we dispose managedCefBrowserAdapter
-            // otherwise the ILifeSpanHandler.DoClose will not be invoked. (More important in the WinForms version,
-            // we do it here for consistency)
-            this.SetHandlersToNull();
 
             Cef.RemoveDisposable(this);
         }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -451,9 +451,26 @@ namespace CefSharp.WinForms
         }
 
         /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="T:System.Windows.Forms.Control" /> and its child controls and optionally releases the managed resources.
+        /// Finalizes an instance of the <see cref="ChromiumWebBrowser"/> class.
         /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        ~ChromiumWebBrowser()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="ChromiumWebBrowser"/> object
+        /// </summary>
+        public new void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// If not in design mode; Releases unmanaged and - optionally - managed resources for the <see cref="ChromiumWebBrowser"/>
+        /// </summary>
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
             if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
@@ -461,73 +478,65 @@ namespace CefSharp.WinForms
                 return;
             }
 
-            if (!designMode && disposing)
-            {
-                //The unmanaged resources should never be created in design mode, so only dispose when
-                //at runtime
-                IsBrowserInitialized = false;
-                FreeUnmanagedResources();
-            }
-
-            // Don't maintain a reference to event listeners anylonger:
-            AddressChanged = null;
-            ConsoleMessage = null;
-            FrameLoadEnd = null;
-            FrameLoadStart = null;
-            IsBrowserInitializedChanged = null;
-            LoadError = null;
-            LoadingStateChanged = null;
-            StatusMessage = null;
-            TitleChanged = null;
-
-            // Release reference to handlers, make sure this is done after we dispose managedCefBrowserAdapter
-            // otherwise the ILifeSpanHandler.DoClose will not be invoked.
-            this.SetHandlersToNull();
-
             if (!designMode)
             {
-                RemoveFromListOfCefBrowsers();
+                InternalDispose(disposing);
             }
 
             base.Dispose(disposing);
         }
 
         /// <summary>
-        /// Required for designer support - this method cannot be inlined as the designer
-        /// will attempt to load libcef.dll and will subsiquently throw an exception.
+        /// Releases unmanaged and - optionally - managed resources for the <see cref="ChromiumWebBrowser"/>
         /// </summary>
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+        /// <remarks>
+        /// This method cannot be inlined as the designer will attempt to load libcef.dll and will subsiquently throw an exception.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void RemoveFromListOfCefBrowsers()
+        private void InternalDispose(bool disposing)
         {
+            if (disposing)
+            {
+                IsBrowserInitialized = false;
+
+                browser = null;
+
+                if (parentFormMessageInterceptor != null)
+                {
+                    parentFormMessageInterceptor.Dispose();
+                    parentFormMessageInterceptor = null;
+                }
+
+                if (browserSettings != null)
+                {
+                    browserSettings.Dispose();
+                    browserSettings = null;
+                }
+
+                if (managedCefBrowserAdapter != null)
+                {
+                    managedCefBrowserAdapter.Dispose();
+                    managedCefBrowserAdapter = null;
+                }
+
+                // Don't maintain a reference to event listeners anylonger:
+                AddressChanged = null;
+                ConsoleMessage = null;
+                FrameLoadEnd = null;
+                FrameLoadStart = null;
+                IsBrowserInitializedChanged = null;
+                LoadError = null;
+                LoadingStateChanged = null;
+                StatusMessage = null;
+                TitleChanged = null;
+
+                // Release reference to handlers, make sure this is done after we dispose managedCefBrowserAdapter
+                // otherwise the ILifeSpanHandler.DoClose will not be invoked.
+                this.SetHandlersToNull();
+            }
+
             Cef.RemoveDisposable(this);
-        }
-
-        /// <summary>
-        /// Required for designer support - this method cannot be inlined as the designer
-        /// will attempt to load libcef.dll and will subsiquently throw an exception.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void FreeUnmanagedResources()
-        {
-            browser = null;
-
-            if (parentFormMessageInterceptor != null)
-            {
-                parentFormMessageInterceptor.Dispose();
-                parentFormMessageInterceptor = null;
-            }
-
-            if (browserSettings != null)
-            {
-                browserSettings.Dispose();
-                browserSettings = null;
-            }
-
-            if (managedCefBrowserAdapter != null)
-            {
-                managedCefBrowserAdapter.Dispose();
-                managedCefBrowserAdapter = null;
-            }
         }
 
         /// <summary>

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -456,6 +456,8 @@ namespace CefSharp.WinForms
         /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
+            // Attempt to move the disposeSignaled state from 0 to 1. If successful, we can be assured that
+            // this thread is the first thread to do so, and can safely dispose of the object.
             if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
             {
                 return;

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -451,23 +451,6 @@ namespace CefSharp.WinForms
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="ChromiumWebBrowser"/> class.
-        /// </summary>
-        ~ChromiumWebBrowser()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Releases all resources used by the <see cref="ChromiumWebBrowser"/> object
-        /// </summary>
-        public new void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
         /// If not in design mode; Releases unmanaged and - optionally - managed resources for the <see cref="ChromiumWebBrowser"/>
         /// </summary>
         /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -69,7 +69,7 @@ namespace CefSharp.WinForms
         /// <summary>
         /// Gets a value indicating whether this instance is disposed.
         /// </summary>
-        /// <value><c>true</c> if this instance is disposed; otherwise, <c>false</c>.</value>
+        /// <value><see langword="true" /> if this instance is disposed; otherwise, <see langword="false" />.</value>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(false)]
         public new bool IsDisposed
         {

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -546,34 +546,22 @@ namespace CefSharp.Wpf
         /// </summary>
         ~ChromiumWebBrowser()
         {
-            if (DesignMode)
-            {
-                return;
-            }
-
             Dispose(false);
         }
 
         /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// Releases all resources used by the <see cref="ChromiumWebBrowser"/> object
         /// </summary>
         public void Dispose()
         {
-            if (DesignMode)
-            {
-                return;
-            }
-
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
         /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
+        /// If not in design mode; Releases unmanaged and - optionally - managed resources for the <see cref="ChromiumWebBrowser"/>
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        // This method cannot be inlined as the designer will attempt to load libcef.dll and will subsiquently throw an exception.
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
@@ -581,6 +569,24 @@ namespace CefSharp.Wpf
                 return;
             }
 
+            if (DesignMode)
+            {
+                return;
+            }
+
+            InternalDispose(disposing);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources for the <see cref="ChromiumWebBrowser"/>
+        /// </summary>
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+        /// <remarks>
+        /// This method cannot be inlined as the designer will attempt to load libcef.dll and will subsiquently throw an exception.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void InternalDispose(bool disposing)
+        {
             if (disposing)
             {
                 browser = null;
@@ -645,28 +651,29 @@ namespace CefSharp.Wpf
                     SetCurrentValue(IsBrowserInitializedProperty, false);
                     WebBrowser = null;
                 });
+
+                // No longer reference event listeners:
+                ConsoleMessage = null;
+                FrameLoadEnd = null;
+                FrameLoadStart = null;
+                IsBrowserInitializedChanged = null;
+                LoadError = null;
+                LoadingStateChanged = null;
+                Paint = null;
+                StatusMessage = null;
+                TitleChanged = null;
+
+                // Release reference to handlers, make sure this is done after we dispose managedCefBrowserAdapter
+                // otherwise the ILifeSpanHandler.DoClose will not be invoked. (More important in the WinForms version,
+                // we do it here for consistency)
+                this.SetHandlersToNull();
+
+                WpfKeyboardHandler.Dispose();
+
+                source = null;
             }
 
-            // No longer reference event listeners:
-            ConsoleMessage = null;
-            FrameLoadEnd = null;
-            FrameLoadStart = null;
-            IsBrowserInitializedChanged = null;
-            LoadError = null;
-            LoadingStateChanged = null;
-            Paint = null;
-            StatusMessage = null;
-            TitleChanged = null;
-
-            // Release reference to handlers, make sure this is done after we dispose managedCefBrowserAdapter
-            // otherwise the ILifeSpanHandler.DoClose will not be invoked. (More important in the WinForms version,
-            // we do it here for consistency)
-            this.SetHandlersToNull();
-
             Cef.RemoveDisposable(this);
-
-            WpfKeyboardHandler.Dispose();
-            source = null;
         }
 
         /// <summary>

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -120,7 +120,7 @@ namespace CefSharp.Wpf
         /// <summary>
         /// Gets a value indicating whether this instance is disposed.
         /// </summary>
-        /// <value><c>true</c> if this instance is disposed; otherwise, <c>false</c>.</value>
+        /// <value><see langword="true" /> if this instance is disposed; otherwise, <see langword="false" />.</value>
         public bool IsDisposed
         {
             get

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -564,6 +564,8 @@ namespace CefSharp.Wpf
         /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
+            // Attempt to move the disposeSignaled state from 0 to 1. If successful, we can be assured that
+            // this thread is the first thread to do so, and can safely dispose of the object.
             if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
             {
                 return;

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -196,6 +196,12 @@ namespace CefSharp
         bool IsBrowserInitialized { get; }
 
         /// <summary>
+        /// A flag that indicates whether the WebBrowser has been disposed (<see langword="true" />) or not (<see langword="false" />)
+        /// </summary>
+        /// <value><see langword="true" /> if this instance is disposed; otherwise, <see langword="false" /></value>
+        bool IsDisposed { get; }
+
+        /// <summary>
         /// A flag that indicates whether the control is currently loading one or more web pages (true) or not (false).
         /// </summary>
         /// <value><c>true</c> if this instance is loading; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
- Added an `IsDisposed` property to `IWebBrowser`
- Implemented a thread safe dispose pattern
- Now only disposes of managed objects when `disposing` is set to `true`
- Simplified the handling of design mode and disposing

Resolves #1954 

EDIT:
As this is getting merged in parts, here are the relevant commits
OffScreen: https://github.com/cefsharp/CefSharp/commit/58fac3865b46c0b55807f670298d0eb070a964ce https://github.com/cefsharp/CefSharp/commit/b1ef9e8bc2c55a5e0e9a0b66988f670695836177