### PR TITLE
Refactor to avoid loading System.ServiceModel assembly

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.cpp
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.cpp
@@ -49,7 +49,8 @@ void ManagedCefBrowserAdapter::CreateBrowser(IWindowInfo^ windowInfo, BrowserSet
     delete windowInfo;
 }
 
-void ManagedCefBrowserAdapter::InitializeBrowserProcessServiceHost(IBrowser^ browser)
+// NOTE: This was moved out of OnAfterBrowserCreated to prevent the System.ServiceModel assembly from being loaded when WCF is not enabled.
+__declspec(noinline) void ManagedCefBrowserAdapter::InitializeBrowserProcessServiceHost(IBrowser^ browser)
 {
     _browserProcessServiceHost = gcnew BrowserProcessServiceHost(_javaScriptObjectRepository, Process::GetCurrentProcess()->Id, browser->Identifier, _javascriptCallbackFactory);
     //NOTE: Attempt to solve timing issue where browser is opened and rapidly disposed. In some cases a call to Open throws
@@ -67,7 +68,8 @@ void ManagedCefBrowserAdapter::InitializeBrowserProcessServiceHost(IBrowser^ bro
     }
 }
 
-void ManagedCefBrowserAdapter::DisposeBrowserProcessServiceHost()
+// NOTE: This was moved out of ~ManagedCefBrowserAdapter to prevent the System.ServiceModel assembly from being loaded when WCF is not enabled.
+__declspec(noinline) void ManagedCefBrowserAdapter::DisposeBrowserProcessServiceHost()
 {
     if (_browserProcessServiceHost != nullptr)
     {

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -39,6 +39,8 @@ namespace CefSharp
 
     private:
         void MethodInvocationComplete(Object^ sender, MethodInvocationCompleteArgs^ e);
+        void InitializeBrowserProcessServiceHost(IBrowser^ browser);
+        void DisposeBrowserProcessServiceHost();
 
     internal:
         MCefRefPtr<ClientAdapter> GetClientAdapter();
@@ -93,17 +95,9 @@ namespace CefSharp
                 _browserWrapper = nullptr;
             }
 
-            if (CefSharpSettings::WcfEnabled && _browserProcessServiceHost != nullptr)
+            if (CefSharpSettings::WcfEnabled)
             {
-                if (CefSharpSettings::WcfTimeout > TimeSpan::Zero)
-                {
-                    _browserProcessServiceHost->Close(CefSharpSettings::WcfTimeout);
-                }
-                else
-                {
-                    _browserProcessServiceHost->Abort();
-                }
-                _browserProcessServiceHost = nullptr;
+                DisposeBrowserProcessServiceHost();
             }
 
             _webBrowserInternal = nullptr;


### PR DESCRIPTION
When WCF is not used the System.ServiceModel assembly is not required. With this refactoring the runtime will avoid loading the assembly if WCF if not used.

Edit: My main motivation behind this change it to be able to use CefSharp with .NET Core 3.0. While in the long term it may be better to generate .NET Core specific assemblies, this change allows .NET Core which does not have System.ServiceModel to load the .NET Framework assemblies. As a side effect it also results in a slightly smaller memory footprint for .NET Framework applications that don't use WCF.

I have tested this change by using the NuGet packages (CefSharp.Common/CefSharp.WinForms generated using `build.ps1 vs2017`) and checking the loaded assemblies when running a program in Release mode. I've also tested it with a .NET Core 3.0 application and it loads up properly (instead of just crashing).