### PR TITLE
Adjust references in .props files for .NET Core projects

### DIFF
--- a/NuGet/CefSharp.Common.props
+++ b/NuGet/CefSharp.Common.props
@@ -14,11 +14,17 @@
       <ItemGroup>
         <Reference Include="CefSharp">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
         <Reference Include="CefSharp.Core">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Core.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
+        </Reference>
+      </ItemGroup>      
+      <!-- Additional references for .NET Core -->
+      <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+        <Reference Include="CefSharp.BrowserSubprocess.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.BrowserSubprocess.Core.dll</HintPath>
         </Reference>
       </ItemGroup>
     </When>
@@ -27,11 +33,17 @@
       <ItemGroup>
         <Reference Include="CefSharp">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
         <Reference Include="CefSharp.Core">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
+        </Reference>
+      </ItemGroup>      
+      <!-- Additional references for .NET Core -->
+      <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+        <Reference Include="CefSharp.BrowserSubprocess.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.BrowserSubprocess.Core.dll</HintPath>
         </Reference>
       </ItemGroup>
     </Otherwise>

--- a/NuGet/CefSharp.OffScreen.props
+++ b/NuGet/CefSharp.OffScreen.props
@@ -12,7 +12,7 @@
       <ItemGroup>
         <Reference Include="CefSharp.OffScreen">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.OffScreen.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
       </ItemGroup>
     </When>
@@ -21,7 +21,7 @@
       <ItemGroup>
         <Reference Include="CefSharp.OffScreen">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.OffScreen.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
       </ItemGroup>
     </Otherwise>

--- a/NuGet/CefSharp.WinForms.props
+++ b/NuGet/CefSharp.WinForms.props
@@ -12,7 +12,7 @@
       <ItemGroup>
         <Reference Include="CefSharp.WinForms">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.WinForms.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
       </ItemGroup>
     </When>
@@ -21,7 +21,7 @@
       <ItemGroup>
         <Reference Include="CefSharp.WinForms">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.WinForms.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
       </ItemGroup>
     </Otherwise>

--- a/NuGet/CefSharp.Wpf.props
+++ b/NuGet/CefSharp.Wpf.props
@@ -12,7 +12,7 @@
       <ItemGroup>
         <Reference Include="CefSharp.Wpf">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Wpf.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
       </ItemGroup>
     </When>
@@ -21,7 +21,7 @@
       <ItemGroup>
         <Reference Include="CefSharp.Wpf">
           <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
-          <Private>False</Private>
+          <Private Condition="!$(TargetFramework.StartsWith('netcoreapp'))">False</Private>
         </Reference>
       </ItemGroup>
     </Otherwise>


### PR DESCRIPTION
Issue #2796

**Summary:**
   - Adjusted the `<Reference>` elements in the NuGet `.props` file for better .NET Core support

**Changes:**
   - For .NET Core projects, a reference to `CefSharp.BrowserSubprocess.Core` is added, so that the app executable can run the subprocess logic (after #2891 is done).
   - `<Private>False</Private>` is no longer specified for the CefSharp assemblies in .NET Core projects, as otherwise these references would not be added to the generated `.deps.json` file and the CoreCLR wouldn't load them.
  (Note that this probably means we cannot support `AnyCPU` for .NET Core, but I think we can ignore that for now because e.g. when you publish a self-contained .NET Core application, it will already be platform-specific.)

Note: The `CefSharp.BrowserSubprocess.exe` file (using .NET Framework 4.5.2) is still copied to the output directory for .NET Core projects.
      
## How Has This Been Tested?
Tested by running `build.ps1`, and then using the built `.nupkg` packages (via local NuGet package source) in the `CefSharp.MinimalExample.NetCore.*` projects (see cefsharp/CefSharp.MinimalExample#57), and removing the `<Reference Update="CefSharp">` elements to verify the assemblies are correctly loaded by the runtime.
Additionally, I tested the new packages with the existing `CefSharp.MinimalExample.*` projects to verify classic .NET Framework projects using `packages.config` still work as expected.

## Screenshots (if appropriate):
![grafik](https://user-images.githubusercontent.com/13289184/64456370-521ef600-d0f0-11e9-8cea-f7563ad01d72.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
