### PR TITLE
Core - WindowInfo: Fixed a memory leak

### DIFF
--- a/CefSharp.Core/WindowInfo.h
+++ b/CefSharp.Core/WindowInfo.h
@@ -14,10 +14,12 @@ namespace CefSharp
     {
     private:
         CefWindowInfo* _windowInfo;
+        bool _ownsPointer = false;
 
     public:
         WindowInfo() : _windowInfo(new CefWindowInfo())
         {
+            _ownsPointer = true;
         }
 
         WindowInfo(CefWindowInfo* windowInfo) : _windowInfo(windowInfo)
@@ -27,6 +29,11 @@ namespace CefSharp
 
         !WindowInfo()
         {
+            if (_ownsPointer)
+            {
+                delete _windowInfo;
+            }
+
             _windowInfo = NULL;
         }
 


### PR DESCRIPTION
When a `WindowInfo` object is created, it creates an instance of `CefWindowInfo`, then when the `WindowInfo` object is disposed/collected it never deletes the `CefWindowInfo` instance meaning it leaks. This PR fixes that by deleting it when `WindowInfo` is disposed/collected.

Before this change, creating and disposing `1 000 000` `WindowInfo` objects caused the memory usage to climb to `130,58 MB`, after this change it goes to `99,32 MB`