### PR TITLE
BrowserSubprocess - Refactor to support .Net Core

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/BrowserSubprocessExecutable.h
+++ b/CefSharp.BrowserSubprocess.Core/BrowserSubprocessExecutable.h
@@ -29,9 +29,42 @@ namespace CefSharp
 
             }
 
+            /// <summary>
+            /// This function should be called from the application entry point function (typically Program.Main)
+            /// to execute a secondary process e.g. gpu, plugin, renderer, utility
+            /// It can be used to run secondary processes (BrowserSubProcess) from your main applications executable
+            /// or from a separate executable specified by the CefSettings.BrowserSubprocessPath value.
+            /// CefSharp defaults to using the latter approach, a default implementation (CefSharp.BrowserSubProcess.exe) is
+            /// supplied, see https://github.com/cefsharp/CefSharp/wiki/General-Usage#processes for more details.
+            /// </summary>
+            /// <param name="args">command line args</param>
+            /// <returns>
+            /// If called for the browser process (identified by no "type" command-line value) it will return immediately
+            /// with a value of -1. If called for a recognized secondary process it will block until the process should exit
+            /// and then return the process exit code.
+            /// </returns
+            int Main(IEnumerable<String^>^ args)
+            {
+                return Main(args, nullptr);
+            }
+
+            /// <summary>
+            /// This function should be called from the application entry point function (typically Program.Main)
+            /// to execute a secondary process e.g. gpu, plugin, renderer, utility
+            /// It can be used to run secondary processes (BrowserSubProcess) from your main applications executable
+            /// or from a separate executable specified by the CefSettings.BrowserSubprocessPath value.
+            /// CefSharp defaults to using the latter approach, a default implementation (CefSharp.BrowserSubProcess.exe) is
+            /// supplied, see https://github.com/cefsharp/CefSharp/wiki/General-Usage#processes for more details.
+            /// </summary>
+            /// <param name="args">command line args</param>
+            /// <param name="handler">An option IRenderProcessHandler implementation, use null if no handler is required</param>
+            /// <returns>
+            /// If called for the browser process (identified by no "type" command-line value) it will return immediately
+            /// with a value of -1. If called for a recognized secondary process it will block until the process should exit
+            /// and then return the process exit code.
+            /// </returns>
             int Main(IEnumerable<String^>^ args, IRenderProcessHandler^ handler)
             {
-                int result;
                 auto type = CommandLineArgsParser::GetArgumentValue(args, CefSharpArguments::SubProcessTypeArgument);
 
                 auto parentProcessId = -1;
@@ -54,19 +87,15 @@ namespace CefSharp
 
                     try
                     {
-                        result = subProcess->Run();
+                        return subProcess->Run();
                     }
                     finally
                     {
                         delete subProcess;
                     }
                 }
-                else
-                {
-                    result = SubProcess::ExecuteProcess(args);
-                }
 
-                return result;
+                return SubProcess::ExecuteProcess(args);
             }
 
         protected:

--- a/CefSharp.BrowserSubprocess.Core/BrowserSubprocessExecutable.h
+++ b/CefSharp.BrowserSubprocess.Core/BrowserSubprocessExecutable.h
@@ -1,0 +1,79 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+
+#include "SubProcess.h"
+#include "WcfEnabledSubProcess.h"
+
+using namespace System;
+using namespace CefSharp::Internals;
+
+namespace CefSharp
+{
+    namespace BrowserSubprocess
+    {
+        /// <summary>
+        /// BrowserSubprocessExecutable provides the fundimental browser process handling for
+        /// CefSharp.BrowserSubprocess.exe and can be used to self host the BrowserSubProcess in your
+        /// existing application (preferred approach for .Net Core).
+        /// </summary>
+        public ref class BrowserSubprocessExecutable
+        {
+        public:
+            BrowserSubprocessExecutable()
+            {
+
+            }
+
+            int Main(IEnumerable<String^>^ args, IRenderProcessHandler^ handler)
+            {
+                int result;
+                auto type = CommandLineArgsParser::GetArgumentValue(args, CefSharpArguments::SubProcessTypeArgument);
+
+                auto parentProcessId = -1;
+
+                // The Crashpad Handler doesn't have any HostProcessIdArgument, so we must not try to
+                // parse it lest we want an ArgumentNullException.
+                if (type != "crashpad-handler")
+                {
+                    parentProcessId = int::Parse(CommandLineArgsParser::GetArgumentValue(args, CefSharpArguments::HostProcessIdArgument));
+                    if (CommandLineArgsParser::HasArgument(args, CefSharpArguments::ExitIfParentProcessClosed))
+                    {
+                        ParentProcessMonitor::StartMonitorTask(parentProcessId);
+                    }
+                }
+
+                // Use our custom subProcess provides features like EvaluateJavascript
+                if (type == "renderer")
+                {
+                    auto subProcess = GetSubprocess(args, parentProcessId, handler);
+
+                    try
+                    {
+                        result = subProcess->Run();
+                    }
+                    finally
+                    {
+                        delete subProcess;
+                    }
+                }
+                else
+                {
+                    result = SubProcess::ExecuteProcess(args);
+                }
+
+                return result;
+            }
+
+        protected:
+            virtual SubProcess^ GetSubprocess(IEnumerable<String^>^ args, int parentProcessId, IRenderProcessHandler^ handler)
+            {
+                return gcnew SubProcess(handler, args);
+            }
+        };
+    }
+}

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -173,6 +173,7 @@
     <ClInclude Include="..\CefSharp.Core\Internals\Serialization\Primitives.h" />
     <ClInclude Include="..\CefSharp.Core\Internals\StringUtils.h" />
     <ClInclude Include="BindObjectAsyncHandler.h" />
+    <ClCompile Include="BrowserSubprocessExecutable.h" />
     <ClInclude Include="SubProcessApp.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodCallback.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodHandler.h" />
@@ -180,6 +181,7 @@
     <ClInclude Include="Async\JavascriptAsyncObjectWrapper.h" />
     <ClInclude Include="CefAppUnmanagedWrapper.h" />
     <ClInclude Include="JavascriptPostMessageHandler.h" />
+    <ClCompile Include="WcfBrowserSubprocessExecutable.h" />
     <ClInclude Include="Wrapper\Frame.h" />
     <ClInclude Include="Wrapper\Browser.h" />
     <ClInclude Include="Wrapper\V8Context.h" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
@@ -181,6 +181,12 @@
     <ClCompile Include="Wrapper\Browser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="WcfBrowserSubprocessExecutable.h">
+      <Filter>Header Files</Filter>
+    </ClCompile>
+    <ClCompile Include="BrowserSubprocessExecutable.h">
+      <Filter>Header Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />

--- a/CefSharp.BrowserSubprocess.Core/WcfBrowserSubprocessExecutable.h
+++ b/CefSharp.BrowserSubprocess.Core/WcfBrowserSubprocessExecutable.h
@@ -17,6 +17,13 @@ namespace CefSharp
 {
     namespace BrowserSubprocess
     {
+        /// <summary>
+        /// WcfBrowserSubprocessExecutable provides the fundimental browser process handling for
+        /// CefSharp.BrowserSubprocess.exe and can be used to self host the BrowserSubProcess in your
+        /// existing application (preferred approach for .Net Core).
+        /// If the <see cref="CefSharpArguments.WcfEnabledArgument"/> command line argument is
+        /// present then the WcfEnabledSubProcess implementation is used.
+        /// </summary>
         public ref class WcfBrowserSubprocessExecutable : BrowserSubprocessExecutable
         {
         public:

--- a/CefSharp.BrowserSubprocess.Core/WcfBrowserSubprocessExecutable.h
+++ b/CefSharp.BrowserSubprocess.Core/WcfBrowserSubprocessExecutable.h
@@ -1,0 +1,39 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Stdafx.h"
+
+#include "SubProcess.h"
+#include "WcfEnabledSubProcess.h"
+#include "BrowserSubprocessExecutable.h"
+
+using namespace System;
+using namespace CefSharp::Internals;
+
+namespace CefSharp
+{
+    namespace BrowserSubprocess
+    {
+        public ref class WcfBrowserSubprocessExecutable : BrowserSubprocessExecutable
+        {
+        public:
+            WcfBrowserSubprocessExecutable()
+            {
+
+            }
+        protected:
+            SubProcess^ GetSubprocess(IEnumerable<String^>^ args, int parentProcessId, IRenderProcessHandler^ handler) override
+            {
+                auto wcfEnabled = CommandLineArgsParser::HasArgument(args, CefSharpArguments::WcfEnabledArgument);
+                if (wcfEnabled)
+                {
+                    return gcnew WcfEnabledSubProcess(parentProcessId, handler, args);
+                }
+                return gcnew SubProcess(handler, args);
+            }
+        };
+    }
+}

--- a/CefSharp.BrowserSubprocess/Program.cs
+++ b/CefSharp.BrowserSubprocess/Program.cs
@@ -2,7 +2,6 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
-using System;
 using System.Diagnostics;
 using CefSharp.RenderProcess;
 
@@ -10,6 +9,8 @@ namespace CefSharp.BrowserSubprocess
 {
     /// <summary>
     /// When implementing your own BrowserSubprocess
+    /// - For Full .Net use <see cref="WcfBrowserSubprocessExecutable"/>
+    /// - For .Net Core use <see cref="BrowserSubprocessExecutable"/> (No WCF Support)
     /// - Include an app.manifest with the dpi/compatability sections, this is required (this project contains the relevant).
     /// - If you are targeting x86/Win32 then you should set /LargeAddressAware (https://docs.microsoft.com/en-us/cpp/build/reference/largeaddressaware?view=vs-2017)
     /// </summary>
@@ -17,13 +18,17 @@ namespace CefSharp.BrowserSubprocess
     {
         public static int Main(string[] args)
         {
-            Debug.WriteLine("BrowserSubprocess starting up with command line: " + String.Join("\n", args));
+            Debug.WriteLine("BrowserSubprocess starting up with command line: " + string.Join("\n", args));
 
             SubProcess.EnableHighDPISupport();
 
             //Add your own custom implementation of IRenderProcessHandler here
             IRenderProcessHandler handler = null;
 
+            //The WcfBrowserSubprocessExecutable provides BrowserSubProcess functionality
+            //specific to CefSharp, WCF support (required for Sync JSB) will optionally be
+            //enabled if the CefSharpArguments.WcfEnabledArgument command line arg is present
+            //For .Net Core use BrowserSubprocessExecutable as there is no WCF support
             var browserProcessExe = new WcfBrowserSubprocessExecutable();
             var result = browserProcessExe.Main(args, handler);
 

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -103,6 +103,7 @@
     <Compile Include="DefaultApp.cs" />
     <Compile Include="Enums\SchemeOptions.cs" />
     <Compile Include="Internals\CommandLineArgDictionary.cs" />
+    <Compile Include="Internals\ParentProcessMonitor.cs" />
     <Compile Include="Internals\ReadOnlyNameValueCollection.cs" />
     <Compile Include="Internals\TaskScheduler\LimitedConcurrencyLevelTaskScheduler.cs" />
     <Compile Include="IUrlRequest.cs" />

--- a/CefSharp/Internals/ParentProcessMonitor.cs
+++ b/CefSharp/Internals/ParentProcessMonitor.cs
@@ -1,0 +1,49 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace CefSharp.Internals
+{
+    /// <summary>
+    /// Monitor the parent process and exit if the parent process closes
+    /// before the subprocess. This class is used by the CefSharp.BrowserSubprocess to
+    /// self terminate if the parent dies without notifying it to exit.
+    /// See https://github.com/cefsharp/CefSharp/issues/2359 for more information.
+    /// </summary>
+    public static class ParentProcessMonitor
+    {
+        /// <summary>
+        /// Starts a long running task (spawns new thread) used to monitor the parent process
+        /// and calls <see cref="Process.Kill"/> if the parent exits unexpectedly (usually result of a crash).
+        /// </summary>
+        /// <param name="parentProcessId">process Id of the parent application</param>
+        public static void StartMonitorTask(int parentProcessId)
+        {
+            Task.Factory.StartNew(() => AwaitParentProcessExit(parentProcessId), TaskCreationOptions.LongRunning);
+        }
+
+        private static async void AwaitParentProcessExit(int parentProcessId)
+        {
+            try
+            {
+                var parentProcess = Process.GetProcessById(parentProcessId);
+                parentProcess.WaitForExit();
+            }
+            catch (Exception e)
+            {
+                //main process probably died already
+                Debug.WriteLine(e);
+            }
+
+            await Task.Delay(1000); //wait a bit before exiting
+
+            Debug.WriteLine("BrowserSubprocess shutting down forcibly.");
+
+            Process.GetCurrentProcess().Kill();
+        }
+    }
+}


### PR DESCRIPTION
Issue #2796

**Summary:**
Refactor the BrowserSubProcess so the core of it's implementation in `CefSharp.BrowserSubprocess.Core`.

**Changes:** 
- Added `BrowserSubprocessExecutable` for use with .Net Core (no WCF)
- Added `WcfBrowserSubprocessExecutable` for use with the existing CefSharp.BrowserSubprocess.exe which supports WCF (conditionally)
      
## How Has This Been Tested?
- The `Javascript Binding` tests pass (both async and sync)
- `Eval` or javascript happens correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)

**TODO**
- [x] Add comments to `WcfBrowserSubprocessExecutable`
- [ ] Consider better names for new classes (open to suggestions here)
- [x] Add comments to `Program.cs` that describe the new structure changes.