### PR TITLE
Core - BrowserSettings: Fixed a memory leak

### DIFF
--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -41,7 +41,12 @@ namespace CefSharp
 
         !BrowserSettings()
         {
-            _browserSettings = NULL;
+            if (_browserSettings != NULL)
+            {
+                delete _browserSettings;
+                _browserSettings = NULL;
+            }
+
             _isDisposed = true;
         }
 

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -49,7 +49,6 @@ namespace CefSharp
             }
 
             _browserSettings = NULL;
-
             _isDisposed = true;
         }
 

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -46,8 +46,9 @@ namespace CefSharp
             if (_ownsPointer)
             {
                 delete _browserSettings;
-                _browserSettings = nullptr;
             }
+
+            _browserSettings = NULL;
 
             _isDisposed = true;
         }

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -20,6 +20,7 @@ namespace CefSharp
     {
     private:
         bool _isDisposed = false;
+        bool _ownsPointer = false;
     internal:
         CefBrowserSettings* _browserSettings;
 
@@ -37,14 +38,15 @@ namespace CefSharp
         /// </summary>
         BrowserSettings() : _browserSettings(new CefBrowserSettings())
         {
+            _ownsPointer = true;
         }
 
         !BrowserSettings()
         {
-            if (_browserSettings != NULL)
+            if (_ownsPointer)
             {
                 delete _browserSettings;
-                _browserSettings = NULL;
+                _browserSettings = nullptr;
             }
 
             _isDisposed = true;


### PR DESCRIPTION
When a `BrowserSettings` object is created, it creates an instance of `CefBrowserSettings`, then when the `BrowserSettings` object is disposed/collected it never deletes the `CefBrowserSettings` instance meaning it leaks. This PR fixes that by deleting it when `BrowserSettings` is disposed/collected.

Before this change, creating and disposing `1 000 000` `BrowserSettings` objects caused the memory usage to climb to `337,71 MB`, after this change it goes to `99,32 MB`