### PR TITLE
Improved handling of BrowserSettings

### DIFF
--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -20,7 +20,7 @@ namespace CefSharp
     {
     private:
         bool _isDisposed = false;
-        int isClaimed = 0;
+        int _isClaimed = 0;
     internal:
         CefBrowserSettings* _browserSettings;
 
@@ -390,7 +390,7 @@ namespace CefSharp
                     "You cannot reuse a BrowserSettings instance");
             }
 
-            if (System::Threading::Interlocked::CompareExchange(isClaimed, 1, 0) != 0)
+            if (System::Threading::Interlocked::CompareExchange(_isClaimed, 1, 0) != 0)
             {
                 throw gcnew Exception("This BrowserSettings instance has already been claimed. "
                     + "You cannot reuse a BrowserSettings instance");

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -386,7 +386,7 @@ namespace CefSharp
         {
             if (IsDisposed)
             {
-                throw gcnew ObjectDisposedException("BrowserSettings", "This BrowserSettings instance has already been disposed. " +
+                throw gcnew ObjectDisposedException("", "This BrowserSettings instance has already been disposed. " +
                     "You cannot reuse a BrowserSettings instance");
             }
 

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -20,6 +20,7 @@ namespace CefSharp
     {
     private:
         bool _isDisposed = false;
+        int isClaimed = 0;
     internal:
         CefBrowserSettings* _browserSettings;
 
@@ -376,6 +377,24 @@ namespace CefSharp
         virtual property bool IsDisposed
         {
             bool get() { return _isDisposed; }
+        }
+
+        /// <summary>
+        /// Marks this instance as claimed, if it's already claimed throws an exception
+        /// </summary>
+        void ClaimInstance()
+        {
+            if (IsDisposed)
+            {
+                throw gcnew ObjectDisposedException("BrowserSettings", "This BrowserSettings instance has already been disposed. " +
+                    "You cannot reuse a BrowserSettings instance");
+            }
+
+            if (System::Threading::Interlocked::CompareExchange(isClaimed, 1, 0) != 0)
+            {
+                throw gcnew Exception("This BrowserSettings instance has already been claimed. "
+                    + "You cannot reuse a BrowserSettings instance");
+            }
         }
     };
 }

--- a/CefSharp.Core/ManagedCefBrowserAdapter.cpp
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.cpp
@@ -28,6 +28,12 @@ void ManagedCefBrowserAdapter::CreateBrowser(IWindowInfo^ windowInfo, BrowserSet
         throw gcnew ArgumentNullException("browserSettings", "cannot be null");
     }
 
+    if (browserSettings->IsDisposed)
+    {
+        throw gcnew ObjectDisposedException("browserSettings", "This BrowserSettings instance has already been disposed. " +
+            "You cannot reuse a BrowserSettings instance");
+    }
+
     if (!CefBrowserHost::CreateBrowser(*cefWindowInfoWrapper->GetWindowInfo(), _clientAdapter.get(), addressNative,
         *browserSettings->_browserSettings, static_cast<CefRefPtr<CefRequestContext>>(requestContext)))
     {

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -373,16 +373,15 @@ namespace CefSharp.OffScreen
                 throw new Exception("An instance of the underlying offscreen browser has already been created, this method can only be called once.");
             }
 
-            browserCreated = true;
-
             if (browserSettings == null)
             {
                 browserSettings = new BrowserSettings();
             }
-            else if(browserSettings.IsDisposed)
-            {
-                throw new ObjectDisposedException("browserSettings", "The BrowserSettings reference you have passed has already been disposed. You cannot reuse the BrowserSettings class");
-            }
+
+            // Claims the BrowserSettings instance for this browser so that it can't be reused
+            browserSettings.ClaimInstance();
+
+            browserCreated = true;
 
             if (windowInfo == null)
             {

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -89,7 +89,8 @@ namespace CefSharp.WinForms
                 }
 
                 // Claims the BrowserSettings instance for this browser so that it can't be reused
-                if (value is BrowserSettings instance)
+                var instance = value as BrowserSettings;
+                if (instance != null)
                 {
                     instance.ClaimInstance();
                 }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -82,10 +82,18 @@ namespace CefSharp.WinForms
                     throw new Exception("Browser has already been created. BrowserSettings must be " +
                                         "set before the underlying CEF browser is created.");
                 }
+
                 if (value != null && value.GetType() != typeof(BrowserSettings))
                 {
                     throw new Exception(string.Format("BrowserSettings can only be of type {0} or null", typeof(BrowserSettings)));
                 }
+
+                // Claims the BrowserSettings instance for this browser so that it can't be reused
+                if (value is BrowserSettings instance)
+                {
+                    instance.ClaimInstance();
+                }
+
                 browserSettings = value;
             }
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -136,7 +136,8 @@ namespace CefSharp.Wpf
                 }
 
                 // Claims the BrowserSettings instance for this browser so that it can't be reused
-                if (value is BrowserSettings instance)
+                var instance = value as BrowserSettings;
+                if (instance != null)
                 {
                     instance.ClaimInstance();
                 }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -135,6 +135,12 @@ namespace CefSharp.Wpf
                                         "set before the underlying CEF browser is created.");
                 }
 
+                // Claims the BrowserSettings instance for this browser so that it can't be reused
+                if (value is BrowserSettings instance)
+                {
+                    instance.ClaimInstance();
+                }
+
                 //New instance is created in the constructor, if you use
                 //xaml to initialize browser settings then it will also create a new
                 //instance, so we dispose of the old one


### PR DESCRIPTION
- Added `BrowserSettings::ClaimInstance()` that checks if the instance has been disposed or claimed then, if possible, claims it
- Made the `WPF`, `WinForms`, and `OffScreen` versions call `BrowserSettings::ClaimInstance`
- Made `ManagedCefBrowserAdapter::CreateBrowser` check if the `BrowserSettings` instance has been disposed

Closes #2643 