### PR TITLE
build.ps1 - escape commas for PowerShell

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -328,8 +328,8 @@ function UpdateSymbolsWithGitLink()
     Write-Diagnostic "GitLink working dir : $WorkingDir"
     
     # Run GitLink in the workingDir
-    . $gitlink $WorkingDir -f CefSharp3.sln -u https://github.com/CefSharp/CefSharp -c Release -p x64 -ignore CefSharp.Example,CefSharp.Wpf.Example,CefSharp.OffScreen.Example,CefSharp.WinForms.Example
-    . $gitlink $WorkingDir -f CefSharp3.sln -u https://github.com/CefSharp/CefSharp -c Release -p x86 -ignore CefSharp.Example,CefSharp.Wpf.Example,CefSharp.OffScreen.Example,CefSharp.WinForms.Example
+    . $gitlink $WorkingDir -f CefSharp3.sln -u https://github.com/CefSharp/CefSharp -c Release -p x64 -ignore CefSharp.Example`,CefSharp.Wpf.Example`,CefSharp.OffScreen.Example`,CefSharp.WinForms.Example
+    . $gitlink $WorkingDir -f CefSharp3.sln -u https://github.com/CefSharp/CefSharp -c Release -p x86 -ignore CefSharp.Example`,CefSharp.Wpf.Example`,CefSharp.OffScreen.Example`,CefSharp.WinForms.Example
 }
 
 function WriteAssemblyVersion


### PR DESCRIPTION
Fixes https://github.com/cefsharp/CefSharp/issues/2395#issuecomment-411751223 from @ray007

**Summary:**
   - Resolves errors of the form:
```
Could not parse command line parameter 'CefSharp.Wpf.Example'.
An unexpected error occurred | [GitLinkException] GitLink.GitLinkException: Could not parse command line parameter 'CefSharp.Wpf.Example'.
   at GitLink.ArgumentParser.ParseArguments(List`1 commandLineArguments, IProviderManager providerManager)
   at GitLink.Program.Main(String[] args)
```

**Changes:**
   - Escape commas in GitLink command line for PowerShell
      
## How Has This Been Tested?
   - Ran build.ps1. Ensured `GitLinkException` did not appear.

## Screenshots (if appropriate):
   - N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code (if applicable)
- [-] Commented my code
- [-] Changed the documentation (if applicable)
- [-] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)

Wasn't sure whether you'd prefer this against `master` or latest release `cefsharp/75`. I can create a new PR for `master` if you'd prefer.