### PR TITLE
added note about '1' is not the opposite of '0'

### DIFF
--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -62,7 +62,13 @@ namespace CefSharp.Example
             //HTML5 databases such as localStorage will only persist across sessions if a cache path is specified. 
             settings.CachePath = "cache";
             //settings.UserAgent = "CefSharp Browser" + Cef.CefSharpVersion; // Example User Agent
+						
             //settings.CefCommandLineArgs.Add("renderer-process-limit", "1");
+			
+			// BEWARE: some of the examples like Add("renderer-startup-dialog", "1") suggest that using "0" instead of would switch off the feature			
+			// But this in not the case: For most of these on/off flags chrome just switches it on as long as it sees the flag like --renderer-startup-dialog 
+			// Using "0","1" or "hell-no" will make no difference			
+			
             //settings.CefCommandLineArgs.Add("renderer-startup-dialog", "1");
             //settings.CefCommandLineArgs.Add("enable-media-stream", "1"); //Enable WebRTC
             //settings.CefCommandLineArgs.Add("no-proxy-server", "1"); //Don't use a proxy server, always make direct connections. Overrides any other proxy server flags that are passed.


### PR DESCRIPTION
Fixes #2858
**Summary:** 
Added a note in the examples, that using "0" as value in a commandline switch does not switch that feature off

**Changes:** 
  Added some comments lines pointing out that setting are CefCommandLineArgs.Add("some-key", "0") is not switching off that given feature but the "opposite"
## How Has This Been Tested?
Testing in Windows 7 x64. I used the CefSharp.Wpf.Example project and tried the following settings:
settings.CefCommandLineArgs.Add("renderer-startup-dialog", "0");
settings.CefCommandLineArgs.Add("enable-media-stream", "0"); 
settings.CefCommandLineArgs.Add("no-proxy-server", "0"); 
settings.CefCommandLineArgs.Add("disable-gpu", "0"); 
And after starting the program I observed that using "0" or "" does not switch off any of the mentioned features. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [x] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
