### PR TITLE
Refactoring - Remove reference to ChromiumWebBrowser in DefaultRenderHandler

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -28,13 +28,6 @@ namespace CefSharp.OffScreen
         private ManagedCefBrowserAdapter managedCefBrowserAdapter;
 
         /// <summary>
-        /// Size of the Chromium viewport.
-        /// This must be set to something other than 0x0 otherwise Chromium will not render,
-        /// and the ScreenshotAsync task will deadlock.
-        /// </summary>
-        private Size size = new Size(1366, 768);
-
-        /// <summary>
         /// The browser
         /// </summary>
         private IBrowser browser;
@@ -318,7 +311,7 @@ namespace CefSharp.OffScreen
                 CreateBrowser(null, browserSettings);
             }
 
-            RenderHandler = new DefaultRenderHandler(this);
+            RenderHandler = new DefaultRenderHandler();
         }
 
         /// <summary>
@@ -427,17 +420,19 @@ namespace CefSharp.OffScreen
         /// <value>The size.</value>
         public Size Size
         {
-            get { return size; }
+            get { return RenderHandler.ViewportSize; }
             set
             {
-                if (size != value)
+                if (RenderHandler.ViewportSize == value)
                 {
-                    size = value;
+                    return;
+                }
 
-                    if (IsBrowserInitialized)
-                    {
-                        browser.GetHost().WasResized();
-                    }
+                RenderHandler.ViewportSize = value;
+
+                if (IsBrowserInitialized)
+                {
+                    browser.GetHost().WasResized();
                 }
             }
         }

--- a/CefSharp.OffScreen/DefaultRenderHandler.cs
+++ b/CefSharp.OffScreen/DefaultRenderHandler.cs
@@ -30,7 +30,7 @@ namespace CefSharp.OffScreen
         /// This must be set to something other than 0x0 otherwise Chromium will not render.
         /// Defaults to 1366x768
         /// </summary>
-        public Size ViewportSize { get; set; } = new Size(1366, 768);
+        public Size ViewportSize { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the popup is open.
@@ -74,6 +74,8 @@ namespace CefSharp.OffScreen
         /// </summary>
         public DefaultRenderHandler()
         {
+            ViewportSize = new Size(1366, 768);
+
             popupPosition = new Point();
             popupSize = new Size();
 

--- a/CefSharp.OffScreen/DefaultRenderHandler.cs
+++ b/CefSharp.OffScreen/DefaultRenderHandler.cs
@@ -16,8 +16,6 @@ namespace CefSharp.OffScreen
     /// </summary>
     public class DefaultRenderHandler : IRenderHandler
     {
-        private ChromiumWebBrowser browser;
-
         private Size popupSize;
         private Point popupPosition;
 
@@ -26,6 +24,13 @@ namespace CefSharp.OffScreen
         /// while Chromium async rendering has returned on another thread.
         /// </summary>
         public readonly object BitmapLock = new object();
+
+        /// <summary>
+        /// Size of the Chromium viewport.
+        /// This must be set to something other than 0x0 otherwise Chromium will not render.
+        /// Defaults to 1366x768
+        /// </summary>
+        public Size ViewportSize { get; set; } = new Size(1366, 768);
 
         /// <summary>
         /// Gets or sets a value indicating whether the popup is open.
@@ -67,11 +72,8 @@ namespace CefSharp.OffScreen
         /// <summary>
         /// Create a new instance of DefaultRenderHadler
         /// </summary>
-        /// <param name="browser">reference to the ChromiumWebBrowser</param>
-        public DefaultRenderHandler(ChromiumWebBrowser browser)
+        public DefaultRenderHandler()
         {
-            this.browser = browser;
-
             popupPosition = new Point();
             popupSize = new Size();
 
@@ -84,7 +86,6 @@ namespace CefSharp.OffScreen
         /// </summary>
         public void Dispose()
         {
-            browser = null;
             BitmapBuffer = null;
             PopupBuffer = null;
         }
@@ -109,10 +110,7 @@ namespace CefSharp.OffScreen
         /// <returns>Return a ViewRect strict containing the rectangle.</returns>
         public virtual Rect GetViewRect()
         {
-            //TODO: See if this can be refactored and remove browser reference
-            var size = browser.Size;
-
-            var viewRect = new Rect(0, 0, size.Width, size.Height);
+            var viewRect = new Rect(0, 0, ViewportSize.Width, ViewportSize.Height);
 
             return viewRect;
         }

--- a/CefSharp.OffScreen/DefaultRenderHandler.cs
+++ b/CefSharp.OffScreen/DefaultRenderHandler.cs
@@ -110,9 +110,7 @@ namespace CefSharp.OffScreen
         /// <returns>Return a ViewRect strict containing the rectangle.</returns>
         public virtual Rect GetViewRect()
         {
-            var viewRect = new Rect(0, 0, ViewportSize.Width, ViewportSize.Height);
-
-            return viewRect;
+            return new Rect(0, 0, ViewportSize.Width, ViewportSize.Height);
         }
 
         /// <summary>

--- a/CefSharp.OffScreen/IRenderHandler.cs
+++ b/CefSharp.OffScreen/IRenderHandler.cs
@@ -15,6 +15,12 @@ namespace CefSharp.OffScreen
     public interface IRenderHandler : IDisposable
     {
         /// <summary>
+        /// Size of the Chromium viewport.
+        /// This must be set to something other than 0x0 otherwise Chromium will not render.
+        /// </summary>
+        System.Drawing.Size ViewportSize { get; set; }
+
+        /// <summary>
         /// Called to allow the client to return a ScreenInfo object with appropriate values.
         /// If null is returned then the rectangle from GetViewRect will be used.
         /// If the rectangle is still empty or invalid popups may not be drawn correctly. 


### PR DESCRIPTION
- Added a `ViewportSize` property to `IRenderHandler` and `DefaultRenderHandler`
- Removed reference to `ChromiumWebBrowser` in the `DefaultRenderHandler`
- Removed `size` field in `ChromiumWebBrowser`
- The `Size` property in `ChromiumWebBrowser` now uses the size from the `RenderHandler`