### PR TITLE
Async JavascriptBinding - Add support for returning Task

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.cpp
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.cpp
@@ -117,7 +117,7 @@ JavascriptObjectRepository^ ManagedCefBrowserAdapter::JavascriptObjectRepository
     return _javaScriptObjectRepository;
 }
 
-MethodRunnerQueue^ ManagedCefBrowserAdapter::MethodRunnerQueue::get()
+IMethodRunnerQueue^ ManagedCefBrowserAdapter::MethodRunnerQueue::get()
 {
     return _methodRunnerQueue;
 }

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -33,7 +33,7 @@ namespace CefSharp
         IWebBrowserInternal^ _webBrowserInternal;
         JavascriptObjectRepository^ _javaScriptObjectRepository;
         JavascriptCallbackFactory^ _javascriptCallbackFactory;
-        MethodRunnerQueue^ _methodRunnerQueue;
+        IMethodRunnerQueue^ _methodRunnerQueue;
         IBrowser^ _browserWrapper;
         bool _isDisposed;
 
@@ -59,7 +59,16 @@ namespace CefSharp
             _webBrowserInternal = webBrowserInternal;
             _javaScriptObjectRepository = gcnew CefSharp::Internals::JavascriptObjectRepository();
             _javascriptCallbackFactory = gcnew CefSharp::Internals::JavascriptCallbackFactory(_clientAdapter->GetPendingTaskRepository());
-            _methodRunnerQueue = gcnew CefSharp::Internals::MethodRunnerQueue(_javaScriptObjectRepository);
+
+            if (CefSharpSettings::ConcurrentTaskExecution)
+            {
+                _methodRunnerQueue = gcnew CefSharp::Internals::ParallelMethodRunnerQueue(_javaScriptObjectRepository);
+            }
+            else
+            {
+                _methodRunnerQueue = gcnew CefSharp::Internals::MethodRunnerQueue(_javaScriptObjectRepository);
+            }
+
             _methodRunnerQueue->MethodInvocationComplete += gcnew EventHandler<MethodInvocationCompleteArgs^>(this, &ManagedCefBrowserAdapter::MethodInvocationComplete);
             _methodRunnerQueue->Start();
         }
@@ -132,9 +141,9 @@ namespace CefSharp
             CefSharp::Internals::JavascriptObjectRepository^ get();
         }
 
-        virtual property MethodRunnerQueue^ MethodRunnerQueue
+        virtual property IMethodRunnerQueue^ MethodRunnerQueue
         {
-            CefSharp::Internals::MethodRunnerQueue^ get();
+            CefSharp::Internals::IMethodRunnerQueue^ get();
         }
     };
 }

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -62,7 +62,7 @@ namespace CefSharp
 
             if (CefSharpSettings::ConcurrentTaskExecution)
             {
-                _methodRunnerQueue = gcnew CefSharp::Internals::ParallelMethodRunnerQueue(_javaScriptObjectRepository);
+                _methodRunnerQueue = gcnew CefSharp::Internals::ConcurrentMethodRunnerQueue(_javaScriptObjectRepository);
             }
             else
             {

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -17,6 +17,7 @@ namespace CefSharp.Example
         public const string DefaultUrl = BaseUrl + "/home.html";
         public const string BindingTestUrl = BaseUrl + "/BindingTest.html";
         public const string BindingTestSingleUrl = BaseUrl + "/BindingTestSingle.html";
+        public const string BindingTestsAsyncTaskUrl = BaseUrl + "/BindingTestsAsyncTask.html";
         public const string LegacyBindingTestUrl = BaseUrl + "/LegacyBindingTest.html";
         public const string PluginsTestUrl = BaseUrl + "/plugins.html";
         public const string PopupTestUrl = BaseUrl + "/PopupTest.html";
@@ -52,7 +53,7 @@ namespace CefSharp.Example
             //NOTE: Not all relevant in relation to `CefSharp`, use for reference purposes only.
             //CEF specific command line args
             //https://bitbucket.org/chromiumembedded/cef/src/master/libcef/common/cef_switches.cc?fileviewer=file-view-default
-            
+
             settings.RemoteDebuggingPort = 8088;
             //The location where cache data will be stored on disk. If empty an in-memory cache will be used for some features and a temporary disk cache for others.
             //HTML5 databases such as localStorage will only persist across sessions if a cache path is specified. 
@@ -187,8 +188,9 @@ namespace CefSharp.Example
             //This must be set before Cef.Initialized is called
             CefSharpSettings.FocusedNodeChangedEnabled = true;
 
-            //Experimental option where bound async methods are queued on TaskScheduler.Default.
-            CefSharpSettings.ConcurrentTaskExecution = true;
+            //Async Javascript Binding - methods are queued on TaskScheduler.Default.
+            //Set this to true to when you have methods that return Task<T>
+            //CefSharpSettings.ConcurrentTaskExecution = true;
 
             //Legacy Binding Behaviour doesn't work for cross-site navigation (navigating to a different domain)
             //See issue https://github.com/cefsharp/CefSharp/issues/1203 for details

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -188,7 +188,7 @@ namespace CefSharp.Example
             CefSharpSettings.FocusedNodeChangedEnabled = true;
 
             //Experimental option where bound async methods are queued on TaskScheduler.Default.
-            //CefSharpSettings.ConcurrentTaskExecution = true;
+            CefSharpSettings.ConcurrentTaskExecution = true;
 
             //Legacy Binding Behaviour doesn't work for cross-site navigation (navigating to a different domain)
             //See issue https://github.com/cefsharp/CefSharp/issues/1203 for details

--- a/CefSharp.Example/CefSharp.Example.csproj
+++ b/CefSharp.Example/CefSharp.Example.csproj
@@ -153,6 +153,7 @@
     <Content Include="Resources\assets\js\shBrushCSharp.js" />
     <None Include="Resources\assets\js\shBrushJScript.js" />
     <Content Include="Resources\assets\js\shCore.js" />
+    <Content Include="Resources\BindingTestsAsyncTask.html" />
     <Content Include="Resources\BindingTestSingle.html" />
     <Content Include="Resources\DragDropCursorsTest.html" />
     <Content Include="Resources\JavascriptCallbackTest.html" />

--- a/CefSharp.Example/CefSharpSchemeHandlerFactory.cs
+++ b/CefSharp.Example/CefSharpSchemeHandlerFactory.cs
@@ -53,7 +53,8 @@ namespace CefSharp.Example
                 { "/Recaptcha.html", Resources.Recaptcha },
                 { "/UnicodeExampleGreaterThan32kb.html", Resources.UnicodeExampleGreaterThan32kb },
                 { "/UnocodeExampleEqualTo32kb.html", Resources.UnocodeExampleEqualTo32kb },
-                { "/JavascriptCallbackTest.html", Resources.JavascriptCallbackTest }
+                { "/JavascriptCallbackTest.html", Resources.JavascriptCallbackTest },
+                { "/BindingTestsAsyncTask.html", Resources.BindingTestsAsyncTask }
             };
         }
 

--- a/CefSharp.Example/JavascriptBinding/AsyncBoundObject.cs
+++ b/CefSharp.Example/JavascriptBinding/AsyncBoundObject.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -149,6 +151,10 @@ namespace CefSharp.Example.JavascriptBinding
             };
         }
 
+        //The Following Test methods can only be used when
+        //CefSharpSettings.ConcurrentTaskExecution = true;
+        //There is a seperate set of QUnit tests for these
+
         public Task<string> ReturnTaskStringAsync()
         {
             return Task.FromResult(nameof(ReturnTaskStringAsync));
@@ -166,6 +172,25 @@ namespace CefSharp.Example.JavascriptBinding
             await Task.Delay(2000);
 
             return str;
+        }
+
+        public async Task<string[]> AsyncDownloadFileAndSplitOnNewLines(string url)
+        {
+            var webClient = new WebClient();
+            var download = await webClient.DownloadStringTaskAsync(new Uri(url));
+
+            var lines = download.Split('\n').Where(x => !string.IsNullOrEmpty(x.Trim())).ToArray();
+
+            return lines;
+        }
+
+        //We expect an exception here, so tell VS to ignore
+        [DebuggerHidden]
+        public async Task<string> AsyncThrowException()
+        {
+            await Task.Delay(2000);
+
+            throw new Exception("Expected Exception");
         }
     }
 }

--- a/CefSharp.Example/JavascriptBinding/AsyncBoundObject.cs
+++ b/CefSharp.Example/JavascriptBinding/AsyncBoundObject.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace CefSharp.Example.JavascriptBinding
 {
@@ -146,6 +147,25 @@ namespace CefSharp.Example.JavascriptBinding
             {
                 {"data", MethodReturnsDictionary2()}
             };
+        }
+
+        public Task<string> ReturnTaskStringAsync()
+        {
+            return Task.FromResult(nameof(ReturnTaskStringAsync));
+        }
+
+        public async void VoidReturnAsync()
+        {
+            await Task.Delay(1000);
+
+            Debug.WriteLine("Delayed 1 second.");
+        }
+
+        public async Task<string> AsyncWaitTwoSeconds(string str)
+        {
+            await Task.Delay(2000);
+
+            return str;
         }
     }
 }

--- a/CefSharp.Example/Properties/Resources.Designer.cs
+++ b/CefSharp.Example/Properties/Resources.Designer.cs
@@ -309,19 +309,46 @@ namespace CefSharp.Example.Properties {
         /// <summary>
         ///   Looks up a localized string similar to &lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0 Transitional//EN&quot;&gt;
         ///&lt;html&gt;
-        ///    &lt;head&gt;
-        ///        &lt;title&gt;Binding Test&lt;/title&gt;
-        ///        &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
-        ///    &lt;/head&gt;
-        ///    &lt;body&gt;
-        ///        &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
-        ///        &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///        &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///&lt;head&gt;
+        ///    &lt;title&gt;Binding Test Async Task&lt;/title&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///&lt;/head&gt;
+        ///&lt;body&gt;
+        ///    &lt;div&gt;
+        ///        These tests require CefSharpSettings.ConcurrentTaskExecution = true;
+        ///        Which by default is set to false
+        ///    &lt;/div&gt;
         ///
-        ///        &lt;script type=&quot;text/javascript&quot;&gt;
-        ///        (async () =&gt;
-        ///        {
-        ///            await CefSharp.BindObjectAsync(&quot;boundAsync [rest of string was truncated]&quot;;.
+        ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
+        ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///
+        ///     [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string BindingTestsAsyncTask {
+            get {
+                return ResourceManager.GetString("BindingTestsAsyncTask", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0 Transitional//EN&quot;&gt;
+        ///&lt;html&gt;
+        ///&lt;head&gt;
+        ///    &lt;title&gt;Binding Test&lt;/title&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///&lt;/head&gt;
+        ///&lt;body&gt;
+        ///    &lt;div&gt;
+        ///        These tests require CefSharpSettings.ConcurrentTaskExecution = true;
+        ///        Which by default is set to false
+        ///    &lt;/div&gt;
+        ///
+        ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
+        ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///
+        ///    &lt;script typ [rest of string was truncated]&quot;;.
         /// </summary>
         public static string BindingTestSingle {
             get {
@@ -567,7 +594,7 @@ namespace CefSharp.Example.Properties {
         ///        (async function ()
         ///        {
         ///            await CefSharp.BindObjectAsync(&apos;boundObject&apos;);
-        ///            boundObject.SetCallBack(myFunction);
+        ///            boundObject.setCallBack(myFunction);
         ///
         ///            function myFunction(param)
         ///            {
@@ -578,8 +605,7 @@ namespace CefSharp.Example.Properties {
         ///    &lt;/script&gt;
         ///&lt;/head&gt;
         ///&lt;body&gt;
-        ///
-        ///&lt;/b [rest of string was truncated]&quot;;.
+        ///    &lt; [rest of string was truncated]&quot;;.
         /// </summary>
         public static string JavascriptCallbackTest {
             get {

--- a/CefSharp.Example/Properties/Resources.resx
+++ b/CefSharp.Example/Properties/Resources.resx
@@ -217,4 +217,7 @@
   <data name="JavascriptCallbackTest" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\JavascriptCallbackTest.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="BindingTestsAsyncTask" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\BindingTestsAsyncTask.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/CefSharp.Example/Resources/BindingTestSingle.html
+++ b/CefSharp.Example/Resources/BindingTestSingle.html
@@ -1,52 +1,68 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
-    <head>
-        <title>Binding Test</title>
-        <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
-    </head>
-    <body>
-        <div id="qunit"></div>
-        <div id="qunit-fixture"></div>
-        <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+<head>
+    <title>Binding Test</title>
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+</head>
+<body>
+    <div>
+        These tests require CefSharpSettings.ConcurrentTaskExecution = true;
+        Which by default is set to false
+    </div>
 
-        <script type="text/javascript">
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+
+    <script type="text/javascript">
         (async () =>
         {
-            await CefSharp.BindObjectAsync("boundAsync", "bound");
+            await CefSharp.BindObjectAsync("boundAsync");
 
-            QUnit.test( "Struct Test:", function( assert )
+            QUnit.test("ReturnTaskStringAsync:", function (assert)
             {
-                var asyncCallback = assert.async();
+                let asyncCallback = assert.async();
 
-                //Returns a Struct
-                boundAsync.returnObject('CefSharp Struct Test').then(function (actualResult)
+                boundAsync.returnTaskStringAsync().then(function (actualResult)
                 {
-                    const expectedResult = 'CefSharp Struct Test';
+                    const expectedResult = 'ReturnTaskStringAsync';
 
-                    assert.equal(expectedResult, actualResult.Value, "Return class " + expectedResult);
+                    assert.equal(expectedResult, actualResult, "Return string " + expectedResult);
 
                     asyncCallback();
-                });                
+                });
             });
 
-            QUnit.test( "Class Test:", function( assert )
+            QUnit.test("VoidReturnAsync Test:", function (assert)
             {
-                var asyncCallback = assert.async();
+                let asyncCallback = assert.async();
 
-                //Returns a class
-                boundAsync.returnClass('CefSharp Class Test').then(function (actualResult)
+                boundAsync.voidReturnAsync().then(function (actualResult)
                 {
-                    const expectedResult = 'CefSharp Class Test';
+                    const expectedResult = null;
 
-                    assert.equal(expectedResult, actualResult.Value, "Return class " + expectedResult);
+                    assert.equal(expectedResult, actualResult, "Return null");
 
                     asyncCallback();
-                });                
+                });
             });
 
+            QUnit.test("AsyncWaitTwoSeconds Test:", function (assert)
+            {
+                let asyncCallback = assert.async();
+
+                const expectedResult = "This method waited two seconds";
+
+                boundAsync.asyncWaitTwoSeconds(expectedResult).then(function (actualResult)
+                {
+                    assert.equal(expectedResult, actualResult, "Return string " + expectedResult);
+
+                    asyncCallback();
+                });
+            });
 
         })();
-        </script>
+    </script>
 
-    </body>
+</body>
 </html>

--- a/CefSharp.Example/Resources/BindingTestsAsyncTask.html
+++ b/CefSharp.Example/Resources/BindingTestsAsyncTask.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+    <title>Binding Test Async Task</title>
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+</head>
+<body>
+    <div>
+        These tests require CefSharpSettings.ConcurrentTaskExecution = true;
+        Which by default is set to false
+    </div>
+
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+
+    <script type="text/javascript">
+        (async () =>
+        {
+            await CefSharp.BindObjectAsync("boundAsync");
+
+            QUnit.test("ReturnTaskStringAsync:", function (assert)
+            {
+                let asyncCallback = assert.async();
+
+                boundAsync.returnTaskStringAsync().then(function (actualResult)
+                {
+                    const expectedResult = 'ReturnTaskStringAsync';
+
+                    assert.equal(expectedResult, actualResult, "Return string " + expectedResult);
+
+                    asyncCallback();
+                });
+            });
+
+            QUnit.test("VoidReturnAsync Test:", function (assert)
+            {
+                let asyncCallback = assert.async();
+
+                boundAsync.voidReturnAsync().then(function (actualResult)
+                {
+                    const expectedResult = null;
+
+                    assert.equal(expectedResult, actualResult, "Return null");
+
+                    asyncCallback();
+                });
+            });
+
+            QUnit.test("AsyncWaitTwoSeconds Test:", function (assert)
+            {
+                let asyncCallback = assert.async();
+
+                const expectedResult = "This method waited two seconds";
+
+                boundAsync.asyncWaitTwoSeconds(expectedResult).then(function (actualResult)
+                {
+                    assert.equal(expectedResult, actualResult, "Return string " + expectedResult);
+
+                    asyncCallback();
+                });
+            });
+
+        })();
+    </script>
+
+</body>
+</html>

--- a/CefSharp.Example/Resources/BindingTestsAsyncTask.html
+++ b/CefSharp.Example/Resources/BindingTestsAsyncTask.html
@@ -15,6 +15,13 @@
     <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
 
     <script type="text/javascript">
+        function getRandomInt(min, max)
+        {
+            min = Math.ceil(min);
+            max = Math.floor(max);
+            return Math.floor(Math.random() * (max - min)) + min; //The maximum is exclusive and the minimum is inclusive
+        }
+
         (async () =>
         {
             await CefSharp.BindObjectAsync("boundAsync");
@@ -47,20 +54,54 @@
                 });
             });
 
-            QUnit.test("AsyncWaitTwoSeconds Test:", function (assert)
+            QUnit.test("Async Download File Test:", function (assert)
             {
                 let asyncCallback = assert.async();
 
-                const expectedResult = "This method waited two seconds";
+                const url = "https://raw.githubusercontent.com/cefsharp/CefSharp/master/.editorconfig";
 
-                boundAsync.asyncWaitTwoSeconds(expectedResult).then(function (actualResult)
+                const expectedResult = "# editorconfig.org";
+
+                boundAsync.asyncDownloadFileAndSplitOnNewLines(url).then(function (actualResult)
                 {
-                    assert.equal(expectedResult, actualResult, "Return string " + expectedResult);
+                    assert.equal(expectedResult, actualResult[0], "Return string " + expectedResult);
 
                     asyncCallback();
                 });
             });
 
+            QUnit.test("Multiple Async Download File Test:", function (assert)
+            {
+                let asyncCallback = assert.async();
+
+                const url = "https://raw.githubusercontent.com/cefsharp/CefSharp/master/.editorconfig";
+
+                let p1 = boundAsync.asyncDownloadFileAndSplitOnNewLines(url);
+                let p2 = boundAsync.asyncDownloadFileAndSplitOnNewLines(url);
+
+                Promise.all([p1, p2]).then(function (values)
+                {
+                    let lineNo = getRandomInt(0, values[0].length);
+                    assert.equal(values[0].length, values[1].length, "Line Count " + values[0].length)
+                    assert.equal(values[0][lineNo], values[1][lineNo], "Return string " + values[0][lineNo]);
+
+                    asyncCallback();
+                });
+            });
+
+            QUnit.test("Async .Net Exception:", function (assert)
+            {
+                let asyncCallback = assert.async();
+
+                const expectedResult = "Expected Exception";
+
+                boundAsync.asyncThrowException().catch(function (ex)
+                {
+                    assert.equal(true, ex.includes(expectedResult), "Return string " + ex);
+
+                    asyncCallback();
+                });
+            });
         })();
     </script>
 

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -99,6 +99,7 @@
   <ItemGroup>
     <Compile Include="Framework\BinderFacts.cs" />
     <Compile Include="Framework\AsyncExtensionFacts.cs" />
+    <Compile Include="Framework\ConcurrentMethodRunnerQueueFacts.cs" />
     <Compile Include="OffScreen\OffScreenBrowserBasicFacts.cs" />
     <Compile Include="CefSharpFixture.cs" />
     <Compile Include="CefSharpFixtureCollection.cs" />
@@ -112,6 +113,10 @@
       <Project>{7b495581-2271-4f41-9476-acb86e8c864f}</Project>
       <Name>CefSharp.Core</Name>
       <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.csproj">
+      <Project>{a4394e7b-1155-43a6-989e-8ab72dddc9e4}</Project>
+      <Name>CefSharp.Example</Name>
     </ProjectReference>
     <ProjectReference Include="..\CefSharp.OffScreen\CefSharp.OffScreen.csproj">
       <Project>{483b158d-f57d-49d9-9046-31e6a73f8a53}</Project>

--- a/CefSharp.Test/Framework/ConcurrentMethodRunnerQueueFacts.cs
+++ b/CefSharp.Test/Framework/ConcurrentMethodRunnerQueueFacts.cs
@@ -1,0 +1,77 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Threading;
+using System.Threading.Tasks;
+using CefSharp.Example.JavascriptBinding;
+using CefSharp.Internals;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CefSharp.Test.Framework
+{
+    public class ConcurrentMethodRunnerQueueFacts
+    {
+        private readonly ITestOutputHelper output;
+
+        public ConcurrentMethodRunnerQueueFacts(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public async Task StopConcurrentMethodRunnerQueueWhenMethodRunning()
+        {
+            var boundObject = new AsyncBoundObject();
+
+            var objectRepository = new JavascriptObjectRepository();
+            objectRepository.Register("testObject", boundObject, true, new BindingOptions { CamelCaseJavascriptNames = false });
+            var methodInvocation = new MethodInvocation(1, 1, 1, nameof(boundObject.AsyncWaitTwoSeconds), 1);
+            methodInvocation.Parameters.Add("Echo Me!");
+            var methodRunnerQueue = new ConcurrentMethodRunnerQueue(objectRepository);
+
+            methodRunnerQueue.Start();
+            methodRunnerQueue.Enqueue(methodInvocation);
+
+            //Wait a litle for the queue to start processing our Method call
+            await Task.Delay(500);
+
+            var ex = Record.Exception(() => methodRunnerQueue.Stop());
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ValidateAsyncTaskMethodOutput()
+        {
+            const string expectedResult = "Echo Me!";
+            var boundObject = new AsyncBoundObject();
+
+            var objectRepository = new JavascriptObjectRepository();
+            objectRepository.Register("testObject", boundObject, true, new BindingOptions { CamelCaseJavascriptNames = false });
+            var methodInvocation = new MethodInvocation(1, 1, 1, nameof(boundObject.AsyncWaitTwoSeconds), 1);
+            methodInvocation.Parameters.Add(expectedResult);
+            var methodRunnerQueue = new ConcurrentMethodRunnerQueue(objectRepository);
+            var manualResetEvent = new ManualResetEvent(false);
+
+            var actualResult = "";
+
+            methodRunnerQueue.MethodInvocationComplete += (sender, args) =>
+            {
+                methodRunnerQueue.Stop();
+
+                actualResult = args.Result.Result.ToString();
+
+                manualResetEvent.Set();
+            };
+
+            methodRunnerQueue.Start();
+            methodRunnerQueue.Enqueue(methodInvocation);
+
+            manualResetEvent.WaitOne(3000);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+    }
+}

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="CefSharp.Wpf.Example.MainWindow"
+<Window x:Class="CefSharp.Wpf.Example.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:CefSharp.Wpf.Example.Controls"
@@ -26,6 +26,7 @@
             </MenuItem>
             <MenuItem Header="_Tests">
                 <MenuItem Header="_Binding Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.BindingTestUrl}}"/>
+                <MenuItem Header="_Binding Test Single" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.BindingTestSingleUrl}}"/>
                 <MenuItem Header="_LegacyBinding Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.LegacyBindingTestUrl}}"/>
                 <MenuItem Header="_List Plugins" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.PluginsTestUrl}}"/>
                 <MenuItem Header="_Tooltip Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.TooltipTestUrl}}"/>

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -43,6 +43,7 @@
                 <MenuItem Header="_Print Current tab to PDF" Command="controls:CefSharpCommands.PrintTabToPdfCommand" />
                 <MenuItem Header="_Load Custom Request" Command="controls:CefSharpCommands.CustomCommand" CommandParameter="CustomRequest" />
                 <MenuItem Header="_CDM/DRM Support Test" Command="controls:CefSharpCommands.OpenTabCommand" CommandParameter="{Binding Source={x:Static ex:CefExample.CdmSupportTestUrl}}"/>
+                <MenuItem Header="_Async JSB Task Tests" Command="controls:CefSharpCommands.CustomCommand" CommandParameter="AsyncJsbTaskTests" />
             </MenuItem>
         </Menu>
         <controls:NonReloadingTabControl x:Name="TabControl"

--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -140,6 +140,16 @@ namespace CefSharp.Wpf.Example
                     browserViewModel.ShowDownloadInfo = !browserViewModel.ShowDownloadInfo;
                 }
 
+                if (param == "AsyncJsbTaskTests")
+                {
+                    //After this setting has changed all tests will run through the Concurrent MethodQueueRunner
+                    CefSharpSettings.ConcurrentTaskExecution = true;
+
+                    CreateNewTab(CefExample.BindingTestsAsyncTaskUrl, true);
+
+                    TabControl.SelectedIndex = TabControl.Items.Count - 1;
+                }
+
                 //NOTE: Add as required
                 //else if (param == "CustomRequest123")
                 //{

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -116,6 +116,8 @@
     <Compile Include="IApp.cs" />
     <Compile Include="Handler\IAudioHandler.cs" />
     <Compile Include="IExtension.cs" />
+    <Compile Include="Internals\IMethodRunnerQueue.cs" />
+    <Compile Include="Internals\ParallelMethodRunnerQueue.cs" />
     <Compile Include="ISchemeRegistrar.cs" />
     <Compile Include="IValue.cs" />
     <Compile Include="IImage.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -117,7 +117,7 @@
     <Compile Include="Handler\IAudioHandler.cs" />
     <Compile Include="IExtension.cs" />
     <Compile Include="Internals\IMethodRunnerQueue.cs" />
-    <Compile Include="Internals\ParallelMethodRunnerQueue.cs" />
+    <Compile Include="Internals\ConcurrentMethodRunnerQueue.cs" />
     <Compile Include="ISchemeRegistrar.cs" />
     <Compile Include="IValue.cs" />
     <Compile Include="IImage.cs" />

--- a/CefSharp/Internals/ConcurrentMethodRunnerQueue.cs
+++ b/CefSharp/Internals/ConcurrentMethodRunnerQueue.cs
@@ -109,7 +109,17 @@ namespace CefSharp.Internals
                                         {
                                             result.Success = false;
                                             result.Result = null;
-                                            result.Message = t.Exception.ToString();
+                                            var aggregateException = t.Exception;
+                                            //TODO: Add support for passing a more complex message
+                                            // to better represent the Exception
+                                            if (aggregateException.InnerExceptions.Count == 1)
+                                            {
+                                                result.Message = aggregateException.InnerExceptions[0].ToString();
+                                            }
+                                            else
+                                            {
+                                                result.Message = t.Exception.ToString();
+                                            }
                                         }
 
                                         OnMethodInvocationComplete(result);

--- a/CefSharp/Internals/ConcurrentMethodRunnerQueue.cs
+++ b/CefSharp/Internals/ConcurrentMethodRunnerQueue.cs
@@ -10,12 +10,12 @@ using System.Threading.Tasks;
 namespace CefSharp.Internals
 {
     /// <summary>
-    /// ParallelMethodRunnerQueue - Async Javascript Binding methods are run
+    /// ConcurrentMethodRunnerQueue - Async Javascript Binding methods are run
     /// on the ThreadPool in parallel, when a method returns a Task
     /// the we use ContinueWith to be notified of completion then
     /// raise the MethodInvocationComplete event
     /// </summary>
-    public class ParallelMethodRunnerQueue : IMethodRunnerQueue
+    public class ConcurrentMethodRunnerQueue : IMethodRunnerQueue
     {
         private readonly JavascriptObjectRepository repository;
         private readonly AutoResetEvent stopped = new AutoResetEvent(false);
@@ -26,7 +26,7 @@ namespace CefSharp.Internals
 
         public event EventHandler<MethodInvocationCompleteArgs> MethodInvocationComplete;
 
-        public ParallelMethodRunnerQueue(JavascriptObjectRepository repository)
+        public ConcurrentMethodRunnerQueue(JavascriptObjectRepository repository)
         {
             this.repository = repository;
         }

--- a/CefSharp/Internals/IBrowserAdapter.cs
+++ b/CefSharp/Internals/IBrowserAdapter.cs
@@ -10,7 +10,7 @@ namespace CefSharp.Internals
     /// </summary>
     public interface IBrowserAdapter
     {
-        MethodRunnerQueue MethodRunnerQueue { get; }
+        IMethodRunnerQueue MethodRunnerQueue { get; }
         JavascriptObjectRepository JavascriptObjectRepository { get; }
         IJavascriptCallbackFactory JavascriptCallbackFactory { get; }
         void OnAfterBrowserCreated(IBrowser browser);

--- a/CefSharp/Internals/IMethodRunnerQueue.cs
+++ b/CefSharp/Internals/IMethodRunnerQueue.cs
@@ -1,0 +1,17 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+
+namespace CefSharp.Internals
+{
+    public interface IMethodRunnerQueue
+    {
+        event EventHandler<MethodInvocationCompleteArgs> MethodInvocationComplete;
+
+        void Enqueue(MethodInvocation methodInvocation);
+        void Start();
+        void Stop();
+    }
+}

--- a/CefSharp/Internals/MethodRunnerQueue.cs
+++ b/CefSharp/Internals/MethodRunnerQueue.cs
@@ -95,6 +95,18 @@ namespace CefSharp.Internals
             try
             {
                 success = repository.TryCallMethod(methodInvocation.ObjectId, methodInvocation.MethodName, methodInvocation.Parameters.ToArray(), out result, out exception);
+
+                //If don't support Tasks by default
+                if (success && result != null && (typeof(Task).IsAssignableFrom(result.GetType())))
+                {
+                    success = false;
+                    result = null;
+                    exception = @"Your method returned a Task which is not supported by default you must set CefSharpSettings.ConcurrentTaskExecution = true; 
+                    before creating your first ChromiumWebBrowser instance. This will likely change to the default at some point in the near future. 
+                    see https://github.com/cefsharp/CefSharp/issues/2758 for more details, please report any issues you have there, make sure you have 
+                    an example ready that reproduces your problem.";
+                }
+
             }
             catch (Exception e)
             {

--- a/CefSharp/Internals/MethodRunnerQueue.cs
+++ b/CefSharp/Internals/MethodRunnerQueue.cs
@@ -96,15 +96,20 @@ namespace CefSharp.Internals
             {
                 success = repository.TryCallMethod(methodInvocation.ObjectId, methodInvocation.MethodName, methodInvocation.Parameters.ToArray(), out result, out exception);
 
-                //If don't support Tasks by default
+                //We don't support Tasks by default
                 if (success && result != null && (typeof(Task).IsAssignableFrom(result.GetType())))
                 {
+                    //Use StringBuilder to improve the formatting/readability of the error message
+                    //I'm sure there's a better way I just cannot remember of the top of my head so going
+                    //with this for now, as it's only for error scenaiors I'm not concerned about performance.
+                    var builder = new System.Text.StringBuilder();
+                    builder.AppendLine("Your method returned a Task which is not supported by default you must set CefSharpSettings.ConcurrentTaskExecution = true; before creating your first ChromiumWebBrowser instance.");
+                    builder.AppendLine("This will likely change to the default at some point in the near future, subscribe to the issue link below to be notified of any changes.");
+                    builder.AppendLine("See https://github.com/cefsharp/CefSharp/issues/2758 for more details, please report any issues you have there, make sure you have an example ready that reproduces your problem.");
+
                     success = false;
                     result = null;
-                    exception = @"Your method returned a Task which is not supported by default you must set CefSharpSettings.ConcurrentTaskExecution = true; 
-                    before creating your first ChromiumWebBrowser instance. This will likely change to the default at some point in the near future. 
-                    see https://github.com/cefsharp/CefSharp/issues/2758 for more details, please report any issues you have there, make sure you have 
-                    an example ready that reproduces your problem.";
+                    exception = builder.ToString();
                 }
 
             }

--- a/CefSharp/Internals/ParallelMethodRunnerQueue.cs
+++ b/CefSharp/Internals/ParallelMethodRunnerQueue.cs
@@ -1,0 +1,181 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CefSharp.Internals
+{
+    /// <summary>
+    /// ParallelMethodRunnerQueue - Async Javascript Binding methods are run
+    /// on the ThreadPool in parallel, when a method returns a Task
+    /// the we use ContinueWith to be notified of completion then
+    /// raise the MethodInvocationComplete event
+    /// </summary>
+    public class ParallelMethodRunnerQueue : IMethodRunnerQueue
+    {
+        private readonly JavascriptObjectRepository repository;
+        private readonly AutoResetEvent stopped = new AutoResetEvent(false);
+        private readonly BlockingCollection<Func<MethodInvocationResult>> queue = new BlockingCollection<Func<MethodInvocationResult>>();
+        private readonly object lockObject = new object();
+        private volatile CancellationTokenSource cancellationTokenSource;
+        private volatile bool running;
+
+        public event EventHandler<MethodInvocationCompleteArgs> MethodInvocationComplete;
+
+        public ParallelMethodRunnerQueue(JavascriptObjectRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public void Start()
+        {
+            lock (lockObject)
+            {
+                if (!running)
+                {
+                    cancellationTokenSource = new CancellationTokenSource();
+                    Task.Factory.StartNew(ConsumeTasks, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                    running = true;
+                }
+            }
+        }
+
+        public void Stop()
+        {
+            lock (lockObject)
+            {
+                if (running)
+                {
+                    cancellationTokenSource.Cancel();
+                    stopped.WaitOne();
+                    //clear the queue
+                    while (queue.Count > 0)
+                    {
+                        queue.Take();
+                    }
+                    cancellationTokenSource = null;
+                    running = false;
+                }
+            }
+        }
+
+        public void Enqueue(MethodInvocation methodInvocation)
+        {
+            queue.Add(() => ExecuteMethodInvocation(methodInvocation));
+        }
+
+        private void ConsumeTasks()
+        {
+            try
+            {
+                //Executes tasks on the ThreadPool
+                while (!cancellationTokenSource.IsCancellationRequested)
+                {
+                    var func = queue.Take(cancellationTokenSource.Token);
+
+                    var task = new Task(() =>
+                    {
+                        var result = func();
+
+                        //If the call failed or returned null then we'll fire the event immediately
+                        if (!result.Success || result.Result == null)
+                        {
+                            OnMethodInvocationComplete(result);
+                        }
+                        else
+                        {
+                            var resultType = result.Result.GetType();
+
+                            //If the returned type is Task then we'll ContinueWith and perform the processing then.
+                            if (typeof(Task).IsAssignableFrom(resultType))
+                            {
+                                var resultTask = (Task)result.Result;
+
+                                if (resultType.IsGenericType)
+                                {
+                                    resultTask.ContinueWith((t) =>
+                                    {
+                                        if (t.Status == TaskStatus.RanToCompletion)
+                                        {
+                                            //We use some reflection to get the Result
+                                            //If someone has a better way of doing this then please submit a PR
+                                            result.Result = resultType.GetProperty("Result").GetValue(resultTask);
+                                        }
+                                        else
+                                        {
+                                            result.Success = false;
+                                            result.Result = null;
+                                            result.Message = t.Exception.ToString();
+                                        }
+
+                                        OnMethodInvocationComplete(result);
+                                    },
+                                    cancellationTokenSource.Token, TaskContinuationOptions.None, TaskScheduler.Default);
+                                }
+                                else
+                                {
+                                    //If it's not a generic Task then it doesn't have a return object
+                                    //So we'll just set the result to null and continue on
+                                    result.Result = null;
+
+                                    OnMethodInvocationComplete(result);
+                                }
+                            }
+                            else
+                            {
+                                OnMethodInvocationComplete(result);
+                            }
+                        }
+
+                    }, cancellationTokenSource.Token);
+
+                    task.Start(TaskScheduler.Default);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Note: Task has been cancelled
+            }
+            finally
+            {
+                stopped.Set();
+            }
+        }
+
+        private MethodInvocationResult ExecuteMethodInvocation(MethodInvocation methodInvocation)
+        {
+            object result = null;
+            string exception;
+            var success = false;
+
+            //make sure we don't throw exceptions in the executor task
+            try
+            {
+                success = repository.TryCallMethod(methodInvocation.ObjectId, methodInvocation.MethodName, methodInvocation.Parameters.ToArray(), out result, out exception);
+            }
+            catch (Exception e)
+            {
+                exception = e.Message;
+            }
+
+            return new MethodInvocationResult
+            {
+                BrowserId = methodInvocation.BrowserId,
+                CallbackId = methodInvocation.CallbackId,
+                FrameId = methodInvocation.FrameId,
+                Message = exception,
+                Result = result,
+                Success = success
+            };
+        }
+
+        private void OnMethodInvocationComplete(MethodInvocationResult e)
+        {
+            MethodInvocationComplete?.Invoke(this, new MethodInvocationCompleteArgs(e));
+        }
+    }
+}


### PR DESCRIPTION
Remove Concurrent Task execution code from MethodRunnerQueue
Add ConcurrentMethodRunnerQueue
  - For the new code path the Func is executed, if the Result is a generic Task we wait for it's completion
  - If the task is not generic then we return immediately

This is only enabled when CefSharpSettings.ConcurrentTaskExecution = true;

Additional tests will be required before this is production ready

Resolves #2758 