### PR TITLE
WPF - Ensure ZoomLevelProperty is updated on UI thread when Visibility Changed

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2026,7 +2026,7 @@ namespace CefSharp.Wpf
                     }
                 });
 
-                if (browser != null)
+                if (browser != null) 
                 {
                     //Fix for #1778 - When browser becomes visible we update the zoom level
                     //browsers of the same origin will share the same zoomlevel and
@@ -2034,11 +2034,16 @@ namespace CefSharp.Wpf
                     //properly
                     var zoomLevel = await browser.GetHost().GetZoomLevelAsync();
 
-                    if (!IsDisposed)
+                    if (!IsDisposed) 
                     {
-                        SetCurrentValue(ZoomLevelProperty, zoomLevel);
+                        await Dispatcher.BeginInvoke(new Action(() => 
+                        {
+                            if (!IsDisposed) 
+                            {
+                                SetCurrentValue(ZoomLevelProperty, zoomLevel);
+                            }
+                        }));
                     }
-
                 }
             }
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2026,7 +2026,7 @@ namespace CefSharp.Wpf
                     }
                 });
 
-                if (browser != null) 
+                if (browser != null)
                 {
                     //Fix for #1778 - When browser becomes visible we update the zoom level
                     //browsers of the same origin will share the same zoomlevel and
@@ -2036,13 +2036,13 @@ namespace CefSharp.Wpf
 
                     if (!IsDisposed) 
                     {
-                        await Dispatcher.BeginInvoke(new Action(() => 
+                        UiThreadRunAsync(() => 
                         {
                             if (!IsDisposed) 
                             {
                                 SetCurrentValue(ZoomLevelProperty, zoomLevel);
                             }
-                        }));
+                        });
                     }
                 }
             }


### PR DESCRIPTION
Fixes crash in OnVisibilityChanged method
   - Call stack:
Unhandled Exception: System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it.
at System.Windows.Threading.Dispatcher.VerifyAccess()
at System.Windows.DependencyObject.SetCurrentValue(DependencyProperty dp, Object value)
at CefSharp.Wpf.ChromiumWebBrowser.<OnIsVisibleChanged>d__325.MoveNext() in C:\projects\cefsharp\CefSharp.Wpf\ChromiumWebBrowser.cs:line 2039

**Summary:**
   - Fixed a crash on the OnVisibilityChanged method, due to the Zoom dependency property being set on a thread other than the dispatcher thread

**Changes:**
   - Set property on the dispatcher thread
      
## How Has This Been Tested?
   - Manual testing (switching tabs)