### PR TITLE
Add support for compiling with Visual studio 2019

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -23,7 +23,7 @@
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
     "Microsoft.VisualStudio.Component.VC.CLI.Support",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
     "Microsoft.VisualStudio.Workload.NativeDesktop"
   ]
 }

--- a/CefSharp.props
+++ b/CefSharp.props
@@ -5,14 +5,14 @@
     <VisualStudioProductVersion>2013</VisualStudioProductVersion>
     <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='14.0'">2015</VisualStudioProductVersion>
     <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='15.0'">2017</VisualStudioProductVersion>
-    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='16.0'">2017</VisualStudioProductVersion>
+    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='16.0'">2019</VisualStudioProductVersion>
 
     <PlatformToolset>v120</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
 	
-	<WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'=='16.0'">10.0.17763.0</WindowsTargetPlatformVersion>
+	<WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'=='16.0'">10.0.18362.0</WindowsTargetPlatformVersion>
     
     <CefSharpBrowserSubprocessPostBuildEvent>
       <![CDATA[


### PR DESCRIPTION
Bumped sdk to 18362 CEF 77 now requires that version but we could lower it is desired.
Does not default to building with it.

Resolves #2628