### PR TITLE
WPF - Modify CopyMemory EntryPoint to work with .Net Core

### DIFF
--- a/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
@@ -20,8 +20,8 @@ namespace CefSharp.Wpf.Rendering
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
     public abstract class AbstractRenderHandler : IDisposable, IRenderHandler
     {
-        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
-        protected static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
+        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory", SetLastError = false)]
+        protected static extern void CopyMemory(IntPtr dest, IntPtr src, UIntPtr count);
 
         internal static readonly PixelFormat PixelFormat = PixelFormats.Pbgra32;
         internal static int BytesPerPixel = PixelFormat.BitsPerPixel / 8;

--- a/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
@@ -20,7 +20,8 @@ namespace CefSharp.Wpf.Rendering
     /// <seealso cref="CefSharp.Wpf.IRenderHandler" />
     public abstract class AbstractRenderHandler : IDisposable, IRenderHandler
     {
-        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory", SetLastError = false)]
+        // Note: In contrast to RtlMoveMemory, RtlCopyMemory requires that the buffers do not overlap.
+        [DllImport("kernel32.dll", EntryPoint = "RtlCopyMemory", SetLastError = false)]
         protected static extern void CopyMemory(IntPtr dest, IntPtr src, UIntPtr count);
 
         internal static readonly PixelFormat PixelFormat = PixelFormats.Pbgra32;

--- a/CefSharp.Wpf/Rendering/Experimental/IncreaseBufferInteropRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/Experimental/IncreaseBufferInteropRenderHandler.cs
@@ -60,7 +60,7 @@ namespace CefSharp.Wpf.Rendering.Experimental
 
                 //TODO: Performance analysis to determine which is the fastest memory copy function
                 //NativeMethodWrapper.CopyMemoryUsingHandle(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, numberOfBytes);
-                CopyMemory(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, (uint)numberOfBytes);
+                CopyMemory(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, (UIntPtr)(uint)numberOfBytes);
 
                 //Take a reference to the backBufferHandle, once we're on the UI thread we need to check if it's still valid
                 var backBufferHandle = mappedFile.SafeMemoryMappedFileHandle;

--- a/CefSharp.Wpf/Rendering/InteropBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/InteropBitmapRenderHandler.cs
@@ -54,7 +54,7 @@ namespace CefSharp.Wpf.Rendering
 
                 //TODO: Performance analysis to determine which is the fastest memory copy function
                 //NativeMethodWrapper.CopyMemoryUsingHandle(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, numberOfBytes);
-                CopyMemory(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, (uint)numberOfBytes);
+                CopyMemory(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, (UIntPtr)(uint)numberOfBytes);
 
                 //Take a reference to the backBufferHandle, once we're on the UI thread we need to check if it's still valid
                 var backBufferHandle = mappedFile.SafeMemoryMappedFileHandle;

--- a/CefSharp.Wpf/Rendering/WritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/WritableBitmapRenderHandler.cs
@@ -64,7 +64,7 @@ namespace CefSharp.Wpf.Rendering
 
                 //TODO: Performance analysis to determine which is the fastest memory copy function
                 //NativeMethodWrapper.CopyMemoryUsingHandle(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, numberOfBytes);
-                CopyMemory(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, (uint)numberOfBytes);
+                CopyMemory(viewAccessor.SafeMemoryMappedViewHandle.DangerousGetHandle(), buffer, (UIntPtr)(uint)numberOfBytes);
 
                 //Take a reference to the sourceBuffer that's used to update our WritableBitmap,
                 //once we're on the UI thread we need to check if it's still valid


### PR DESCRIPTION
Contributes to #2796

**Summary:**
   - Fixed the `CopyMemory` entrypoint declaration, which is not working on .NET Core 3.0 as `kernel32.dll` doesn't have an `CopyMemory` export.

**Changes:**
- Changed `EntryPoint` from `CopyMemory` to `RtlCopyMemory`
- Changed the `numberOfBytes` parameter from `uint` to `UIntPtr`

Note: I believe using an pointer type (`IntPtr` or `UIntPtr`) for the `numberOfBytes` parameter is correct even though pinvoke.net (and other sites) specify it as `int`, because the documentation for [`CopyMemory`/`RtlCopyMemory`](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/aa366535%28v%3dvs.85%29) declares it as `SIZE_T` which is defined as pointer-sized integer (`ULONG_PTR`). Additionally, I have done some testing to verify that the value is actually interpreted as 64-bit integer when running as x64 (by specifying a value greater than 0xFFFFFFFF and verifying the correct number of bytes was copied).

Note: There is also a managed API [`Buffer.MemoryCopy()`](https://docs.microsoft.com/en-us/dotnet/api/system.buffer.memorycopy?view=netcore-3.0#System_Buffer_MemoryCopy_System_Void__System_Void__System_Int64_System_Int64_) that could be used instead of p/invoking `RtlCopyMemory`/`RtlMoveMemory`, available starting with .NET Framework 4.6, but that one seems to be slower.
      
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, operating system, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually using `CefSharp.MinimalExample.NetCore.Wpf` (see https://github.com/cefsharp/CefSharp.MinimalExample/pull/57)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [X] Tested the code(if applicable)
- [X] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
