### PR TITLE
Readme.md - Add SharpBrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ Now that I (@amaitland) am a stay at home dad your contributions are the only re
 
 - [HtmlView](https://github.com/MISoftware/HtmlView) : Visual Studio extension bringing CefSharp for showing HTML pages inside VS.
 - [Chromely](https://github.com/mattkol/Chromely) : Build .NET/.NET Core HTML5 desktop apps using cross-platform native GUI API.
+- [SharpBrowser](https://github.com/sharpbrowser/SharpBrowser) : The fastest web browser for C# with tabbed browsing and HTML5/CSS3.


### PR DESCRIPTION
I've added SharpBrowser to the readme. The last time you mentioned that it was not using nuget, so I fixed that. Its now taking the latest version from nuget. I just included the `bin` directory in the repo because sometimes CefSharp has issues downloading all the needed assets. I've also updated to CefSharp 71 and .NET 4.6.

Could you consider it please?