### PR TITLE
Add a handler for when the browser is not responding

### DIFF
--- a/CefSharp.WinForms/Internals/DefaultFocusHandler.cs
+++ b/CefSharp.WinForms/Internals/DefaultFocusHandler.cs
@@ -22,7 +22,8 @@ namespace CefSharp.WinForms.Internals
         public virtual void OnGotFocus(IWebBrowser chromiumWebBrowser, IBrowser browser)
         {
             //We don't deal with popups as they're rendered by default entirely by CEF
-            if (browser.IsPopup)
+            //For print dialogs the browser will be null, we don't want to deal with that either.
+            if (browser == null || browser.IsPopup)
             {
                 return;
             }

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -364,6 +364,9 @@ namespace CefSharp
 
                 request.Url = url;
                 request.Method = "POST";
+                //Add AllowCachedCredentials as per suggestion linked in
+                //https://github.com/cefsharp/CefSharp/issues/2705#issuecomment-476819788
+                request.Flags = UrlRequestFlags.AllowCachedCredentials;
 
                 request.PostData.AddData(postDataBytes);
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2015
 
-version: 73.0.0-CI{build}
+version: 73.1.120-CI{build}
 
 clone_depth: 10
 

--- a/build.ps1
+++ b/build.ps1
@@ -345,7 +345,7 @@ function WriteAssemblyVersion
     $CurrentYear = Get-Date -Format yyyy
     
     $NewString = $AssemblyInfo -replace $Regex, "public const string AssemblyVersion = ""$AssemblyVersion"""
-    $NewString = $NewString -replace $Regex2, "public const string AssemblyFileVersion = ""$AssemblyVersion"""
+    $NewString = $NewString -replace $Regex2, "public const string AssemblyFileVersion = ""$AssemblyVersion.0"""
     $NewString = $NewString -replace $Regex3, "public const string AssemblyCopyright = ""Copyright © $CurrentYear The CefSharp Authors"""
     
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
@@ -358,7 +358,7 @@ function WriteVersionToManifest($manifest)
     $Regex = 'assemblyIdentity version="(.*?)"';
     
     $ManifestData = Get-Content -Encoding UTF8 $Filename
-    $NewString = $ManifestData -replace $Regex, "assemblyIdentity version=""$AssemblyVersion"""
+    $NewString = $ManifestData -replace $Regex, "assemblyIdentity version=""$AssemblyVersion.0"""
     
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)


### PR DESCRIPTION
The ability to create a handler to display a message box or some kind of prompt notifying the user about the browser is not responding before the program works again or crashes.