### PR TITLE
Nuget - Update targets to use <ContentWithTargetPath/>

### DIFF
--- a/CefSharp3.sln
+++ b/CefSharp3.sln
@@ -49,8 +49,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{A23AA466
 		NuGet\CefSharp.OffScreen.props = NuGet\CefSharp.OffScreen.props
 		NuGet\CefSharp.WinForms.nuspec = NuGet\CefSharp.WinForms.nuspec
 		NuGet\CefSharp.WinForms.props = NuGet\CefSharp.WinForms.props
+		NuGet\CefSharp.WinForms.targets = NuGet\CefSharp.WinForms.targets
 		NuGet\CefSharp.Wpf.nuspec = NuGet\CefSharp.Wpf.nuspec
 		NuGet\CefSharp.Wpf.props = NuGet\CefSharp.Wpf.props
+		NuGet\CefSharp.Wpf.targets = NuGet\CefSharp.Wpf.targets
 		NuGet\Readme.txt = NuGet\Readme.txt
 	EndProjectSection
 EndProject

--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -19,43 +19,43 @@
    -->
 
   <ItemGroup Condition="('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
-    <None Include="@(CefRedist32)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    <ContentWithTargetPath Include="@(CefRedist32)">
+      <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="@(CefSharpCommonBinaries32)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="@(CefSharpCommonBinaries32)">
+      <TargetPath>%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </ContentWithTargetPath>
   </ItemGroup>
 
   <ItemGroup Condition="'$(Platform)' == 'x64'">
-    <None Include="@(CefRedist64)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    <ContentWithTargetPath Include="@(CefRedist64)">
+      <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="@(CefSharpCommonBinaries64)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="@(CefSharpCommonBinaries64)">
+      <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </ContentWithTargetPath>
   </ItemGroup>
 
   <ItemGroup Condition="'$(Platform)' == 'AnyCPU'">
-    <None Include="@(CefRedist32)">
-      <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    <ContentWithTargetPath Include="@(CefRedist32)">
+      <TargetPath>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="@(CefRedist64)">
-      <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="@(CefRedist64)">
+      <TargetPath>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="@(CefSharpCommonBinaries32)">
-      <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="@(CefSharpCommonBinaries32)">
+      <TargetPath>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="@(CefSharpCommonBinaries64)">
-      <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="@(CefSharpCommonBinaries64)">
+      <TargetPath>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </ContentWithTargetPath>
   </ItemGroup>
 </Project>

--- a/NuGet/CefSharp.WinForms.targets
+++ b/NuGet/CefSharp.WinForms.targets
@@ -14,31 +14,31 @@
   <Choose>
     <When Condition="'$(Platform)' == 'AnyCPU'">
       <ItemGroup>
-        <None Include="@(CefSharpWinFormsBinaries32)">
-          <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <ContentWithTargetPath Include="@(CefSharpWinFormsBinaries32)">
+          <TargetPath>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <None Include="@(CefSharpWinFormsBinaries64)">
-          <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        </ContentWithTargetPath>
+        <ContentWithTargetPath Include="@(CefSharpWinFormsBinaries64)">
+          <TargetPath>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
+        </ContentWithTargetPath>
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'x64'">
       <ItemGroup>
-        <None Include="@(CefSharpWinFormsBinaries64)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <ContentWithTargetPath Include="@(CefSharpWinFormsBinaries64)">
+          <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
+        </ContentWithTargetPath>
       </ItemGroup>
     </When>
     <!-- x86, and Win32 -->
     <Otherwise>
       <ItemGroup>
-        <None Include="@(CefSharpWinFormsBinaries32)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <ContentWithTargetPath Include="@(CefSharpWinFormsBinaries32)">
+          <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
+        </ContentWithTargetPath>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/NuGet/CefSharp.Wpf.targets
+++ b/NuGet/CefSharp.Wpf.targets
@@ -14,31 +14,31 @@
   <Choose>
     <When Condition="'$(Platform)' == 'AnyCPU'">
       <ItemGroup>
-        <None Include="@(CefSharpWpfBinaries32)">
-          <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <ContentWithTargetPath Include="@(CefSharpWpfBinaries32)">
+          <TargetPath>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <None Include="@(CefSharpWpfBinaries64)">
-          <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        </ContentWithTargetPath>
+        <ContentWithTargetPath Include="@(CefSharpWpfBinaries64)">
+          <TargetPath>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
+        </ContentWithTargetPath>
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'x64'">
       <ItemGroup>
-        <None Include="@(CefSharpWpfBinaries64)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <ContentWithTargetPath Include="@(CefSharpWpfBinaries64)">
+          <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
+        </ContentWithTargetPath>
       </ItemGroup>
     </When>    
     <!-- x86, and Win32 -->
     <Otherwise>
       <ItemGroup>
-        <None Include="@(CefSharpWpfBinaries32)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <ContentWithTargetPath Include="@(CefSharpWpfBinaries32)">
+          <TargetPath>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
+        </ContentWithTargetPath>
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
replace None with ContentWithTargetPath

Fixes #2456 

**Summary:** [summary of the change and which issue is fixed here]
- modify “None” to  "ContentWithTargetPath" in nuget floder

**Changes:** 
- modify CefSharp.Common.targets
- modify CefSharp.WinForms.targets
- modify CefSharp.Wpf.targets
- add winform/wpf .targets file to nuget folder
      
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, operating system, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
before change:
![image](https://user-images.githubusercontent.com/80653/65759991-bca2df00-e14e-11e9-8ff7-0b101e54c702.png)
after change:
![image](https://user-images.githubusercontent.com/80653/65759938-a09f3d80-e14e-11e9-9e49-8e87441d7cf9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
