### PR TITLE
WPF - Implement PerMonitorV2 dpiAwareness

### DIFF
--- a/CefSharp.Wpf.Example/app.manifest
+++ b/CefSharp.Wpf.Example/app.manifest
@@ -29,8 +29,9 @@
   </trustInfo>
 
   <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true/PM</dpiAware>
+    <asmv3:windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
 

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1743,6 +1743,8 @@ namespace CefSharp.Wpf
 
                 monitorInfo.Init();
                 MonitorInfo.GetMonitorInfoForWindowHandle(source.Handle, ref monitorInfo);
+
+                source.AddHook(DpiChangedHook);
             }
             else if (args.OldSource != null)
             {
@@ -1755,6 +1757,8 @@ namespace CefSharp.Wpf
                     window.LocationChanged -= OnWindowLocationChanged;
                     sourceWindow = null;
                 }
+
+                (args.OldSource as HwndSource)?.RemoveHook(DpiChangedHook);
             }
         }
 
@@ -2033,6 +2037,17 @@ namespace CefSharp.Wpf
 
             //Initial value for screen location
             browserScreenLocation = GetBrowserScreenLocation();
+        }
+
+        private IntPtr DpiChangedHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            int WM_DPICHANGED = 0x02E0;
+            if (msg == WM_DPICHANGED)
+            {
+                var dpi = wParam.CastToInt32() & 0xffff;
+                NotifyDpiChange(dpi / 96);
+            }
+            return IntPtr.Zero;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes [issue-number] 
   -  Fixes #1535

**Summary:**
   - Implement PerMonitorV2 dpiAwareness

**Changes:**
   - Add a hook to handle `WM_DPICHANGED` message.
   - Change dpiAwareness to PerMonitorV2 in `app.manifest`.
      
## How Has This Been Tested?
I tested it on a 4k screen with dpi from 100% to 350%, and it works fine.
And I tested it at a computer with two screen which has different dpi, and it also works fine when moving between screens.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
