### PR TITLE
Fix all C6246 warnings: Local declaration hides declaration of the same name in outer scope.

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -241,15 +241,15 @@ namespace CefSharp
         auto frames = CefListValue::Create();
         for (auto i = 0; i < stackTrace->GetFrameCount(); i++)
         {
-            auto frame = CefListValue::Create();
+            auto stackTraceFrame = CefListValue::Create();
             auto frameArg = stackTrace->GetFrame(i);
 
-            frame->SetString(0, frameArg->GetFunctionName());
-            frame->SetInt(1, frameArg->GetLineNumber());
-            frame->SetInt(2, frameArg->GetColumn());
-            frame->SetString(3, frameArg->GetScriptNameOrSourceURL());
+            stackTraceFrame->SetString(0, frameArg->GetFunctionName());
+            stackTraceFrame->SetInt(1, frameArg->GetLineNumber());
+            stackTraceFrame->SetInt(2, frameArg->GetColumn());
+            stackTraceFrame->SetString(3, frameArg->GetScriptNameOrSourceURL());
 
-            frames->SetList(i, frame);
+            frames->SetList(i, stackTraceFrame);
         }
 
         list->SetList(1, frames);
@@ -579,8 +579,8 @@ namespace CefSharp
                             for (auto i = 0; i < javascriptObjects->Count; i++)
                             {
                                 auto dict = CefDictionaryValue::Create();
-                                auto name = javascriptObjects[i]->JavascriptName;
-                                dict->SetString("Name", StringUtils::ToNative(name));
+                                auto objectName = javascriptObjects[i]->JavascriptName;
+                                dict->SetString("Name", StringUtils::ToNative(objectName));
                                 dict->SetBool("IsCached", false);
                                 dict->SetBool("AlreadyBound", false);
 

--- a/CefSharp.BrowserSubprocess.Core/RegisterBoundObjectHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/RegisterBoundObjectHandler.h
@@ -96,8 +96,6 @@ namespace CefSharp
 
                             auto objectName = arguments[0]->GetStringValue();
 
-                            auto global = context->GetGlobal();
-
                             auto success = global->DeleteValue(objectName);
 
                             retval = CefV8Value::CreateBool(success);

--- a/CefSharp.BrowserSubprocess.Core/RegisterBoundObjectHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/RegisterBoundObjectHandler.h
@@ -42,8 +42,6 @@ namespace CefSharp
                 {
                     try
                     {
-                        auto global = context->GetGlobal();
-
                         if (name == kIsObjectCached || name == kIsObjectCachedCamelCase)
                         {
                             if (arguments.size() == 0 || arguments.size() > 1)
@@ -95,6 +93,8 @@ namespace CefSharp
                             }
 
                             auto objectName = arguments[0]->GetStringValue();
+
+                            auto global = context->GetGlobal();
 
                             auto success = global->DeleteValue(objectName);
 

--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -190,9 +190,9 @@ namespace CefSharp
 
             if (handler != nullptr)
             {
-                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), isPopup);
+                auto innerBrowserWrapper = GetBrowserWrapper(browser->GetIdentifier(), isPopup);
 
-                handler->OnAfterCreated(_browserControl, browserWrapper);
+                handler->OnAfterCreated(_browserControl, innerBrowserWrapper);
             }
         }
 
@@ -1026,11 +1026,11 @@ namespace CefSharp
                     for (auto i = 0; i < boundObjects->GetSize(); i++)
                     {
                         auto obj = boundObjects->GetDictionary(i);
-                        auto name = obj->GetString("Name");
+                        auto objectName = obj->GetString("Name");
                         auto alreadyBound = obj->GetBool("AlreadyBound");
                         auto isCached = obj->GetBool("IsCached");
 
-                        objs->Add(Tuple::Create(StringUtils::ToClr(name), alreadyBound, isCached));
+                        objs->Add(Tuple::Create(StringUtils::ToClr(objectName), alreadyBound, isCached));
                     }
 
                     objectRepository->ObjectsBound(objs);
@@ -1137,13 +1137,13 @@ namespace CefSharp
 
                     for (auto i = 0; i < static_cast<int>(argFrames->GetSize()); i++)
                     {
-                        auto frame = argFrames->GetList(i);
+                        auto argFrame = argFrames->GetList(i);
 
                         auto stackFrame = gcnew JavascriptStackFrame();
-                        stackFrame->FunctionName = StringUtils::ToClr(frame->GetString(0));
-                        stackFrame->LineNumber = frame->GetInt(1);
-                        stackFrame->ColumnNumber = frame->GetInt(2);
-                        stackFrame->SourceName = StringUtils::ToClr(frame->GetString(3));
+                        stackFrame->FunctionName = StringUtils::ToClr(argFrame->GetString(0));
+                        stackFrame->LineNumber = argFrame->GetInt(1);
+                        stackFrame->ColumnNumber = argFrame->GetInt(2);
+                        stackFrame->SourceName = StringUtils::ToClr(argFrame->GetString(3));
 
                         stackTrace->Add(stackFrame);
                     }
@@ -1204,9 +1204,9 @@ namespace CefSharp
                     auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
                     CefFrameWrapper frameWrapper(frame);
 
-                    auto message = DeserializeObject(argList, 0, callbackFactory);
+                    auto deserializedMessage = DeserializeObject(argList, 0, callbackFactory);
 
-                    _browserControl->SetJavascriptMessageReceived(gcnew JavascriptMessageReceivedEventArgs(browserWrapper, %frameWrapper, message));
+                    _browserControl->SetJavascriptMessageReceived(gcnew JavascriptMessageReceivedEventArgs(browserWrapper, %frameWrapper, deserializedMessage));
                 }
 
                 handled = true;

--- a/CefSharp.Core/Internals/TypeConversion.h
+++ b/CefSharp.Core/Internals/TypeConversion.h
@@ -159,8 +159,8 @@ namespace CefSharp
                     for each (System::Collections::DictionaryEntry entry in dictionary)
                     {
                         auto key = StringUtils::ToNative(Convert::ToString(entry.Key));
-                        auto value = entry.Value;
-                        SerializeV8Object(cefDictionary, key, value);
+                        auto entryValue = entry.Value;
+                        SerializeV8Object(cefDictionary, key, entryValue);
                     }
 
                     cefValue->SetDictionary(cefDictionary);


### PR DESCRIPTION
**Summary:**

Fixing C6246  warnings. Some examples are:

- Warning	C6246	Local declaration of 'frame' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '234' of 'cefsharp.browsersubprocess.core\cefappunmanagedwrapper.cpp'.
- Warning	C6246	Local declaration of 'name' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '299' of 'cefsharp.browsersubprocess.core\cefappunmanagedwrapper.cpp'.
- Warning	C6246	Local declaration of 'global' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '45' of 'cefsharp.browsersubprocess.core\registerboundobjecthandler.h'.

These warning are frequently flagged by our build system, so it would be nice if we could push this fix into CefSharp's master branch.

**Changes:**

- Most of the fixes are simple renames for the inner scope identifiers.
- However, there is a declaration removal at CefSharp.BrowserSubprocess.Core/RegisterBoundObjectHandler.h since it seems to be redundant.
      
## How Has This Been Tested?

- Built locally with Visual Studio 2017: *Configure Code Analysis* > *Microsoft All Rules*
- All sample apps working as expected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**

- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
