### PR TITLE
WinForms  - Add Shift+Tab to IsInputKey (used when MultiThreadedMessageLoop is disabled)

### DIFF
--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -913,6 +913,7 @@ namespace CefSharp.WinForms
                 {
                     return true;
                 }
+                case Keys.Shift | Keys.Tab:
                 case Keys.Shift | Keys.Right:
                 case Keys.Shift | Keys.Left:
                 case Keys.Shift | Keys.Up:


### PR DESCRIPTION
**Summary:**
   - When MultiThreaded message loop is disabled, we use the winform message loop. We want to ensure that Shift+Tab (cycle selection back) is recognized as a valid input by the browser control otherwise it breaks keyboard accessibility.

**Changes:** 
   - I have added Shift + Tab to the list of inputs recognized by the browser.
      
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, operating system, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I changed the winforms example and set MultiThreadedMessageLoop = false. Then I opened the webpage and tried shift + tab. The selection didn't cycle through the HTML content, instead it cycled through the WinForm controls.
Then, I added my change and redid the same steps as above. Shift + tab works fine. 

Note: I was looking at the original change to the code that I am modifying but couldn't find any automated tests that were written for it. I'd be happy to write tests if someone can point me to the right direction.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
