### PR TITLE
WPF - Use Canvas.Top="0" for PART_image absolute position.

### DIFF
--- a/CefSharp.Wpf/Themes/Generic.xaml
+++ b/CefSharp.Wpf/Themes/Generic.xaml
@@ -12,7 +12,7 @@
                         <Image Name="PART_image" 
                                Stretch="None"
                                Canvas.Left="0"
-                               Canvas.Bottom="0"
+                               Canvas.Top="0"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Top"
                                RenderOptions.BitmapScalingMode="{TemplateBinding Property=RenderOptions.BitmapScalingMode}" />


### PR DESCRIPTION
Fixes #2843

**Summary:**
   - CefSharp Image Jumps Vertically on Height Change

**Changes:**
   - Change canvas offset to Canvas.Top for PART_image in Generic.xaml
      
## How Has This Been Tested?
   - I do not have a build environment for CefSharp set up, so I tested this by overriding the default template with the changes in this commit. So further testing may be needed

## Screenshots (if appropriate):
![CefSharpBug](https://user-images.githubusercontent.com/14193838/61781537-1b8a6600-ae37-11e9-82ad-c8b754fde3f5.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
