### PR TITLE
WPF - Refactor RenderHandler implementations

### DIFF
--- a/CefSharp.Wpf/CefSharp.Wpf.csproj
+++ b/CefSharp.Wpf/CefSharp.Wpf.csproj
@@ -96,6 +96,7 @@
     <AppDesigner Include="Properties\" />
     <Compile Include="ChromiumWebBrowser.cs" />
     <Compile Include="PaintEventArgs.cs" />
+    <Compile Include="Rendering\AbstractRenderHandler.cs" />
     <Compile Include="Rendering\Experimental\IncreaseBufferInteropRenderHandler.cs" />
     <Compile Include="Rendering\Experimental\ByteArrayWritableBitmapRenderHandler.cs" />
     <Compile Include="Rendering\InteropBitmapRenderHandler.cs" />

--- a/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
@@ -1,0 +1,127 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Rect = CefSharp.Structs.Rect;
+
+namespace CefSharp.Wpf.Rendering
+{
+    /// <summary>
+    /// AbstractRenderHandler - abstracts away the basics of implementing a <see cref="IRenderHandler"/>
+    /// </summary>
+    /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
+    public abstract class AbstractRenderHandler : IDisposable, IRenderHandler
+    {
+        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
+        protected static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
+
+        protected static readonly PixelFormat PixelFormat = PixelFormats.Pbgra32;
+        protected static int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
+
+        protected object lockObject = new object();
+
+        protected Size viewSize;
+        protected Size popupSize;
+        protected DispatcherPriority dispatcherPriority;
+
+        protected MemoryMappedFile viewMemoryMappedFile;
+        protected MemoryMappedFile popupMemoryMappedFile;
+        protected MemoryMappedViewAccessor viewMemoryMappedViewAccessor;
+        protected MemoryMappedViewAccessor popupMemoryMappedViewAccessor;
+
+        #region IDisposable Support
+        /// <summary>
+        /// The value for disposal, if it's 1 (one) then this instance is either disposed
+        /// or in the process of getting disposed
+        /// </summary>
+        private int disposeSignaled;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is disposed.
+        /// </summary>
+        /// <value><c>true</c> if this instance is disposed; otherwise, <c>false</c>.</value>
+        public bool IsDisposed
+        {
+            get
+            {
+                return Interlocked.CompareExchange(ref disposeSignaled, 1, 1) == 1;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
+            {
+                return;
+            }
+
+            if (!disposing)
+            {
+                return;
+            }
+
+            ReleaseMemoryMappedView(ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
+            ReleaseMemoryMappedView(ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
+        }
+        #endregion
+
+        protected void ReleaseMemoryMappedView(ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor stream)
+        {
+            if (stream != null)
+            {
+                stream.Dispose();
+                stream = null;
+            }
+
+            if (mappedFile != null)
+            {
+                mappedFile.Dispose();
+                mappedFile = null;
+            }
+        }
+
+        /// <summary>
+        /// Called when an element has been rendered to the shared texture handle.
+        /// This method is only called when <see cref="IWindowInfo.SharedTextureEnabled"/> is set to true
+        /// </summary>
+        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
+        /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
+        /// <param name="sharedHandle">is the handle for a D3D11 Texture2D that can be accessed via ID3D11Device using the OpenSharedResource method.</param>
+        public virtual void OnAcceleratedPaint(bool isPopup, Rect dirtyRect, IntPtr sharedHandle)
+        {
+            // NOT USED
+        }
+
+        public virtual void OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
+        {
+            if (image.Dispatcher.HasShutdownStarted)
+            {
+                return;
+            }
+
+            if (isPopup)
+            {
+                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref popupSize, ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
+            }
+            else
+            {
+                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref viewSize, ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
+            }
+        }
+
+        protected abstract void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor);
+    }
+}

--- a/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
@@ -15,7 +15,7 @@ using Rect = CefSharp.Structs.Rect;
 namespace CefSharp.Wpf.Rendering
 {
     /// <summary>
-    /// AbstractRenderHandler - abstracts away the basics of implementing a <see cref="IRenderHandler"/>
+    /// Implements the basics of a <see cref="IRenderHandler"/>
     /// </summary>
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
     public abstract class AbstractRenderHandler : IDisposable, IRenderHandler
@@ -37,7 +37,6 @@ namespace CefSharp.Wpf.Rendering
         protected MemoryMappedViewAccessor viewMemoryMappedViewAccessor;
         protected MemoryMappedViewAccessor popupMemoryMappedViewAccessor;
 
-        #region IDisposable Support
         /// <summary>
         /// The value for disposal, if it's 1 (one) then this instance is either disposed
         /// or in the process of getting disposed
@@ -47,7 +46,7 @@ namespace CefSharp.Wpf.Rendering
         /// <summary>
         /// Gets a value indicating whether this instance is disposed.
         /// </summary>
-        /// <value><c>true</c> if this instance is disposed; otherwise, <c>false</c>.</value>
+        /// <value><see langword="true"/> if this instance is disposed; otherwise, <see langword="true"/>.</value>
         public bool IsDisposed
         {
             get
@@ -56,11 +55,18 @@ namespace CefSharp.Wpf.Rendering
             }
         }
 
+        /// <summary>
+        /// Releases all resources used by the <see cref="AbstractRenderHandler"/> object
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
         }
 
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources for the <see cref="AbstractRenderHandler"/>
+        /// </summary>
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (Interlocked.CompareExchange(ref disposeSignaled, 1, 0) != 0)
@@ -76,7 +82,6 @@ namespace CefSharp.Wpf.Rendering
             ReleaseMemoryMappedView(ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
             ReleaseMemoryMappedView(ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
         }
-        #endregion
 
         protected void ReleaseMemoryMappedView(ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor stream)
         {
@@ -105,6 +110,16 @@ namespace CefSharp.Wpf.Rendering
             // NOT USED
         }
 
+        /// <summary>
+        /// Called when an element should be painted. (Invoked from CefRenderHandler.OnPaint)
+        /// This method is only called when <see cref="IWindowInfo.SharedTextureEnabled"/> is set to false.
+        /// </summary>
+        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
+        /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
+        /// <param name="buffer">The bitmap will be will be  width * height *4 bytes in size and represents a BGRA image with an upper-left origin</param>
+        /// <param name="width">width</param>
+        /// <param name="height">height</param>
+        /// <param name="image">image used as parent for rendered bitmap</param>
         public virtual void OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
         {
             if (image.Dispatcher.HasShutdownStarted)

--- a/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
@@ -61,6 +61,7 @@ namespace CefSharp.Wpf.Rendering
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/CefSharp.Wpf/Rendering/Experimental/ByteArrayWritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/Experimental/ByteArrayWritableBitmapRenderHandler.cs
@@ -7,7 +7,6 @@ using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Rect = CefSharp.Structs.Rect;
@@ -23,9 +22,6 @@ namespace CefSharp.Wpf.Rendering.Experimental
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
     public class ByteArrayWritableBitmapRenderHandler : AbstractRenderHandler
     {
-        private static new readonly PixelFormat PixelFormat = PixelFormats.Prgba64;
-        private static new int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
-
         private double dpiX;
         private double dpiY;
         private bool invalidateDirtyRect;

--- a/CefSharp.Wpf/Rendering/Experimental/ByteArrayWritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/Experimental/ByteArrayWritableBitmapRenderHandler.cs
@@ -3,13 +3,13 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
-
 using Rect = CefSharp.Structs.Rect;
 
 namespace CefSharp.Wpf.Rendering.Experimental
@@ -21,18 +21,14 @@ namespace CefSharp.Wpf.Rendering.Experimental
     /// wise.
     /// </summary>
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
-    public class ByteArrayWritableBitmapRenderHandler : IRenderHandler
+    public class ByteArrayWritableBitmapRenderHandler : AbstractRenderHandler
     {
-        /// <summary>
-        /// The pixel format
-        /// </summary>
-        private static readonly PixelFormat PixelFormat = PixelFormats.Prgba64;
-        private static int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
+        private static new readonly PixelFormat PixelFormat = PixelFormats.Prgba64;
+        private static new int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
 
         private double dpiX;
         private double dpiY;
         private bool invalidateDirtyRect;
-        private DispatcherPriority dispatcherPriority;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WritableBitmapRenderHandler"/> class.
@@ -49,25 +45,8 @@ namespace CefSharp.Wpf.Rendering.Experimental
             this.dispatcherPriority = dispatcherPriority;
         }
 
-        /// <summary>
-        /// Called when an element has been rendered to the shared texture handle.
-        /// This method is only called when <see cref="IWindowInfo.SharedTextureEnabled"/> is set to true
-        /// </summary>
-        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
-        /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
-        /// <param name="sharedHandle">is the handle for a D3D11 Texture2D that can be accessed via ID3D11Device using the OpenSharedResource method.</param>
-        void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, IntPtr sharedHandle)
+        protected override void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
         {
-            //NOT USED
-        }
-
-        void IRenderHandler.OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
-        {
-            if (image.Dispatcher.HasShutdownStarted)
-            {
-                return;
-            }
-
             int pixels = width * height;
             int numberOfBytes = pixels * BytesPerPixel;
             var stride = width * BytesPerPixel;
@@ -116,11 +95,6 @@ namespace CefSharp.Wpf.Rendering.Experimental
                     bitmap.Unlock();
                 }
             }), dispatcherPriority);
-        }
-
-        void IDisposable.Dispose()
-        {
-
         }
     }
 }

--- a/CefSharp.Wpf/Rendering/Experimental/IncreaseBufferInteropRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/Experimental/IncreaseBufferInteropRenderHandler.cs
@@ -4,11 +4,9 @@
 
 using System;
 using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Threading;
 using Rect = CefSharp.Structs.Rect;
 
@@ -20,28 +18,8 @@ namespace CefSharp.Wpf.Rendering.Experimental
     /// when the size increases
     /// </summary>
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
-    public class IncreaseBufferInteropRenderHandler : IRenderHandler
+    public class IncreaseBufferInteropRenderHandler : AbstractRenderHandler
     {
-        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
-        private static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
-
-        /// <summary>
-        /// The pixel format
-        /// </summary>
-        private static readonly PixelFormat PixelFormat = PixelFormats.Pbgra32;
-        private static int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
-
-        private object lockObject = new object();
-
-        private Size viewSize;
-        private Size popupSize;
-        private DispatcherPriority dispatcherPriority;
-
-        private MemoryMappedFile viewMemoryMappedFile;
-        private MemoryMappedFile popupMemoryMappedFile;
-        private MemoryMappedViewAccessor viewMemoryMappedViewAccessor;
-        private MemoryMappedViewAccessor popupMemoryMappedViewAccessor;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InteropBitmapRenderHandler"/> class.
         /// </summary>
@@ -51,46 +29,8 @@ namespace CefSharp.Wpf.Rendering.Experimental
             this.dispatcherPriority = dispatcherPriority;
         }
 
-        /// <summary>
-        /// Dispose
-        /// </summary>
-        public void Dispose()
+        protected override void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
         {
-            ReleaseMemoryMappedView(ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
-            ReleaseMemoryMappedView(ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
-        }
-
-        /// <summary>
-        /// Called when an element has been rendered to the shared texture handle.
-        /// This method is only called when <see cref="IWindowInfo.SharedTextureEnabled"/> is set to true
-        /// </summary>
-        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
-        /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
-        /// <param name="sharedHandle">is the handle for a D3D11 Texture2D that can be accessed via ID3D11Device using the OpenSharedResource method.</param>
-        void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, IntPtr sharedHandle)
-        {
-            //NOT USED
-        }
-
-        void IRenderHandler.OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
-        {
-            if (isPopup)
-            {
-                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref popupSize, ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
-            }
-            else
-            {
-                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref viewSize, ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
-            }
-        }
-
-        private void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
-        {
-            if (image.Dispatcher.HasShutdownStarted)
-            {
-                return;
-            }
-
             var createNewBitmap = false;
 
             lock (lockObject)
@@ -146,32 +86,14 @@ namespace CefSharp.Wpf.Rendering.Experimental
                             var bitmap = (InteropBitmap)Imaging.CreateBitmapSourceFromMemorySection(backBufferHandle.DangerousGetHandle(), width, height, PixelFormat, stride, 0);
                             image.Source = bitmap;
                         }
-                        else
+                        else if (image.Source != null)
                         {
-                            if (image.Source != null)
-                            {
-                                var sourceRect = new Int32Rect(dirtyRect.X, dirtyRect.Y, dirtyRect.Width, dirtyRect.Height);
-                                var bitmap = (InteropBitmap)image.Source;
-                                bitmap.Invalidate(sourceRect);
-                            }
+                            var sourceRect = new Int32Rect(dirtyRect.X, dirtyRect.Y, dirtyRect.Width, dirtyRect.Height);
+                            var bitmap = (InteropBitmap)image.Source;
+                            bitmap.Invalidate(sourceRect);
                         }
                     }
                 }), dispatcherPriority);
-            }
-        }
-
-        private void ReleaseMemoryMappedView(ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor stream)
-        {
-            if (stream != null)
-            {
-                stream.Dispose();
-                stream = null;
-            }
-
-            if (mappedFile != null)
-            {
-                mappedFile.Dispose();
-                mappedFile = null;
             }
         }
     }

--- a/CefSharp.Wpf/Rendering/InteropBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/InteropBitmapRenderHandler.cs
@@ -4,11 +4,9 @@
 
 using System;
 using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Threading;
 using Rect = CefSharp.Structs.Rect;
 
@@ -20,28 +18,8 @@ namespace CefSharp.Wpf.Rendering
     /// or creates a new InteropBitmap when required
     /// </summary>
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
-    public class InteropBitmapRenderHandler : IRenderHandler
+    public class InteropBitmapRenderHandler : AbstractRenderHandler
     {
-        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
-        private static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
-
-        /// <summary>
-        /// The pixel format
-        /// </summary>
-        private static readonly PixelFormat PixelFormat = PixelFormats.Pbgra32;
-        private static int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
-
-        private object lockObject = new object();
-
-        private Size viewSize;
-        private Size popupSize;
-        private DispatcherPriority dispatcherPriority;
-
-        private MemoryMappedFile viewMemoryMappedFile;
-        private MemoryMappedFile popupMemoryMappedFile;
-        private MemoryMappedViewAccessor viewMemoryMappedViewAccessor;
-        private MemoryMappedViewAccessor popupMemoryMappedViewAccessor;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InteropBitmapRenderHandler"/> class.
         /// </summary>
@@ -51,46 +29,8 @@ namespace CefSharp.Wpf.Rendering
             this.dispatcherPriority = dispatcherPriority;
         }
 
-        /// <summary>
-        /// Dispose
-        /// </summary>
-        public void Dispose()
+        protected override void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
         {
-            ReleaseMemoryMappedView(ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
-            ReleaseMemoryMappedView(ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
-        }
-
-        /// <summary>
-        /// Called when an element has been rendered to the shared texture handle.
-        /// This method is only called when <see cref="IWindowInfo.SharedTextureEnabled"/> is set to true
-        /// </summary>
-        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
-        /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
-        /// <param name="sharedHandle">is the handle for a D3D11 Texture2D that can be accessed via ID3D11Device using the OpenSharedResource method.</param>
-        void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, IntPtr sharedHandle)
-        {
-            //NOT USED
-        }
-
-        void IRenderHandler.OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
-        {
-            if (isPopup)
-            {
-                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref popupSize, ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
-            }
-            else
-            {
-                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref viewSize, ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
-            }
-        }
-
-        private void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
-        {
-            if (image.Dispatcher.HasShutdownStarted)
-            {
-                return;
-            }
-
             var createNewBitmap = false;
 
             lock (lockObject)
@@ -142,32 +82,14 @@ namespace CefSharp.Wpf.Rendering
                             var bitmap = (InteropBitmap)Imaging.CreateBitmapSourceFromMemorySection(backBufferHandle.DangerousGetHandle(), width, height, PixelFormat, stride, 0);
                             image.Source = bitmap;
                         }
-                        else
+                        else if (image.Source != null)
                         {
-                            if (image.Source != null)
-                            {
-                                var sourceRect = new Int32Rect(dirtyRect.X, dirtyRect.Y, dirtyRect.Width, dirtyRect.Height);
-                                var bitmap = (InteropBitmap)image.Source;
-                                bitmap.Invalidate(sourceRect);
-                            }
+                            var sourceRect = new Int32Rect(dirtyRect.X, dirtyRect.Y, dirtyRect.Width, dirtyRect.Height);
+                            var bitmap = (InteropBitmap)image.Source;
+                            bitmap.Invalidate(sourceRect);
                         }
                     }
                 }), dispatcherPriority);
-            }
-        }
-
-        private void ReleaseMemoryMappedView(ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor stream)
-        {
-            if (stream != null)
-            {
-                stream.Dispose();
-                stream = null;
-            }
-
-            if (mappedFile != null)
-            {
-                mappedFile.Dispose();
-                mappedFile = null;
             }
         }
     }

--- a/CefSharp.Wpf/Rendering/WritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/WritableBitmapRenderHandler.cs
@@ -4,13 +4,10 @@
 
 using System;
 using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
-
 using Rect = CefSharp.Structs.Rect;
 
 namespace CefSharp.Wpf.Rendering
@@ -21,30 +18,11 @@ namespace CefSharp.Wpf.Rendering
     /// or creates a new WritableBitmap when required
     /// </summary>
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
-    public class WritableBitmapRenderHandler : IRenderHandler
+    public class WritableBitmapRenderHandler : AbstractRenderHandler
     {
-        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
-        private static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
-
-        /// <summary>
-        /// The pixel format
-        /// </summary>
-        private static readonly PixelFormat PixelFormat = PixelFormats.Pbgra32;
-        private static int BytesPerPixel = PixelFormat.BitsPerPixel / 8;
-
-        private object lockObject = new object();
-
-        private Size viewSize;
-        private Size popupSize;
         private double dpiX;
         private double dpiY;
         private bool invalidateDirtyRect;
-        private DispatcherPriority dispatcherPriority;
-
-        private MemoryMappedFile viewMemoryMappedFile;
-        private MemoryMappedFile popupMemoryMappedFile;
-        private MemoryMappedViewAccessor viewMemoryMappedViewAccessor;
-        private MemoryMappedViewAccessor popupMemoryMappedViewAccessor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WritableBitmapRenderHandler"/> class.
@@ -61,51 +39,12 @@ namespace CefSharp.Wpf.Rendering
             this.dispatcherPriority = dispatcherPriority;
         }
 
-        /// <summary>
-        /// Dispose
-        /// </summary>
-        public void Dispose()
-        {
-            ReleaseMemoryMappedView(ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
-            ReleaseMemoryMappedView(ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
-        }
-
-        /// <summary>
-        /// Called when an element has been rendered to the shared texture handle.
-        /// This method is only called when <see cref="IWindowInfo.SharedTextureEnabled"/> is set to true
-        /// </summary>
-        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
-        /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
-        /// <param name="sharedHandle">is the handle for a D3D11 Texture2D that can be accessed via ID3D11Device using the OpenSharedResource method.</param>
-        void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, IntPtr sharedHandle)
-        {
-            //NOT USED
-        }
-
-        void IRenderHandler.OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
-        {
-            if (isPopup)
-            {
-                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref popupSize, ref popupMemoryMappedFile, ref popupMemoryMappedViewAccessor);
-            }
-            else
-            {
-                CreateOrUpdateBitmap(isPopup, dirtyRect, buffer, width, height, image, ref viewSize, ref viewMemoryMappedFile, ref viewMemoryMappedViewAccessor);
-            }
-        }
-
-        private void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
+        protected override void CreateOrUpdateBitmap(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image, ref Size currentSize, ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor viewAccessor)
         {
             bool createNewBitmap = false;
 
-            if (image.Dispatcher.HasShutdownStarted)
-            {
-                return;
-            }
-
             lock (lockObject)
             {
-
                 int pixels = width * height;
                 int numberOfBytes = pixels * BytesPerPixel;
 
@@ -179,21 +118,6 @@ namespace CefSharp.Wpf.Rendering
                         }
                     }
                 }), dispatcherPriority);
-            }
-        }
-
-        private void ReleaseMemoryMappedView(ref MemoryMappedFile mappedFile, ref MemoryMappedViewAccessor stream)
-        {
-            if (stream != null)
-            {
-                stream.Dispose();
-                stream = null;
-            }
-
-            if (mappedFile != null)
-            {
-                mappedFile.Dispose();
-                mappedFile = null;
             }
         }
     }


### PR DESCRIPTION
- Added `AbstractRenderHandler` that takes care of the basics of a `IRenderHandler`
- Refactored the `RenderHandler`s to inherit from `AbstractRenderHandler`
- Implemented the correct and thread safe dispose pattern