### PR TITLE
Add a ".NETCoreApp3.0" dependency to the .nuspec files

### DIFF
--- a/NuGet/CefSharp.OffScreen.nuspec
+++ b/NuGet/CefSharp.OffScreen.nuspec
@@ -15,6 +15,9 @@
       <group targetFramework=".NETFramework4.5.2">
         <dependency id="CefSharp.Common" version="[$version$]" />
       </group>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="CefSharp.Common" version="[$version$]" />
+      </group>
     </dependencies>
     <releaseNotes>
     <![CDATA[

--- a/NuGet/CefSharp.WinForms.nuspec
+++ b/NuGet/CefSharp.WinForms.nuspec
@@ -15,6 +15,9 @@
       <group targetFramework=".NETFramework4.5.2">
         <dependency id="CefSharp.Common" version="[$version$]" />
       </group>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="CefSharp.Common" version="[$version$]" />
+      </group>
     </dependencies>
     <releaseNotes>
     <![CDATA[

--- a/NuGet/CefSharp.Wpf.nuspec
+++ b/NuGet/CefSharp.Wpf.nuspec
@@ -15,6 +15,9 @@
       <group targetFramework=".NETFramework4.5.2">
         <dependency id="CefSharp.Common" version="[$version$]" />
       </group>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="CefSharp.Common" version="[$version$]" />
+      </group>
     </dependencies>
     <releaseNotes>
     <![CDATA[


### PR DESCRIPTION
Issue #2796

**Summary:** 
   - Added a `.NETCoreApp3.0` dependency to the .nuspec files.

**Changes:**
   - Added `<group targetFramework=".NETCoreApp3.0">` to `CefSharp.OffScreen.nuspec`, `CefSharp.WinForms.nuspec` and `CefSharp.Wpf.nuspec`.
This ensures the transitive dependencies (CefSharp.Common) will be resolved in .NET Core 3.0 projects, when adding only `CefSharp.WinForms`, `CefSharp.WPF` or `CefSharp.OffScreen` via `<PackageReference>`.
      
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, operating system, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running `build.ps1`, and then using the built `.nupkg` packages (via local NuGet package source) in the `CefSharp.MinimalExample.NetCore.*` projects (see https://github.com/cefsharp/CefSharp.MinimalExample/pull/57) and removing the package reference to `CefSharp.Common`.

## Screenshots (if appropriate):
![grafik](https://user-images.githubusercontent.com/13289184/64440893-1d4d7780-d0cd-11e9-9db7-cf22995aaa72.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
