### PR TITLE
Add IAudioHandler

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -1156,6 +1156,42 @@ namespace CefSharp
             }
         }
 
+        void ClientAdapter::OnAudioStreamStarted(CefRefPtr<CefBrowser> browser, int audio_stream_id, int channels, ChannelLayout channel_layout, int sample_rate, int frames_per_buffer)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnAudioStreamStarted(_browserControl, browserWrapper, audio_stream_id, channels, (CefSharp::Enums::ChannelLayout)channel_layout, sample_rate, frames_per_buffer);
+            }
+        }
+
+        void ClientAdapter::OnAudioStreamPacket(CefRefPtr<CefBrowser> browser, int audio_stream_id, const float** data, int frames, int64 pts)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnAudioStreamPacket(_browserControl, browserWrapper, audio_stream_id, IntPtr((void *)data), frames, pts);
+            }
+        }
+
+        void ClientAdapter::OnAudioStreamStopped(CefRefPtr<CefBrowser> browser, int audio_stream_id)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnAudioStreamStopped(_browserControl, browserWrapper, audio_stream_id);
+            }
+        }
+
         bool ClientAdapter::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefProcessId source_process, CefRefPtr<CefProcessMessage> message)
         {
             auto handled = false;

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -101,7 +101,17 @@ namespace CefSharp
             virtual DECL CefRefPtr<CefDialogHandler> GetDialogHandler() OVERRIDE { return this; }
             virtual DECL CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE { return this; }
             virtual DECL CefRefPtr<CefFindHandler> GetFindHandler() OVERRIDE { return this; }
-            virtual DECL CefRefPtr<CefAudioHandler> GetAudioHandler() OVERRIDE { return this; }
+            virtual DECL CefRefPtr<CefAudioHandler> GetAudioHandler() OVERRIDE
+            {
+                //Audio Mirroring in CEF is only enabled when we a handler is returned
+                //We return NULL if no handler is specified for performance reasons
+                if (_browserControl->AudioHandler == nullptr)
+                {
+                    return NULL;
+                }
+
+                return this;
+            }
             virtual DECL bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefProcessId source_process, CefRefPtr<CefProcessMessage> message) OVERRIDE;
 
 

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -32,7 +32,8 @@ namespace CefSharp
             public CefDialogHandler,
             public CefDragHandler,
             public CefDownloadHandler,
-            public CefFindHandler
+            public CefFindHandler,
+            public CefAudioHandler
         {
         private:
             gcroot<IWebBrowserInternal^> _browserControl;
@@ -100,6 +101,7 @@ namespace CefSharp
             virtual DECL CefRefPtr<CefDialogHandler> GetDialogHandler() OVERRIDE { return this; }
             virtual DECL CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE { return this; }
             virtual DECL CefRefPtr<CefFindHandler> GetFindHandler() OVERRIDE { return this; }
+            virtual DECL CefRefPtr<CefAudioHandler> GetAudioHandler() OVERRIDE { return this; }
             virtual DECL bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefProcessId source_process, CefRefPtr<CefProcessMessage> message) OVERRIDE;
 
 
@@ -195,7 +197,12 @@ namespace CefSharp
                 CefRefPtr<CefDownloadItemCallback> callback) OVERRIDE;
 
             //CefFindHandler
-            virtual DECL void OnFindResult(CefRefPtr<CefBrowser> browser, int identifier, int count, const CefRect& selectionRect, int activeMatchOrdinal, bool finalUpdate);
+            virtual DECL void OnFindResult(CefRefPtr<CefBrowser> browser, int identifier, int count, const CefRect& selectionRect, int activeMatchOrdinal, bool finalUpdate) OVERRIDE;
+
+            //CefAudioHandler
+            virtual DECL void OnAudioStreamStarted(CefRefPtr<CefBrowser> browser, int audio_stream_id, int channels, ChannelLayout channel_layout, int sample_rate, int frames_per_buffer) OVERRIDE;
+            virtual DECL void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser, int audio_stream_id, const float** data, int frames, int64 pts) OVERRIDE;
+            virtual DECL void OnAudioStreamStopped(CefRefPtr<CefBrowser> browser, int audio_stream_id) OVERRIDE;
 
             //sends out an eval script request to the render process
             Task<JavascriptResponse^>^ EvaluateScriptAsync(int browserId, bool isBrowserPopup, int64 frameId, String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout);

--- a/CefSharp.Example/CefSharp.Example.csproj
+++ b/CefSharp.Example/CefSharp.Example.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Callback\RunFileDialogCallback.cs" />
+    <Compile Include="Handlers\AudioHandler.cs" />
     <Compile Include="Handlers\ExtensionHandler.cs" />
     <Compile Include="JavascriptBinding\AsyncBoundObject.cs" />
     <Compile Include="JavascriptBinding\BoundObject.cs" />

--- a/CefSharp.Example/Handlers/AudioHandler.cs
+++ b/CefSharp.Example/Handlers/AudioHandler.cs
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
-using System.Runtime.InteropServices;
 using CefSharp.Enums;
 
 namespace CefSharp.Example.Handlers
@@ -11,21 +10,21 @@ namespace CefSharp.Example.Handlers
     public class AudioHandler : IAudioHandler
     {
         private ChannelLayout channelLayout;
+        private int channelCount;
+        private int sampleRate;
 
         void IAudioHandler.OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, IntPtr data, int noOfFrames, long pts)
         {
-            var channelLayoutSize = 2;
-            var sizeOfData = noOfFrames * channelLayoutSize * 4;
-
-            float[] managedData = new float[sizeOfData];
-
-            Marshal.Copy(data, managedData, 0, sizeOfData);
-
+            //NOTE: data is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s)
+            //Based on and the channelLayout value passed to IAudioHandler.OnAudioStreamStarted
+            //you can calculate the size of the data array in bytes.
         }
 
         void IAudioHandler.OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, int channels, ChannelLayout channelLayout, int sampleRate, int framesPerBuffer)
         {
             this.channelLayout = channelLayout;
+            this.channelCount = channels;
+            this.sampleRate = sampleRate;
         }
 
         void IAudioHandler.OnAudioStreamStopped(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId)

--- a/CefSharp.Example/Handlers/AudioHandler.cs
+++ b/CefSharp.Example/Handlers/AudioHandler.cs
@@ -1,0 +1,36 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Runtime.InteropServices;
+using CefSharp.Enums;
+
+namespace CefSharp.Example.Handlers
+{
+    public class AudioHandler : IAudioHandler
+    {
+        private ChannelLayout channelLayout;
+
+        void IAudioHandler.OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, IntPtr data, int noOfFrames, long pts)
+        {
+            var channelLayoutSize = 2;
+            var sizeOfData = noOfFrames * channelLayoutSize * 4;
+
+            float[] managedData = new float[sizeOfData];
+
+            Marshal.Copy(data, managedData, 0, sizeOfData);
+
+        }
+
+        void IAudioHandler.OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, int channels, ChannelLayout channelLayout, int sampleRate, int framesPerBuffer)
+        {
+            this.channelLayout = channelLayout;
+        }
+
+        void IAudioHandler.OnAudioStreamStopped(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId)
+        {
+
+        }
+    }
+}

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -183,13 +183,15 @@ namespace CefSharp.OffScreen
         /// </summary>
         /// <value>The find handler.</value>
         public IFindHandler FindHandler { get; set; }
-
+        /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        public IAudioHandler AudioHandler { get; set; }
         /// <summary>
         /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
         /// </summary>
         /// <value>The accessibility handler.</value>
         public IAccessibilityHandler AccessibilityHandler { get; set; }
-
         /// <summary>
         /// Event handler that will get called when the resource load for a navigation fails or is canceled.
         /// It's important to note this event is fired on a CEF UI thread, which by default is not the same as your application UI

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -221,7 +221,11 @@ namespace CefSharp.WinForms
         /// <value>The find handler.</value>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(null)]
         public IFindHandler FindHandler { get; set; }
-
+        /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never), DefaultValue(null)]
+        public IAudioHandler AudioHandler { get; set; }
         /// <summary>
         /// The <see cref="IFocusHandler" /> for this ChromiumWebBrowser.
         /// </summary>

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -96,6 +96,7 @@ namespace CefSharp.Wpf.Example.Views
             downloadHandler.OnBeforeDownloadFired += OnBeforeDownloadFired;
             downloadHandler.OnDownloadUpdatedFired += OnDownloadUpdatedFired;
             browser.DownloadHandler = downloadHandler;
+            browser.AudioHandler = new AudioHandler();
 
             //Read an embedded bitmap into a memory stream then register it as a resource you can then load custom://cefsharp/images/beach.jpg
             var beachImageStream = new MemoryStream();
@@ -147,7 +148,7 @@ namespace CefSharp.Wpf.Example.Views
                 var errorBody = string.Format("<html><body bgcolor=\"white\"><h2>Failed to load URL {0} with error {1} ({2}).</h2></body></html>",
                                               args.FailedUrl, args.ErrorText, args.ErrorCode);
 
-                args.Frame.LoadHtml(errorBody, base64Encode:true);
+                args.Frame.LoadHtml(errorBody, base64Encode: true);
             };
 
             CefExample.RegisterTestResources(browser);

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -263,7 +263,10 @@ namespace CefSharp.Wpf
         /// </summary>
         /// <value>The find handler.</value>
         public IFindHandler FindHandler { get; set; }
-
+        /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        public IAudioHandler AudioHandler { get; set; }
         /// <summary>
         /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
         /// </summary>

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -99,6 +99,7 @@
     <Compile Include="CdmRegistration.cs" />
     <Compile Include="DefaultApp.cs" />
     <Compile Include="Enums\AlphaType.cs" />
+    <Compile Include="Enums\ChannelLayout.cs" />
     <Compile Include="Enums\PointerType.cs" />
     <Compile Include="Enums\TextInputMode.cs" />
     <Compile Include="Enums\TouchEventType.cs" />
@@ -113,6 +114,7 @@
     <Compile Include="Handler\IAccessibilityHandler.cs" />
     <Compile Include="Handler\IExtensionHandler.cs" />
     <Compile Include="IApp.cs" />
+    <Compile Include="Handler\IAudioHandler.cs" />
     <Compile Include="IExtension.cs" />
     <Compile Include="ISchemeRegistrar.cs" />
     <Compile Include="IValue.cs" />

--- a/CefSharp/Enums/ChannelLayout.cs
+++ b/CefSharp/Enums/ChannelLayout.cs
@@ -1,0 +1,187 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.Enums
+{
+    /// <summary>
+    /// Enumerates the various representations of the ordering of audio channels.
+    /// Logged to UMA, so never reuse a value, always add new/greater ones!
+    /// See media\base\channel_layout.h
+    /// </summary>
+    public enum ChannelLayout
+    {
+        /// <summary>
+        /// None
+        /// </summary>
+        LayoutNone = 0,
+
+        /// <summary>
+        /// Unsupported
+        /// </summary>
+        LayoutUnsupported = 1,
+
+        /// <summary>
+        /// Front C
+        /// </summary>
+        LayoutMono = 2,
+
+        /// <summary>
+        /// Front L, Front R
+        /// </summary>
+        LayoutStereo = 3,
+
+        /// <summary>
+        /// Front L, Front R, Back C
+        /// </summary>
+        Layout2_1 = 4,
+
+        /// <summary>
+        /// Front L, Front R, Front C
+        /// </summary>
+        LayoutSurround = 5,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Back C
+        /// </summary>
+        Layout4_0 = 6,
+
+        /// <summary>
+        /// Front L, Front R, Side L, Side R
+        /// </summary>
+        Layout2_2 = 7,
+
+        /// <summary>
+        /// Front L, Front R, Back L, Back R
+        /// </summary>
+        LayoutQuad = 8,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R
+        /// </summary>
+        Layout5_0 = 9,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Side L, Side R
+        /// </summary>
+        Layout5_1 = 10,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Back L, Back R
+        /// </summary>
+        Layout5_0Back = 11,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Back L, Back R
+        /// </summary>
+        Layout5_1Back = 12,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R, Back L, Back R
+        /// </summary>
+        Layout7_0 = 13,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Side L, Side R, Back L, Back R
+        /// </summary>
+        Layout7_1 = 14,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Side L, Side R, Front LofC, Front RofC
+        /// </summary>
+        Layout7_1Wide = 15,
+
+        /// <summary>
+        /// Stereo L, Stereo R
+        /// </summary>
+        LayoutStereoDownMix = 16,
+
+        /// <summary>
+        /// Stereo L, Stereo R, LFE
+        /// </summary>
+        Layout2Point1 = 17,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, LFE
+        /// </summary>
+        Layout3_1 = 18,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, Rear C, LFE
+        /// </summary>
+        Layout4_1 = 19,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, Side L, Side R, Back C
+        /// </summary>
+        Layout6_0 = 20,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Side L, Side R, Front LofC, Front RofC
+        /// </summary>
+        Layout6_0Front = 21,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, Rear L, Rear R, Rear C
+        /// </summary>
+        LayoutHexagonal = 22,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, LFE, Side L, Side R, Rear Center
+        /// </summary>
+        Layout6_1 = 23,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, LFE, Back L, Back R, Rear Center
+        /// </summary>
+        Layout6_1Back = 24,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Side L, Side R, Front LofC, Front RofC, LFE
+        /// </summary>
+        Layout6_1Front = 25,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R, Front LofC, Front RofC
+        /// </summary>
+        Layout7_0Front = 26,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Back L, Back R, Front LofC, Front RofC
+        /// </summary>
+        Layout7_1WideBack = 27,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R, Rear L, Back R, Back C.
+        /// </summary>
+        LayoutOctagonal = 28,
+
+        /// <summary>
+        /// Channels are not explicitly mapped to speakers.
+        /// </summary>
+        LayoutDiscrete = 29,
+
+        /// <summary>
+        /// Front L, Front R, Front C. Front C contains the keyboard mic audio. This
+        /// layout is only intended for input for WebRTC. The Front C channel
+        /// is stripped away in the WebRTC audio input pipeline and never seen outside
+        /// of that.
+        /// </summary>
+        LayoutStereoKeyboardAndMic = 30,
+
+        /// <summary>
+        /// Front L, Front R, Side L, Side R, LFE
+        /// </summary>
+        Layout4_1QuadSize = 31,
+
+        /// <summary>
+        /// Actual channel layout is specified in the bitstream and the actual channel
+        /// count is unknown at Chromium media pipeline level (useful for audio
+        /// pass-through mode).
+        /// </summary>
+        LayoutBitstream = 32,
+
+        // Max value, must always equal the largest entry ever logged.
+        LayoutMax = LayoutBitstream
+    }
+}

--- a/CefSharp/Handler/IAudioHandler.cs
+++ b/CefSharp/Handler/IAudioHandler.cs
@@ -1,0 +1,59 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using CefSharp.Enums;
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Implement this interface to handle audio events
+    /// All methods will be called on the CEF UI thread
+    /// </summary>
+    public interface IAudioHandler
+    {
+        /// <summary>
+        /// Called when the stream identified by <paramref name="audioStreamId"/> has started.
+        /// <see cref="IAudioHandler.OnAudioSteamStopped"/> will always be called after  <see cref="IAudioHandler.OnAudioStreamStarted"/>;
+        /// both methods may be called multiple times for the same stream.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="audioStreamId">will uniquely identify the stream across all future IAudioHandler callbacks</param>
+        /// <param name="channels">is the number of channels</param>
+        /// <param name="channelLayout">is the layout of the channels</param>
+        /// <param name="sampleRate"> is the stream sample rate</param>
+        /// <param name="framesPerBuffer">is the maximum number of frames that will occur in the PCM packet passed to OnAudioStreamPacket</param>
+        void OnAudioStreamStarted(IWebBrowser chromiumWebBrowser,
+            IBrowser browser,
+            int audioStreamId,
+            int channels,
+            ChannelLayout channelLayout,
+            int sampleRate,
+            int framesPerBuffer);
+
+        /// <summary>
+        /// Called when a PCM packet is received for the stream identified by <paramref name="audioStreamId"/>
+        /// Based on and the <see cref="ChannelLayout"/> value passed to <see cref="IAudioHandler.OnAudioStreamStarted"/>
+        /// you can calculate the size of the <paramref name="data"/> array in bytes.
+        /// </summary>
+        /// <param name="chromiumWebBrowser"></param>
+        /// <param name="audioStreamId">will uniquely identify the stream across all future IAudioHandler callbacks</param>
+        /// <param name="data">is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s)</param>
+        /// <param name="frames">is the number of frames in the PCM packet</param>
+        /// <param name="pts">is the presentation timestamp (in milliseconds since the Unix Epoch)
+        /// and represents the time at which the decompressed packet should be presented to the user</param>
+        void OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, IntPtr data, int frames, long pts);
+
+        /// <summary>
+        /// Called when the stream identified by <paramref name="audioStreamId"/> has stopped.
+        /// <see cref="IAudioHandler.OnAudioStreamStopped"/> will always be called after <see cref="IAudioHandler.OnAudioStreamStarted"/>;
+        /// both methods may be called multiple times for the same stream.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="audioStreamId">will uniquely identify the stream across all future IAudioHandler callbacks</param>
+        void OnAudioStreamStopped(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId);
+    }
+}

--- a/CefSharp/Handler/IAudioHandler.cs
+++ b/CefSharp/Handler/IAudioHandler.cs
@@ -15,7 +15,7 @@ namespace CefSharp
     {
         /// <summary>
         /// Called when the stream identified by <paramref name="audioStreamId"/> has started.
-        /// <see cref="IAudioHandler.OnAudioSteamStopped"/> will always be called after  <see cref="IAudioHandler.OnAudioStreamStarted"/>;
+        /// <see cref="IAudioHandler.OnAudioSteamStopped"/> will always be called after  <see cref="OnAudioStreamStarted"/>;
         /// both methods may be called multiple times for the same stream.
         /// </summary>
         /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
@@ -48,7 +48,7 @@ namespace CefSharp
 
         /// <summary>
         /// Called when the stream identified by <paramref name="audioStreamId"/> has stopped.
-        /// <see cref="IAudioHandler.OnAudioStreamStopped"/> will always be called after <see cref="IAudioHandler.OnAudioStreamStarted"/>;
+        /// <see cref="OnAudioStreamStopped"/> will always be called after <see cref="IAudioHandler.OnAudioStreamStarted"/>;
         /// both methods may be called multiple times for the same stream.
         /// </summary>
         /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>

--- a/CefSharp/Handler/IAudioHandler.cs
+++ b/CefSharp/Handler/IAudioHandler.cs
@@ -41,10 +41,10 @@ namespace CefSharp
         /// <param name="chromiumWebBrowser"></param>
         /// <param name="audioStreamId">will uniquely identify the stream across all future IAudioHandler callbacks</param>
         /// <param name="data">is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s)</param>
-        /// <param name="frames">is the number of frames in the PCM packet</param>
+        /// <param name="noOfFrames">is the number of frames in the PCM packet</param>
         /// <param name="pts">is the presentation timestamp (in milliseconds since the Unix Epoch)
         /// and represents the time at which the decompressed packet should be presented to the user</param>
-        void OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, IntPtr data, int frames, long pts);
+        void OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, int audioStreamId, IntPtr data, int noOfFrames, long pts);
 
         /// <summary>
         /// Called when the stream identified by <paramref name="audioStreamId"/> has stopped.

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -169,6 +169,11 @@ namespace CefSharp
         IFindHandler FindHandler { get; set; }
 
         /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        IAudioHandler AudioHandler { get; set; }
+
+        /// <summary>
         /// A flag that indicates whether the WebBrowser is initialized (true) or not (false).
         /// </summary>
         /// <value><c>true</c> if this instance is browser initialized; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
Initial implementation for #2714

Still some work required, this compiles, nothing past that so far. Still need to validate how to map `float**` to a `C#` type. One option would be to copy the data to a `byte[]` in native code, this implies the user is always going to want access to the data, and will have a perf implication if they don't.

The default pattern of `return this` in `ClientAdapter` has been used.

```
virtual DECL CefRefPtr<CefAudioHandler> GetAudioHandler() OVERRIDE { return this; }
```

Unfortunately this will always trigger the `Audio Mirroring` feature, which we don't want unless the user has explicitly provided an `IAudioHandler` implementation. So this will also need to be rewritten with a separate wrapper class.

https://bitbucket.org/chromiumembedded/cef/commits/9f41a27e586a6b557fc171d2f03b332c1338e8d2?at=3683#Llibcef/browser/browser_host_impl.ccT3046