### PR TITLE
Cefsharp/79

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,17 +30,17 @@ Still have a question to ask or unsure where to go next? Start with the Gitter C
 Delete this line and everything above, and then fill in the details below.
 
 - **What version of the product are you using?**
-    - What version are you using? Nuget? CI Nuget? build from a branch? If so which branch? Please include the exact version number you are using (no ambiguous statements like `Latest from Nuget`)
-e.g. 57.0.0 or 63.0.0-pre01
-    - Please only create an issue if you can reproduce the problem with the latest version. (If you are using the latest stable release please check to see if there is a newer `-pre` release and test with that also).
+    - What version are you using? Nuget? CI Nuget? build from a branch? If so please link to the relevant commit.
+	- Please include the exact version number you are using e.g. 79.1.350 (no ambiguous statements like `Latest from Nuget`)
+    - Please only create an issue if you can reproduce the problem with version 79.1.350 or greater.
 
 - **What architecture x86 or x64?**
-
+    <x86/x64>
 - **On what operating system?**
-    - Win7, Win 8, Win10, etc?
+    <Win7/Win8.1/Win10>
 
 - **Are you using `WinForms`, `WPF` or `OffScreen`?**
-
+    <WinForms/WPF/OffScreen>
 - **What steps will reproduce the problem?**
     - Please provide detailed information here, enough for someone else to reprodce your problem.
     - Please no binary (zip, etc) links, fork the [MinimalExample](https://github.com/cefsharp/CefSharp.MinimalExample) and push your changes to `GitHub`. (Alternatively use a code sharing service list `Gist` or `Pastebin`).
@@ -54,9 +54,11 @@ e.g. 57.0.0 or 63.0.0-pre01
 
     - Any other background information that's relevant? Are you doing something out of the ordinary? 3rd party controls?
 
-- **Does this problem also occur in the `CEF` Sample Application from http://opensource.spotify.com/cefbuilds/index.html?**
-
-    - To compare with WPF/OffScreen run cefclient --multi-threaded-message-loop --off-screen-rendering-enabled --enable-gpu
-    - To compare with WinForms run cefclient --multi-threaded-message-loop
+- **Does this problem also occur in the `CEF` Sample Application**
+    - Download one of the following:
+	    - For x86 download http://opensource.spotify.com/cefbuilds/cef_binary_79.1.35%2Bgfebbb4a%2Bchromium-79.0.3945.130_windows32_client.tar.bz2
+	    - For x64 download http://opensource.spotify.com/cefbuilds/cef_binary_79.1.35%2Bgfebbb4a%2Bchromium-79.0.3945.130_windows64_client.tar.bz2
+	- If you are using WPF/OffScreen run cefclient --multi-threaded-message-loop --off-screen-rendering-enabled --enable-gpu
+    - If you are using WinForms run cefclient --multi-threaded-message-loop
+	- **MAKE SURE TO TEST WITH THE COMMAND LINE ARGS LISTED ABOVE**
     - If you can reproduce the problem with `cefclient` then you'll need to report the bug on https://bitbucket.org/chromiumembedded/cef/overview there is no point opening an issue here. (Make sure you search before opening an issue)
-    - Please include the version you tested with e.g. `cef_binary_3.3029.1611.g44e39a8_windows64_client.tar.bz2`. It's important to you test with the same version that `CefSharp` is based on. Check the release notes to determine the version (https://github.com/cefsharp/CefSharp/releases) or load `chrome://version` in the browser.

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.79.1.35\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.35\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.79.1.36\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.36\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.79.1.31\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.31\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.79.1.35\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.35\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/CefSharp.BrowserSubprocess.Core/packages.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="79.1.35" targetFramework="native" />
+  <package id="cef.sdk" version="79.1.36" targetFramework="native" />
 </packages>

--- a/CefSharp.BrowserSubprocess.Core/packages.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="79.1.31" targetFramework="native" />
+  <package id="cef.sdk" version="79.1.35" targetFramework="native" />
 </packages>

--- a/CefSharp.Core/AbstractCefSettings.h
+++ b/CefSharp.Core/AbstractCefSettings.h
@@ -404,7 +404,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set command line argument to disable GPU Acceleration, this will disable WebGL.
+        /// Set command line argument to disable GPU Acceleration. WebGL will use
+		/// software rendering via Swiftshader (https://swiftshader.googlesource.com/SwiftShader#introduction)
         /// </summary>
         void DisableGpuAcceleration()
         {
@@ -427,14 +428,14 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set command line arguments for best OSR (Offscreen and WPF) Rendering performance This will disable WebGL, look at the source
-        /// to determine which flags best suite your requirements.
+        /// Set command line arguments for best OSR (Offscreen and WPF) Rendering performance Swiftshader will be used for WebGL, look at the source
+        /// to determine which flags best suite your requirements. See https://swiftshader.googlesource.com/SwiftShader#introduction for
+		/// details on Swiftshader
         /// </summary>
         void SetOffScreenRenderingBestPerformanceArgs()
         {
             // Use software rendering and compositing (disable GPU) for increased FPS
-            // and decreased CPU usage. This will also disable WebGL so remove these
-            // switches if you need that capability.
+            // and decreased CPU usage. 
             // See https://bitbucket.org/chromiumembedded/cef/issues/1257 for details.
             if (!_cefCommandLineArgs->ContainsKey("disable-gpu"))
             {

--- a/CefSharp.Core/AbstractCefSettings.h
+++ b/CefSharp.Core/AbstractCefSettings.h
@@ -12,22 +12,33 @@ using namespace System::IO;
 namespace CefSharp
 {
     /// <summary>
-    /// Initialization settings. Many of these and other settings can also configured
-    /// using command-line switches.
+    /// Initialization settings. Many of these and other settings can also configured using command-line switches.
     /// </summary>
     public ref class AbstractCefSettings abstract
     {
     private:
+        /// <summary>
+        /// CEF V8 Extensions
+        /// </summary>
         List<V8Extension^>^ _cefExtensions;
+        /// <summary>
+        /// Command Line Arguments Dictionary. 
+        /// </summary>
         CommandLineArgDictionary^ _cefCommandLineArgs;
 
     internal:
+        /// <summary>
+        /// CefSettings unmanaged pointer
+        /// </summary>
         ::CefSettings* _cefSettings;
+        /// <summary>
+        /// CefCustomScheme collection
+        /// </summary>
         List<CefCustomScheme^>^ _cefCustomSchemes;
 
     public:
         /// <summary>
-        /// Default Constructor
+        /// Default Constructor.
         /// </summary>
         AbstractCefSettings() : _cefSettings(new ::CefSettings())
         {
@@ -47,18 +58,24 @@ namespace CefSharp
             _cefCommandLineArgs->Add("disable-site-isolation-trials");
         }
 
+        /// <summary>
+        /// Finalizer.
+        /// </summary>
         !AbstractCefSettings()
         {
             delete _cefSettings;
         }
 
+        /// <summary>
+        /// Destructor.
+        /// </summary>
         ~AbstractCefSettings()
         {
             this->!AbstractCefSettings();
         }
 
         /// <summary>
-        /// Add Customs schemes to this collection
+        /// Add Customs schemes to this collection.
         /// </summary>
         property IEnumerable<CefCustomScheme^>^ CefCustomSchemes
         {
@@ -66,8 +83,7 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// List of all V8Extensions to be registered using CefRegisterExtension
-        /// in the render process.
+        /// List of all V8Extensions to be registered using CefRegisterExtension in the render process.
         /// </summary>
         virtual property IEnumerable<V8Extension^>^ Extensions
         {
@@ -75,9 +91,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Add custom command line argumens to this collection, they will be
-        /// added in OnBeforeCommandLineProcessing.
-        // The CefSettings.command_line_args_disabled value can be used to start with an empty command-line object. Any values specified in CefSettings that equate to command-line arguments will be set before this method is called.
+        /// Add custom command line argumens to this collection, they will be added in OnBeforeCommandLineProcessing. The
+        /// CefSettings.CommandLineArgsDisabled value can be used to start with an empty command-line object. Any values specified in
+        /// CefSettings that equate to command-line arguments will be set before this method is called.
         /// </summary>
         virtual property CommandLineArgDictionary^ CefCommandLineArgs
         {
@@ -85,9 +101,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to true to disable configuration of browser process features using
-        /// standard CEF and Chromium command-line arguments. Configuration can still
-        /// be specified using CEF data structures or by adding to CefCommandLineArgs
+        /// Set to true to disable configuration of browser process features using standard CEF and Chromium command-line arguments.
+        /// Configuration can still be specified using CEF data structures or by adding to CefCommandLineArgs.
         /// </summary>
         property bool CommandLineArgsDisabled
         {
@@ -96,14 +111,11 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to true to control browser process main (UI) thread message pump
-        /// scheduling via the IBrowserProcessHandler.OnScheduleMessagePumpWork
-        /// callback. This option is recommended for use in combination with the
-        /// Cef.DoMessageLoopWork() function in cases where the CEF message loop must be
-        /// integrated into an existing application message loop (see additional
-        /// comments and warnings on Cef.DoMessageLoopWork). Enabling this option is not
-        /// recommended for most users; leave this option disabled and use either
-        /// MultiThreadedMessageLoop (the default) if possible.
+        /// Set to true to control browser process main (UI) thread message pump scheduling via the
+        /// IBrowserProcessHandler.OnScheduleMessagePumpWork callback. This option is recommended for use in combination with the
+        /// Cef.DoMessageLoopWork() function in cases where the CEF message loop must be integrated into an existing application message
+        /// loop (see additional comments and warnings on Cef.DoMessageLoopWork). Enabling this option is not recommended for most users;
+        /// leave this option disabled and use either MultiThreadedMessageLoop (the default) if possible.
         /// </summary>
         property bool ExternalMessagePump
         {
@@ -112,10 +124,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to true to have the browser process message loop run in a separate
-        /// thread. If false than the CefDoMessageLoopWork() function must be
-        /// called from your application message loop. This option is only supported on
-        /// Windows. The default value is true
+        /// Set to true to have the browser process message loop run in a separate thread. If false than the CefDoMessageLoopWork()
+        /// function must be called from your application message loop. This option is only supported on Windows. The default value is
+        /// true.
         /// </summary>
         property bool MultiThreadedMessageLoop
         {
@@ -124,10 +135,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The path to a separate executable that will be launched for sub-processes.
-        /// By default the browser process executable is used. See the comments on
-        /// Cef.ExecuteProcess() for details. Also configurable using the
-        /// "browser-subprocess-path" command-line switch. Default is CefSharp.BrowserSubprocess.exe
+        /// The path to a separate executable that will be launched for sub-processes. By default the browser process executable is used.
+        /// See the comments on Cef.ExecuteProcess() for details. Also configurable using the "browser-subprocess-path" command-line
+        /// switch. Default is CefSharp.BrowserSubprocess.exe.
         /// </summary>
         property String^ BrowserSubprocessPath
         {
@@ -136,13 +146,11 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The location where data for the global browser cache will be stored on disk.
-        /// In non-empty this must be either equal to or a child directory of CefSettings.RootCachePath
-        /// (if RootCachePath is empty it will default to this value).
-        /// If empty then browsers will be created in "incognito mode" where in-memory caches are used
-        /// for storage and no data is persisted to disk. HTML5 databases such as localStorage will
-        /// only persist across sessions if a cache path is specified. Can be overridden for individual
-        /// RequestContext instances via the RequestContextSettings.CachePath value.
+        /// The location where data for the global browser cache will be stored on disk. In non-empty this must be either equal to or a
+        /// child directory of CefSettings.RootCachePath (if RootCachePath is empty it will default to this value). If empty then
+        /// browsers will be created in "incognito mode" where in-memory caches are used for storage and no data is persisted to disk.
+        /// HTML5 databases such as localStorage will only persist across sessions if a cache path is specified. Can be overridden for
+        /// individual RequestContext instances via the RequestContextSettings.CachePath value.
         /// </summary>
         property String^ CachePath
         {
@@ -151,13 +159,11 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The root directory that all CefSettings.CachePath and RequestContextSettings.CachePath values
-        /// must have in common. If this value is empty and CefSettings.CachePath is non-empty then this
-        /// value will default to the CefSettings.CachePath value. Failure to set this value correctly
-        /// may result in the sandbox blocking read/write access to the CachePath directory.
-        /// NOTE: CefSharp does not implement the CHROMIUM SANDBOX.
-        /// A non-empty RootCachePath can be used in conjuncation with an empty CefSettings.CachePath
-        /// in instances where you would like browsers attached to the Global RequestContext (the default)
+        /// The root directory that all CefSettings.CachePath and RequestContextSettings.CachePath values must have in common. If this
+        /// value is empty and CefSettings.CachePath is non-empty then this value will default to the CefSettings.CachePath value.
+        /// Failure to set this value correctly may result in the sandbox blocking read/write access to the CachePath directory. NOTE:
+        /// CefSharp does not implement the CHROMIUM SANDBOX. A non-empty RootCachePath can be used in conjuncation with an empty
+        /// CefSettings.CachePath in instances where you would like browsers attached to the Global RequestContext (the default)
         /// created in "incognito mode" and instances created with a custom RequestContext using a disk based cache.
         /// </summary>
         property String^ RootCachePath
@@ -167,11 +173,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The location where user data such as spell checking dictionary files will
-        /// be stored on disk. If empty then the default platform-specific user data
-        /// directory will be used ("~/.cef_user_data" directory on Linux,
-        /// "~/Library/Application Support/CEF/User Data" directory on Mac OS X,
-        /// "Local Settings\Application Data\CEF\User Data" directory under the user
+        /// The location where user data such as spell checking dictionary files will be stored on disk. If empty then the default
+        /// platform-specific user data directory will be used ("Local Settings\Application Data\CEF\User Data" directory under the user
         /// profile directory on Windows).
         /// </summary>
         property String^ UserDataPath
@@ -181,8 +184,7 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to true in order to completely ignore SSL certificate errors.
-        /// This is NOT recommended.
+        /// Set to true in order to completely ignore SSL certificate errors. This is NOT recommended.
         /// </summary>
         property bool IgnoreCertificateErrors
         {
@@ -191,9 +193,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The locale string that will be passed to WebKit. If empty the default
-        /// locale of "en-US" will be used. Also configurable using the "lang"
-        /// command-line switch.
+        /// The locale string that will be passed to WebKit. If empty the default locale of "en-US" will be used. Also configurable using
+        /// the "lang" command-line switch.
         /// </summary>
         property String^ Locale
         {
@@ -202,9 +203,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The fully qualified path for the locales directory. If this value is empty
-        /// the locales directory must be located in the module directory.
-        /// Also configurable using the "locales-dir-path" command-line switch.
+        /// The fully qualified path for the locales directory. If this value is empty the locales directory must be located in the
+        /// module directory. Also configurable using the "locales-dir-path" command-line switch.
         /// </summary>
         property String^ LocalesDirPath
         {
@@ -213,10 +213,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The fully qualified path for the resources directory. If this value is
-        /// empty the cef.pak and/or devtools_resources.pak files must be located in
-        /// the module directory. Also configurable using the "resources-dir-path" command-line
-        /// switch.
+        /// The fully qualified path for the resources directory. If this value is empty the cef.pak and/or devtools_resources.pak files
+        /// must be located in the module directory. Also configurable using the "resources-dir-path" command-line switch.
         /// </summary>
         property String^ ResourcesDirPath
         {
@@ -225,10 +223,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The directory and file name to use for the debug log. If empty a default
-        /// log file name and location will be used. On Windows and Linux a "debug.log"
-        /// file will be written in the main executable directory.
-        /// Also configurable using the"log-file" command-line switch.
+        /// The directory and file name to use for the debug log. If empty a default log file name and location will be used. On Windows
+        /// a "debug.log" file will be written in the main executable directory. Also configurable using the"log-file" command- line
+        /// switch.
         /// </summary>
         property String^ LogFile
         {
@@ -237,10 +234,10 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The log severity. Only messages of this severity level or higher will be
-        /// logged. When set to <see cref="CefSharp.LogSeverity.Disable"/> no messages will be written to the log file,
-        /// but Fatal messages will still be output to stderr. Also configurable using the "log-severity" command-line switch with
-        /// a value of "verbose", "info", "warning", "error", "fatal", "error-report" or "disable".
+        /// The log severity. Only messages of this severity level or higher will be logged. When set to
+        /// <see cref="CefSharp::LogSeverity::Disable"/> no messages will be written to the log file, but Fatal messages will still be
+        /// output to stderr. Also configurable using the "log-severity" command-line switch with a value of "verbose", "info", "warning",
+        /// "error", "fatal", "error-report" or "disable".
         /// </summary>
         property CefSharp::LogSeverity LogSeverity
         {
@@ -249,9 +246,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Custom flags that will be used when initializing the V8 JavaScript engine.
-        /// The consequences of using custom flags may not be well tested. Also
-        /// configurable using the "js-flags" command-line switch.
+        /// Custom flags that will be used when initializing the V8 JavaScript engine. The consequences of using custom flags may not be
+        /// well tested. Also configurable using the "js-flags" command-line switch.
         /// </summary>
         property String^ JavascriptFlags
         {
@@ -260,11 +256,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to true to disable loading of pack files for resources and locales.
-        /// A resource bundle handler must be provided for the browser and render
-        /// processes via CefApp::GetResourceBundleHandler() if loading of pack files
-        /// is disabled. Also configurable using the "disable-pack-loading" command-
-        /// line switch.
+        /// Set to true to disable loading of pack files for resources and locales. A resource bundle handler must be provided for the
+        /// browser and render processes via CefApp::GetResourceBundleHandler() if loading of pack files is disabled. Also configurable
+        /// using the "disable-pack-loading" command- line switch.
         /// </summary>
         property bool PackLoadingDisabled
         {
@@ -273,10 +267,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Value that will be inserted as the product portion of the default
-        /// User-Agent string. If empty the Chromium product version will be used. If
-        /// |userAgent| is specified this value will be ignored. Also configurable
-        /// using the "product-version" command-line switch.
+        /// Value that will be inserted as the product portion of the default User-Agent string. If empty the Chromium product version
+        /// will be used. If UserAgent is specified this value will be ignored. Also configurable using the "product-version" command-
+        /// line switch.
         /// </summary>
         property String^ ProductVersion
         {
@@ -285,11 +278,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to a value between 1024 and 65535 to enable remote debugging on the
-        /// specified port. For example, if 8080 is specified the remote debugging URL
-        /// will be http://localhost:8080. CEF can be remotely debugged from any CEF or
-        /// Chrome browser window. Also configurable using the "remote-debugging-port"
-        /// command-line switch.
+        /// Set to a value between 1024 and 65535 to enable remote debugging on the specified port. For example, if 8080 is specified the
+        /// remote debugging URL will be http://localhost:8080. CEF can be remotely debugged from any CEF or Chrome browser window. Also
+        /// configurable using the "remote-debugging-port" command-line switch.
         /// </summary>
         property int RemoteDebuggingPort
         {
@@ -298,11 +289,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// The number of stack trace frames to capture for uncaught exceptions.
-        /// Specify a positive value to enable the CefRenderProcessHandler::
-        /// OnUncaughtException() callback. Specify 0 (default value) and
-        /// OnUncaughtException() will not be called. Also configurable using the
-        /// "uncaught-exception-stack-size" command-line switch.
+        /// The number of stack trace frames to capture for uncaught exceptions. Specify a positive value to enable the
+        /// CefRenderProcessHandler:: OnUncaughtException() callback. Specify 0 (default value) and OnUncaughtException() will not be
+        /// called. Also configurable using the "uncaught-exception-stack-size" command-line switch.
         /// </summary>
         property int UncaughtExceptionStackSize
         {
@@ -311,9 +300,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Value that will be returned as the User-Agent HTTP header. If empty the
-        /// default User-Agent string will be used. Also configurable using the
-        /// "user-agent" command-line switch.
+        /// Value that will be returned as the User-Agent HTTP header. If empty the default User-Agent string will be used. Also
+        /// configurable using the "user-agent" command-line switch.
         /// </summary>
         property String^ UserAgent
         {
@@ -322,9 +310,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set to true (1) to enable windowless (off-screen) rendering support. Do not
-        /// enable this value if the application does not use windowless rendering as
-        /// it may reduce rendering performance on some systems.
+        /// Set to true (1) to enable windowless (off-screen) rendering support. Do not enable this value if the application does not use
+        /// windowless rendering as it may reduce rendering performance on some systems.
         /// </summary>
         property bool WindowlessRenderingEnabled
         {
@@ -333,13 +320,10 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// To persist session cookies (cookies without an expiry date or validity
-        /// interval) by default when using the global cookie manager set this value to
-        /// true. Session cookies are generally intended to be transient and most
-        /// Web browsers do not persist them. A CachePath value must also be
-        /// specified to enable this feature. Also configurable using the
-        /// "persist-session-cookies" command-line switch. Can be overridden for
-        /// individual RequestContext instances via the
+        /// To persist session cookies (cookies without an expiry date or validity interval) by default when using the global cookie
+        /// manager set this value to true. Session cookies are generally intended to be transient and most Web browsers do not persist
+        /// them. A CachePath value must also be specified to enable this feature. Also configurable using the "persist-session-cookies"
+        /// command-line switch. Can be overridden for individual RequestContext instances via the
         /// RequestContextSettings.PersistSessionCookies value.
         /// </summary>
         property bool PersistSessionCookies
@@ -349,12 +333,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// To persist user preferences as a JSON file in the cache path directory set
-        /// this value to true. A CachePath value must also be specified
-        /// to enable this feature. Also configurable using the
-        /// "persist-user-preferences" command-line switch. Can be overridden for
-        /// individual RequestContext instances via the
-        /// RequestContextSettings.PersistUserPreferences value.
+        /// To persist user preferences as a JSON file in the cache path directory set this value to true. A CachePath value must also be
+        /// specified to enable this feature. Also configurable using the "persist-user-preferences" command-line switch. Can be
+        /// overridden for individual RequestContext instances via the RequestContextSettings.PersistUserPreferences value.
         /// </summary>
         property bool PersistUserPreferences
         {
@@ -363,10 +344,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Comma delimited ordered list of language codes without any whitespace that
-        /// will be used in the "Accept-Language" HTTP header. May be set globally
-        /// using the CefSettings.AcceptLanguageList value. If both values are
-        /// empty then "en-US,en" will be used.
+        /// Comma delimited ordered list of language codes without any whitespace that will be used in the "Accept-Language" HTTP header.
+        /// May be set globally using the CefSettings.AcceptLanguageList value. If both values are empty then "en-US,en" will be used.
+        /// 
         /// </summary>
         property String^ AcceptLanguageList
         {
@@ -375,12 +355,11 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Background color used for the browser before a document is loaded and when no document color is
-        /// specified. The alpha component must be either fully opaque (0xFF) or fully transparent (0x00).
-        /// If the alpha component is fully opaque then the RGB components will be used as the background
-        /// color. If the alpha component is fully transparent for a WinForms browser then the default value
-        /// of opaque white be used. If the alpha component is fully transparent for a windowless
-        /// (WPF/OffScreen) browser then transparent painting will be enabled.
+        /// Background color used for the browser before a document is loaded and when no document color is specified. The alpha
+        /// component must be either fully opaque (0xFF) or fully transparent (0x00). If the alpha component is fully opaque then the RGB
+        /// components will be used as the background color. If the alpha component is fully transparent for a WinForms browser then the
+        /// default value of opaque white be used. If the alpha component is fully transparent for a windowless (WPF/OffScreen) browser
+        /// then transparent painting will be enabled.
         /// </summary>
         virtual property uint32 BackgroundColor
         {
@@ -389,10 +368,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// GUID string used for identifying the application. This is passed to the
-        /// system AV function for scanning downloaded files. By default, the GUID
-        /// will be an empty string and the file will be treated as an untrusted
-        /// file when the GUID is empty.
+        /// GUID string used for identifying the application. This is passed to the system AV function for scanning downloaded files. By
+        /// default, the GUID will be an empty string and the file will be treated as an untrusted file when the GUID is empty.
         /// </summary>
         property String^ ApplicationClientIdForFileScanning
         {
@@ -413,8 +390,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Register a new V8 extension with the specified JavaScript extension code
+        /// Register a new V8 extension with the specified JavaScript extension code.
         /// </summary>
+        /// <exception cref="ArgumentException">Thrown when one or more arguments have unsupported or illegal values.</exception>
         /// <param name="extension">The V8Extension that contains the extension code.</param>
         void RegisterExtension(V8Extension^ extension)
         {
@@ -437,8 +415,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set command line argument to enable Print Preview
-        /// See https://bitbucket.org/chromiumembedded/cef/issues/123/add-support-for-print-preview for details
+        /// Set command line argument to enable Print Preview See
+        /// https://bitbucket.org/chromiumembedded/cef/issues/123/add-support-for-print-preview for details.
         /// </summary>
         void EnablePrintPreview()
         {
@@ -449,9 +427,8 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Set command line arguments for best OSR (Offscreen and WPF) Rendering performance
-        /// This will disable WebGL, look at the source to determine which flags best suite
-        /// your requirements.
+        /// Set command line arguments for best OSR (Offscreen and WPF) Rendering performance This will disable WebGL, look at the source
+        /// to determine which flags best suite your requirements.
         /// </summary>
         void SetOffScreenRenderingBestPerformanceArgs()
         {

--- a/CefSharp.Core/BrowserSettings.h
+++ b/CefSharp.Core/BrowserSettings.h
@@ -48,6 +48,9 @@ namespace CefSharp
             _ownsPointer = true;
         }
 
+        /// <summary>
+        /// Finalizer.
+        /// </summary>
         !BrowserSettings()
         {
             if (_ownsPointer)
@@ -59,6 +62,9 @@ namespace CefSharp
             _isDisposed = true;
         }
 
+        /// <summary>
+        /// Destructor.
+        /// </summary>
         ~BrowserSettings()
         {
             this->!BrowserSettings();
@@ -392,6 +398,9 @@ namespace CefSharp
             bool get() { return _isDisposed; }
         }
 
+        /// <summary>
+        /// True if framework created.
+        /// </summary>
         virtual property bool FrameworkCreated
         {
             bool get() { return _frameworkCreated; }

--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -33,6 +33,11 @@ using namespace msclr::interop;
 
 namespace CefSharp
 {
+    /// <summary>
+    /// Global CEF methods are exposed through this class. e.g. CefInitalize maps to Cef.Initialize
+    /// CEF API Doc https://magpcss.org/ceforum/apidocs3/projects/(default)/(_globals).html
+    /// This class cannot be inherited.
+    /// </summary>
     public ref class Cef sealed
     {
     private:
@@ -688,7 +693,7 @@ namespace CefSharp
         /// The client application is responsible for downloading an appropriate
         /// platform-specific CDM binary distribution from Google, extracting the
         /// contents, and building the required directory structure on the local machine.
-        /// The <see cref="CefSharp.IBrowserHost.StartDownload"/> method class can be used
+        /// The <see cref="CefSharp::IBrowserHost::StartDownload"/> method class can be used
         /// to implement this functionality in CefSharp. Contact Google via
         /// https://www.widevine.com/contact.html for details on CDM download.
         /// 
@@ -702,7 +707,7 @@ namespace CefSharp
         ///
         /// If any of these files are missing or if the manifest file has incorrect
         /// contents the registration will fail and callback will receive an ErrorCode
-        /// value of <see cref="CefSharp.CdmRegistrationErrorCode.IncorrectContents"/>.
+        /// value of <see cref="CefSharp::CdmRegistrationErrorCode::IncorrectContents"/>.
         ///
         /// The manifest.json file must contain the following keys:
         ///   A. "os": Supported OS (e.g. "mac", "win" or "linux").
@@ -715,13 +720,13 @@ namespace CefSharp
         ///
         /// A through E are used to verify compatibility with the current Chromium
         /// version. If the CDM is not compatible the registration will fail and
-        /// callback will receive an ErrorCode value of <see cref="CdmRegistrationErrorCode.Incompatible"/>.
+        /// callback will receive an ErrorCode value of <see cref="CdmRegistrationErrorCode::Incompatible"/>.
         ///
         /// If registration is not supported at the time that Cef.RegisterWidevineCdm() is called then callback
-        /// will receive an ErrorCode value of <see cref="CdmRegistrationErrorCode.NotSupported"/>.
+        /// will receive an ErrorCode value of <see cref="CdmRegistrationErrorCode::NotSupported"/>.
         /// </summary>
         /// <param name="path"> is a directory that contains the Widevine CDM files</param>
-        /// <param name="callback">optional callback - <see cref="IRegisterCdmCallback.OnRegistrationCompletecallback"/> 
+        /// <param name="callback">optional callback - <see cref="IRegisterCdmCallback::OnRegistrationCompletecallback"/> 
         /// will be executed asynchronously once registration is complete</param>
         static void RegisterWidevineCdm(String^ path, [Optional] IRegisterCdmCallback^ callback)
         {

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.79.1.35\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.35\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.79.1.36\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.36\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.79.1.31\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.31\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.79.1.35\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.79.1.35\build\cef.sdk.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/CefSharp.Core/CookieManager.h
+++ b/CefSharp.Core/CookieManager.h
@@ -11,6 +11,7 @@
 
 namespace CefSharp
 {
+    /// <exclude />
     public ref class CookieManager : public ICookieManager
     {
     private:

--- a/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
@@ -150,6 +150,13 @@ void CefBrowserHostWrapper::CloseBrowser(bool forceClose)
     _browserHost->CloseBrowser(forceClose);
 }
 
+bool CefBrowserHostWrapper::TryCloseBrowser()
+{
+    ThrowIfDisposed();
+
+    return _browserHost->TryCloseBrowser();
+}
+
 void CefBrowserHostWrapper::ShowDevTools(IWindowInfo^ windowInfo, int inspectElementAtX, int inspectElementAtY)
 {
     ThrowIfDisposed();

--- a/CefSharp.Core/Internals/CefBrowserHostWrapper.h
+++ b/CefSharp.Core/Internals/CefBrowserHostWrapper.h
@@ -50,6 +50,7 @@ namespace CefSharp
             virtual Task<double>^ GetZoomLevelAsync();
             virtual IntPtr GetWindowHandle();
             virtual void CloseBrowser(bool forceClose);
+            virtual bool TryCloseBrowser();
 
             virtual void DragTargetDragEnter(IDragData^ dragData, MouseEvent mouseEvent, DragOperationsMask allowedOperations);
             virtual void DragTargetDragOver(MouseEvent mouseEvent, DragOperationsMask allowedOperations);

--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -26,6 +26,7 @@ using namespace CefSharp::ModelBinding;
 
 namespace CefSharp
 {
+    /// <exclude />
     public ref class ManagedCefBrowserAdapter : public IBrowserAdapter
     {
         MCefRefPtr<ClientAdapter> _clientAdapter;

--- a/CefSharp.Core/NativeMethodWrapper.h
+++ b/CefSharp.Core/NativeMethodWrapper.h
@@ -8,6 +8,7 @@
 
 namespace CefSharp
 {
+    /// <exclude />
     public ref class NativeMethodWrapper sealed
     {
     public:

--- a/CefSharp.Core/PopupFeatures.h
+++ b/CefSharp.Core/PopupFeatures.h
@@ -11,12 +11,17 @@ namespace CefSharp
     /// <summary>
     /// Class representing popup window features.
     /// </summary>
+    /// <exclude />
     public ref class PopupFeatures : IPopupFeatures
     {
     private:
         const CefPopupFeatures* _popupFeatures;
 
     public:
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="popupFeatures">The popup features.</param>
         PopupFeatures(const CefPopupFeatures* popupFeatures)
         {
             _popupFeatures = popupFeatures;

--- a/CefSharp.Core/PostData.h
+++ b/CefSharp.Core/PostData.h
@@ -17,6 +17,10 @@ using namespace System::Collections::ObjectModel;
 
 namespace CefSharp
 {
+    /// <summary>
+    /// Form Post Data
+    /// </summary>
+    /// <seealso cref="T:IPostData"/>
     public ref class PostData : public IPostData, public CefWrapper
     {
         MCefRefPtr<CefPostData> _postData;
@@ -29,11 +33,17 @@ namespace CefSharp
 
         }
 
+        /// <summary>
+        /// Finalizer.
+        /// </summary>
         !PostData()
         {
             _postData = nullptr;
         }
 
+        /// <summary>
+        /// Destructor.
+        /// </summary>
         ~PostData()
         {
             this->!PostData();
@@ -52,12 +62,30 @@ namespace CefSharp
             _disposed = true;
         }
 
+        /// <summary>
+        /// Throw exception if Readonly
+        /// </summary>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        void ThrowIfReadOnly()
+        {
+            if (IsReadOnly)
+            {
+                throw gcnew Exception(gcnew String(L"This IPostDataWrapper is readonly and cannot be modified."));
+            }
+        }
+
     public:
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
         PostData()
         {
             _postData = CefPostData::Create();
         }
 
+        /// <summary>
+        /// Returns true if this object is read-only.
+        /// </summary>
         virtual property bool IsReadOnly
         {
             bool get()
@@ -68,6 +96,9 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// Retrieve the post data elements.
+        /// </summary>
         virtual property IList<IPostDataElement^>^ Elements
         {
             IList<IPostDataElement^>^ get()
@@ -99,6 +130,11 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// Add the specified <see cref="IPostDataElement"/>.
+        /// </summary>
+        /// <param name="element">element to be added.</param>
+        /// <returns>Returns true if the add succeeds.</returns>
         virtual bool AddElement(IPostDataElement^ element)
         {
             ThrowIfDisposed();
@@ -121,6 +157,11 @@ namespace CefSharp
             return _postData->AddElement(elementWrapper);
         }
 
+        /// <summary>
+        /// Remove  the specified <see cref="IPostDataElement"/>.
+        /// </summary>
+        /// <param name="element">element to be removed.</param>
+        /// <returns> Returns true if the add succeeds.</returns>
         virtual bool RemoveElement(IPostDataElement^ element)
         {
             ThrowIfDisposed();
@@ -142,6 +183,9 @@ namespace CefSharp
             return _postData->RemoveElement(elementWrapper);
         }
 
+        /// <summary>
+        /// Remove all existing post data elements.
+        /// </summary>
         virtual void RemoveElements()
         {
             ThrowIfDisposed();
@@ -151,6 +195,10 @@ namespace CefSharp
             _postData->RemoveElements();
         }
 
+        /// <summary>
+        /// Create a new <see cref="IPostDataElement"/> instance
+        /// </summary>
+        /// <returns>PostDataElement</returns>
         virtual IPostDataElement^ CreatePostDataElement()
         {
             auto element = CefPostDataElement::Create();
@@ -158,6 +206,12 @@ namespace CefSharp
             return gcnew PostDataElement(element);
         }
 
+        /// <summary>
+        /// Returns true if the underlying POST data includes elements that are not
+        /// represented by this IPostData object (for example, multi-part file upload
+        /// data). Modifying IPostData objects with excluded elements may result in
+        /// the request failing.
+        /// </summary>
         virtual property bool HasExcludedElements
         {
             bool get()
@@ -165,14 +219,6 @@ namespace CefSharp
                 ThrowIfDisposed();
 
                 return _postData->HasExcludedElements();
-            }
-        }
-
-        void ThrowIfReadOnly()
-        {
-            if (IsReadOnly)
-            {
-                throw gcnew Exception(gcnew String(L"This IPostDataWrapper is readonly and cannot be modified."));
             }
         }
 

--- a/CefSharp.Core/packages.config
+++ b/CefSharp.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="79.1.35" targetFramework="native" />
+  <package id="cef.sdk" version="79.1.36" targetFramework="native" />
 </packages>

--- a/CefSharp.Core/packages.config
+++ b/CefSharp.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="79.1.31" targetFramework="native" />
+  <package id="cef.sdk" version="79.1.35" targetFramework="native" />
 </packages>

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/CefSharp.OffScreen.Example/packages.config
+++ b/CefSharp.OffScreen.Example/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="79.1.35" targetFramework="net462" />
-  <package id="cef.redist.x86" version="79.1.35" targetFramework="net462" />
+  <package id="cef.redist.x64" version="79.1.36" targetFramework="net462" />
+  <package id="cef.redist.x86" version="79.1.36" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/CefSharp.OffScreen.Example/packages.config
+++ b/CefSharp.OffScreen.Example/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="79.1.31" targetFramework="net462" />
-  <package id="cef.redist.x86" version="79.1.31" targetFramework="net462" />
+  <package id="cef.redist.x64" version="79.1.35" targetFramework="net462" />
+  <package id="cef.redist.x86" version="79.1.35" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -20,7 +20,6 @@ namespace CefSharp.OffScreen
     /// An offscreen instance of Chromium that you can use to take
     /// snapshots or evaluate JavaScript.
     /// </summary>
-    /// <seealso cref="CefSharp.Internals.IRenderWebBrowser" />
     public class ChromiumWebBrowser : IRenderWebBrowser
     {
         /// <summary>

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CefSharp.Test/packages.config
+++ b/CefSharp.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net462" />
-  <package id="cef.redist.x64" version="79.1.35" targetFramework="net462" />
-  <package id="cef.redist.x86" version="79.1.35" targetFramework="net462" />
+  <package id="cef.redist.x64" version="79.1.36" targetFramework="net462" />
+  <package id="cef.redist.x86" version="79.1.36" targetFramework="net462" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net462" />

--- a/CefSharp.Test/packages.config
+++ b/CefSharp.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net462" />
-  <package id="cef.redist.x64" version="79.1.31" targetFramework="net462" />
-  <package id="cef.redist.x86" version="79.1.31" targetFramework="net462" />
+  <package id="cef.redist.x64" version="79.1.35" targetFramework="net462" />
+  <package id="cef.redist.x86" version="79.1.35" targetFramework="net462" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net462" />

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CefSharp.WinForms.Example/packages.config
+++ b/CefSharp.WinForms.Example/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="79.1.35" targetFramework="net462" />
-  <package id="cef.redist.x86" version="79.1.35" targetFramework="net462" />
+  <package id="cef.redist.x64" version="79.1.36" targetFramework="net462" />
+  <package id="cef.redist.x86" version="79.1.36" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/CefSharp.WinForms.Example/packages.config
+++ b/CefSharp.WinForms.Example/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="79.1.31" targetFramework="net462" />
-  <package id="cef.redist.x86" version="79.1.31" targetFramework="net462" />
+  <package id="cef.redist.x64" version="79.1.35" targetFramework="net462" />
+  <package id="cef.redist.x86" version="79.1.35" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -416,10 +416,12 @@ namespace CefSharp.WinForms
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChromiumWebBrowser"/> class.
+        /// **Important** - When using this constructor the <see cref="Control.Dock"/> property
+        /// will default to <see cref="DockStyle.Fill"/>.
         /// </summary>
         /// <param name="html">html string to be initially loaded in the browser.</param>
-        /// <param name="requestContext">Request context that will be used for this browser instance,
-        /// if null the Global Request Context will be used</param>
+        /// <param name="requestContext">(Optional) Request context that will be used for this browser instance, if null the Global
+        /// Request Context will be used.</param>
         public ChromiumWebBrowser(HtmlString html, IRequestContext requestContext = null) : this(html.ToDataUriString(), requestContext)
         {
 
@@ -427,10 +429,12 @@ namespace CefSharp.WinForms
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChromiumWebBrowser"/> class.
+        /// **Important** - When using this constructor the <see cref="Control.Dock"/> property
+        /// will default to <see cref="DockStyle.Fill"/>.
         /// </summary>
         /// <param name="address">The address.</param>
-        /// <param name="requestContext">Request context that will be used for this browser instance,
-        /// if null the Global Request Context will be used</param>
+        /// <param name="requestContext">(Optional) Request context that will be used for this browser instance, if null the Global
+        /// Request Context will be used.</param>
         public ChromiumWebBrowser(string address, IRequestContext requestContext = null)
         {
             Dock = DockStyle.Fill;

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -18,7 +18,6 @@ namespace CefSharp.WinForms
     /// ChromiumWebBrowser is the WinForms web browser control
     /// </summary>
     /// <seealso cref="System.Windows.Forms.Control" />
-    /// <seealso cref="CefSharp.Internals.IWebBrowserInternal" />
     /// <seealso cref="CefSharp.WinForms.IWinFormsWebBrowser" />
     [Docking(DockingBehavior.AutoDock), DefaultEvent("LoadingStateChanged"), ToolboxBitmap(typeof(ChromiumWebBrowser)),
     Description("CefSharp ChromiumWebBrowser - Chromium Embedded Framework .Net wrapper. https://github.com/cefsharp/CefSharp"),

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -376,7 +376,7 @@ namespace CefSharp.WinForms
         /// <summary>
         /// ParentFormMessageInterceptor hooks the Form handle and forwards
         /// the move/active messages to the browser, the default is true
-        /// and should only be required when using <see cref="CefSettings.MultiThreadedMessageLoop"/>
+        /// and should only be required when using <see cref="AbstractCefSettings.MultiThreadedMessageLoop"/>
         /// set to true.
         /// </summary>
         [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden), DefaultValue(true)]
@@ -619,7 +619,7 @@ namespace CefSharp.WinForms
         /// To re-enable Window Activation then remove WS_EX_NOACTIVATE from ExStyle
         /// <code>
         /// const uint WS_EX_NOACTIVATE = 0x08000000;
-        /// windowInfo.ExStyle &= ~WS_EX_NOACTIVATE;
+        /// windowInfo.ExStyle &amp;= ~WS_EX_NOACTIVATE;
         ///</code>
         /// </example>
         protected virtual IWindowInfo CreateBrowserWindowInfo(IntPtr handle)

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.36\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.36\build\cef.redist.x64.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.31\build\cef.redist.x86.props')" />
-  <Import Project="..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.31\build\cef.redist.x64.props')" />
+  <Import Project="..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.79.1.35\build\cef.redist.x86.props')" />
+  <Import Project="..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.79.1.35\build\cef.redist.x64.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -41,6 +41,12 @@ namespace CefSharp.Wpf.Example.Views
             //the browser is initialized.
             CefSharpSettings.WcfEnabled = true;
 
+            if (CefSharpSettings.LegacyJavascriptBindingEnabled)
+            {
+                browser.JavascriptObjectRepository.Register("bound", new BoundObject(), isAsync: false, options: BindingOptions.DefaultBinder);
+                browser.JavascriptObjectRepository.Register("boundAsync", new AsyncBoundObject(), isAsync: true, options: bindingOptions);
+            }
+
             //If you call CefSharp.BindObjectAsync in javascript and pass in the name of an object which is not yet
             //bound, then ResolveObject will be called, you can then register it
             browser.JavascriptObjectRepository.ResolveObject += (sender, e) =>

--- a/CefSharp.Wpf.Example/packages.config
+++ b/CefSharp.Wpf.Example/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="79.1.35" targetFramework="net472" />
-  <package id="cef.redist.x86" version="79.1.35" targetFramework="net472" />
+  <package id="cef.redist.x64" version="79.1.36" targetFramework="net472" />
+  <package id="cef.redist.x86" version="79.1.36" targetFramework="net472" />
   <package id="CommonServiceLocator" version="2.0.2" targetFramework="net462" requireReinstallation="true" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net462" developmentDependency="true" />
   <package id="MvvmLightLibs" version="5.4.1.1" targetFramework="net462" />

--- a/CefSharp.Wpf.Example/packages.config
+++ b/CefSharp.Wpf.Example/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="79.1.31" targetFramework="net472" />
-  <package id="cef.redist.x86" version="79.1.31" targetFramework="net472" />
+  <package id="cef.redist.x64" version="79.1.35" targetFramework="net472" />
+  <package id="cef.redist.x86" version="79.1.35" targetFramework="net472" />
   <package id="CommonServiceLocator" version="2.0.2" targetFramework="net462" requireReinstallation="true" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net462" developmentDependency="true" />
   <package id="MvvmLightLibs" version="5.4.1.1" targetFramework="net462" />

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -698,7 +698,8 @@ namespace CefSharp.Wpf
 
                 //Stop rendering immediately so later on when we dispose of the
                 //RenderHandler no further OnPaint calls take place
-                browser.GetHost().WasHidden(true);
+                //Check browser not null as it's possible to call Dispose before it's created
+                browser?.GetHost().WasHidden(true);
 
                 UiThreadRunAsync(() =>
                 {

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -36,7 +36,14 @@ namespace CefSharp.Wpf
     [TemplatePart(Name = PartPopupImageName, Type = typeof(Image))]
     public class ChromiumWebBrowser : Control, IRenderWebBrowser, IWpfWebBrowser
     {
+        /// <summary>
+        /// TemplatePart Name constant for the Image used to represent the browser
+        /// </summary>
         public const string PartImageName = "PART_image";
+        /// <summary>
+        /// TemplatePart Name constant for the Image used to represent the popup
+        /// overlayed on the browser
+        /// </summary>
         public const string PartPopupImageName = "PART_popupImage";
 
         /// <summary>
@@ -1981,6 +1988,13 @@ namespace CefSharp.Wpf
             }
         }
 
+        /// <summary>
+        /// Run the Action on the CEF UI Thread in an async fashion
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <returns>
+        /// An asynchronous result.
+        /// </returns>
         protected async Task CefUiThreadRunAsync(Action action)
         {
             if (!IsDisposed && InternalIsBrowserInitialized())
@@ -2471,6 +2485,11 @@ namespace CefSharp.Wpf
             base.OnMouseLeave(e);
         }
 
+        /// <summary>
+        /// Invoked when an unhandled <see cref="E:System.Windows.Input.Mouse.LostMouseCapture" /> attached event reaches an element in
+        /// its route that is derived from this class. Implement this method to add class handling for this event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.Windows.Input.MouseEventArgs" /> that contains event data.</param>
         protected override void OnLostMouseCapture(MouseEventArgs e)
         {
             if (!e.Handled && browser != null)

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -30,7 +30,6 @@ namespace CefSharp.Wpf
     /// ChromiumWebBrowser is the WPF web browser control
     /// </summary>
     /// <seealso cref="System.Windows.Controls.Control" />
-    /// <seealso cref="CefSharp.Internals.IRenderWebBrowser" />
     /// <seealso cref="CefSharp.Wpf.IWpfWebBrowser" />
     [TemplatePart(Name = PartImageName, Type = typeof(Image))]
     [TemplatePart(Name = PartPopupImageName, Type = typeof(Image))]

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -134,11 +134,20 @@ namespace CefSharp.Wpf
         /// </summary>
         private static bool DesignMode;
 
+        private bool resizeHackForIssue2779Enabled;
+        private CefSharp.Structs.Size? resizeHackForIssue2779Size;
+
         /// <summary>
         /// The value for disposal, if it's 1 (one) then this instance is either disposed
         /// or in the process of getting disposed
         /// </summary>
         private int disposeSignaled;
+
+        /// <summary>
+        /// Hack to work around issue https://github.com/cefsharp/CefSharp/issues/2779
+        /// Enabled by default
+        /// </summary>
+        public bool EnableResizeHackForIssue2779 { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this instance is disposed.
@@ -557,6 +566,8 @@ namespace CefSharp.Wpf
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void NoInliningConstructor()
         {
+            EnableResizeHackForIssue2779 = true;
+
             //Initialize CEF if it hasn't already been initialized
             if (!Cef.IsInitialized)
             {
@@ -822,7 +833,18 @@ namespace CefSharp.Wpf
         /// <returns>View Rectangle</returns>
         protected virtual Rect GetViewRect()
         {
-            return viewRect;
+            //Take a local copy as the value is set on a different thread,
+            //Its possible the struct is set to null after our initial check.
+            var resizeRect = resizeHackForIssue2779Size;
+
+            if (resizeRect == null)
+            {
+                return viewRect;
+            }
+
+            var size = resizeRect.Value;
+
+            return new Rect(0, 0, size.Width, size.Height);
         }
 
         bool IRenderWebBrowser.GetScreenPoint(int viewX, int viewY, out int screenX, out int screenY)
@@ -967,6 +989,11 @@ namespace CefSharp.Wpf
         /// <param name="height">height</param>
         protected virtual void OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height)
         {
+            if (resizeHackForIssue2779Enabled)
+            {
+                return;
+            }
+
             var paint = Paint;
             if (paint != null)
             {
@@ -1759,7 +1786,7 @@ namespace CefSharp.Wpf
             }
         }
 
-        private void OnWindowStateChanged(object sender, EventArgs e)
+        private async void OnWindowStateChanged(object sender, EventArgs e)
         {
             var window = (Window)sender;
 
@@ -1770,16 +1797,54 @@ namespace CefSharp.Wpf
                 {
                     if (previousWindowState == WindowState.Minimized && browser != null)
                     {
-                        browser.GetHost().WasHidden(false);
+                        await CefUiThreadRunAsync(async () =>
+                        {
+                            var host = browser?.GetHost();
+                            if (host != null && !host.IsDisposed)
+                            {
+                                try
+                                {
+                                    host.WasHidden(false);
+
+                                    await ResizeHackFor2779();
+                                }
+                                catch (ObjectDisposedException)
+                                {
+                                    // Because Dispose runs in another thread there's a race condition between
+                                    // that and this code running on the CEF UI thread, so the host could be disposed
+                                    // between the check and using it. We can either synchronize access using locking
+                                    // (potentially blocking the UI thread in Dispose) or catch the extremely rare
+                                    // exception, which is what we do here
+                                }
+                            }
+                        });
                     }
+
                     break;
                 }
                 case WindowState.Minimized:
                 {
-                    if (browser != null)
+                    await CefUiThreadRunAsync(() =>
                     {
-                        browser.GetHost().WasHidden(true);
-                    }
+                        var host = browser?.GetHost();
+                        if (host != null && !host.IsDisposed)
+                        {
+                            if (EnableResizeHackForIssue2779)
+                            {
+                                resizeHackForIssue2779Enabled = true;
+                            }
+
+                            try
+                            {
+                                host.WasHidden(true);
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                // See comment in catch in OnWindowStateChanged
+                            }
+                        }
+                    });
+
                     break;
                 }
             }
@@ -1916,6 +1981,24 @@ namespace CefSharp.Wpf
             }
         }
 
+        protected async Task CefUiThreadRunAsync(Action action)
+        {
+            if (!IsDisposed && InternalIsBrowserInitialized())
+            {
+                if (Cef.CurrentlyOnThread(CefThreadIds.TID_UI))
+                {
+                    action();
+                }
+                else
+                {
+                    await Cef.UIThreadTaskFactory.StartNew(delegate
+                    {
+                        action();
+                    });
+                }
+            }
+        }
+
         /// <summary>
         /// Runs the specific Action on the Dispatcher in an sync fashion
         /// </summary>
@@ -1938,20 +2021,44 @@ namespace CefSharp.Wpf
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="SizeChangedEventArgs"/> instance containing the event data.</param>
-        private void OnActualSizeChanged(object sender, SizeChangedEventArgs e)
+        private async void OnActualSizeChanged(object sender, SizeChangedEventArgs e)
         {
             // Initialize RenderClientAdapter when WPF has calculated the actual size of current content.
             CreateOffscreenBrowser(e.NewSize);
 
+            if (InternalIsBrowserInitialized())
+            {
+                await CefUiThreadRunAsync(() =>
+                {
+                    SetViewRect(e);
+
+                    var host = browser?.GetHost();
+                    if (host != null && !host.IsDisposed)
+                    {
+                        try
+                        {
+                            host.WasResized();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // See comment in catch in OnWindowStateChanged
+                        }
+                    }
+                });
+            }
+            else
+            {
+                //If the browser hasn't been created yet then directly update the viewRect
+                SetViewRect(e);
+            }
+        }
+
+        private void SetViewRect(SizeChangedEventArgs e)
+        {
             //NOTE: Previous we used Math.Ceiling to round the sizing up, we
             //now set UseLayoutRounding = true; on the control so the sizes are
             //already rounded to a whole number for us.
             viewRect = new Rect(0, 0, (int)e.NewSize.Width, (int)e.NewSize.Height);
-
-            if (browser != null)
-            {
-                browser.GetHost().WasResized();
-            }
         }
 
         /// <summary>
@@ -1959,31 +2066,52 @@ namespace CefSharp.Wpf
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="args">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
-        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs args)
+        private async void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs args)
         {
             var isVisible = (bool)args.NewValue;
 
             if (browser != null)
             {
-                var host = browser.GetHost();
-                host.WasHidden(!isVisible);
+                await CefUiThreadRunAsync(async () =>
+                {
+                    var host = browser?.GetHost();
+                    if (host != null && !host.IsDisposed)
+                    {
+                        try
+                        {
+                            host.WasHidden(!isVisible);
 
-                if (isVisible)
+                            if (isVisible)
+                            {
+                                await ResizeHackFor2779();
+                            }
+                            else if (EnableResizeHackForIssue2779)
+                            {
+                                resizeHackForIssue2779Enabled = true;
+                            }
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // See comment in catch in OnWindowStateChanged
+                        }
+                    }
+                });
+
+                if (browser != null)
                 {
                     //Fix for #1778 - When browser becomes visible we update the zoom level
                     //browsers of the same origin will share the same zoomlevel and
                     //we need to track the update, so our ZoomLevelProperty works
                     //properly
-                    host.GetZoomLevelAsync().ContinueWith(t =>
+                    var zoomLevel = await browser.GetHost().GetZoomLevelAsync();
+
+                    UiThreadRunAsync(() =>
                     {
                         if (!IsDisposed)
                         {
-                            SetCurrentValue(ZoomLevelProperty, t.Result);
+                            SetCurrentValue(ZoomLevelProperty, zoomLevel);
                         }
-                    },
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnRanToCompletion,
-                    TaskScheduler.FromCurrentSynchronizationContext());
+                    });
                 }
             }
         }
@@ -2624,6 +2752,33 @@ namespace CefSharp.Wpf
             // Use CompareExchange to read the current value - if disposeCount is 1, we set it to 1, effectively a no-op
             // Volatile.Read would likely use a memory barrier which I believe is unnecessary in this scenario
             return Interlocked.CompareExchange(ref browserInitialized, 0, 0) == 1;
+        }
+
+        private async Task ResizeHackFor2779()
+        {
+            if (EnableResizeHackForIssue2779)
+            {
+                const int delayInMs = 50;
+
+                var host = browser?.GetHost();
+                if (host != null && !host.IsDisposed)
+                {
+                    resizeHackForIssue2779Size = new Structs.Size(viewRect.Width - 1, viewRect.Height - 1);
+                    host.WasResized();
+
+                    await Task.Delay(delayInMs);
+
+                    if (!host.IsDisposed)
+                    {
+                        resizeHackForIssue2779Size = null;
+                        host.WasResized();
+
+                        resizeHackForIssue2779Enabled = false;
+
+                        host.Invalidate(PaintElementType.View);
+                    }
+                }
+            }
         }
     }
 }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2575,8 +2575,6 @@ namespace CefSharp.Wpf
         /// <param name="e">The <see cref="TouchEventArgs"/> instance containing the event data.</param>
         private void OnTouch(TouchEventArgs e)
         {
-            var browser = GetBrowser();
-
             if (!e.Handled && browser != null)
             {
                 var modifiers = WpfExtensions.GetModifierKeys();
@@ -2756,7 +2754,14 @@ namespace CefSharp.Wpf
         public IBrowser GetBrowser()
         {
             this.ThrowExceptionIfDisposed();
-            this.ThrowExceptionIfBrowserNotInitialized();
+
+            //We don't use the this.ThrowExceptionIfBrowserNotInitialized(); extension method here
+            // As it relies on the IWebBrowser.IsBrowserInitialized property which is a DependencyProperty
+            // in WPF and will throw an InvalidOperationException if called on a Non-UI thread.
+            if (!InternalIsBrowserInitialized())
+            {
+                throw new Exception(WebBrowserExtensions.BrowserNotInitializedExceptionErrorMessage);
+            }
 
             return browser;
         }

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -15,6 +15,10 @@ using Rect = CefSharp.Structs.Rect;
 
 namespace CefSharp.Wpf.Experimental
 {
+    /// <summary>
+    /// A WPF Keyboard handler implementation that supports IME
+    /// </summary>
+    /// <seealso cref="T:CefSharp.Wpf.Internals.WpfKeyboardHandler"/>
     public class WpfImeKeyboardHandler : WpfKeyboardHandler
     {
         private int languageCodeId;
@@ -27,10 +31,19 @@ namespace CefSharp.Wpf.Experimental
         private MouseButtonEventHandler mouseDownEventHandler;
         private bool isActive;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
         public WpfImeKeyboardHandler(ChromiumWebBrowser owner) : base(owner)
         {
         }
 
+        /// <summary>
+        /// Change composition range.
+        /// </summary>
+        /// <param name="selectionRange">The selection range.</param>
+        /// <param name="characterBounds">The character bounds.</param>
         public void ChangeCompositionRange(Range selectionRange, Rect[] characterBounds)
         {
             if (!isActive)
@@ -70,6 +83,10 @@ namespace CefSharp.Wpf.Experimental
             });
         }
 
+        /// <summary>
+        /// Setup the Ime Keyboard Handler specific hooks and events
+        /// </summary>
+        /// <param name="source">HwndSource.</param>
         public override void Setup(HwndSource source)
         {
             if (isSetup)
@@ -98,6 +115,9 @@ namespace CefSharp.Wpf.Experimental
             }
         }
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public override void Dispose()
         {
             // Note Setup can be run after disposing, to "reset" this instance
@@ -245,6 +265,10 @@ namespace CefSharp.Wpf.Experimental
             }
         }
 
+        /// <summary>
+        /// Cancel composition.
+        /// </summary>
+        /// <param name="hwnd">The hwnd.</param>
         public void CancelComposition(IntPtr hwnd)
         {
             owner.GetBrowserHost().ImeCancelComposition();

--- a/CefSharp.shfbproj
+++ b/CefSharp.shfbproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
@@ -31,7 +31,7 @@
       <DocumentationSource sourceFile="CefSharp\CefSharp.csproj" />
       <DocumentationSource sourceFile="CefSharp.Core\CefSharp.Core.vcxproj" />
     </DocumentationSources>
-    <HelpFileVersion>76.1.90</HelpFileVersion>
+    <HelpFileVersion>79.1.350</HelpFileVersion>
     <MaximumGroupParts>2</MaximumGroupParts>
     <NamespaceGrouping>False</NamespaceGrouping>
     <SyntaxFilters>C#, Managed C++</SyntaxFilters>
@@ -55,9 +55,11 @@
     </RootNamespaceTitle>
     <ApiFilter>
       <Filter entryType="Namespace" fullName="CefSharp.Internals" isExposed="False" xmlns="" />
+      <Filter entryType="Namespace" fullName="CefSharp.WinForms.Internals" isExposed="False" xmlns="" />
+      <Filter entryType="Namespace" fullName="CefSharp.Wpf.Internals" isExposed="False" xmlns="" />
     </ApiFilter>
     <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
-    <HeaderText>Version 76.1.90</HeaderText>
+    <HeaderText>Version 79.1.350</HeaderText>
     <CopyrightHref>https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE</CopyrightHref>
     <NamespaceSummaries>
       <NamespaceSummaryItem name="CefSharp" isDocumented="True">Interfaces, enums, structs and classes that make up the core API interface</NamespaceSummaryItem>

--- a/CefSharp/AsyncExtensions.cs
+++ b/CefSharp/AsyncExtensions.cs
@@ -134,5 +134,20 @@ namespace CefSharp
             //returns null if cookies cannot be accessed.
             return Task.FromResult(false);
         }
+
+        /// <summary>
+        /// Retrieve a snapshot of current navigation entries
+        /// </summary>
+        /// <param name="browserHost">browserHost</param>
+        /// <param name="currentOnly">If true the List will only contain the current navigation entry.
+        /// If false the List will include all navigation entries will be included. Default is false</param>
+        public static Task<List<NavigationEntry>> GetNavigationEntriesAsync(this IBrowserHost browserHost, bool currentOnly = false)
+        {
+            var visitor = new TaskNavigationEntryVisitor();
+
+            browserHost.GetNavigationEntries(visitor, currentOnly);
+
+            return visitor.Task;
+        }
     }
 }

--- a/CefSharp/Callback/IJavascriptCallback.cs
+++ b/CefSharp/Callback/IJavascriptCallback.cs
@@ -27,6 +27,7 @@ namespace CefSharp
         /// <summary>
         /// Execute the javascript callback
         /// </summary>
+        /// <param name="timeout">timeout</param>
         /// <param name="parms">param array of objects</param>
         /// <returns>JavascriptResponse</returns>
         Task<JavascriptResponse> ExecuteWithTimeoutAsync(TimeSpan? timeout, params object[] parms);

--- a/CefSharp/Callback/IResourceReadCallback.cs
+++ b/CefSharp/Callback/IResourceReadCallback.cs
@@ -7,17 +7,17 @@ using System;
 namespace CefSharp.Callback
 {
     /// <summary>
-    /// Callback for asynchronous continuation of <see cref="IResourceHandler.Read(System.IO.Stream, int, out int, IResourceReadCallback)"/>.
+    /// Callback for asynchronous continuation of <see cref="IResourceHandler.Read"/>.
     /// </summary>
     public interface IResourceReadCallback : IDisposable
     {
         /// <summary>
-        /// Callback for asynchronous continuation of <see cref="IResourceHandler.Read(System.IO.Stream, int, out int, IResourceReadCallback)"/>. If bytesRead == 0
+        /// Callback for asynchronous continuation of <see cref="IResourceHandler.Read"/>. If bytesRead == 0
         /// the response will be considered complete. 
         /// </summary>
         /// <param name="bytesRead">
         /// If bytesRead == 0 the response will be considered complete.
-        /// If bytesRead &gt; 0 then <see cref="IResourceHandler.Read(System.IO.Stream, int, out int, IResourceReadCallback)"/> will be called again until the request is complete (based on either the
+        /// If bytesRead &gt; 0 then <see cref="IResourceHandler.Read"/> will be called again until the request is complete (based on either the
         /// result or the expected content length). If bytesRead &lt; 0 then the
         /// request will fail and the bytesRead value will be treated as the error
         /// code.

--- a/CefSharp/Callback/IResourceSkipCallback.cs
+++ b/CefSharp/Callback/IResourceSkipCallback.cs
@@ -7,7 +7,7 @@ using System;
 namespace CefSharp.Callback
 {
     /// <summary>
-    /// Callback for asynchronous continuation of <see cref="IResourceHandler.Skip(long, long, IResourceSkipCallback)"/>.
+    /// Callback for asynchronous continuation of <see cref="IResourceHandler.Skip"/>.
     /// </summary>
     public interface IResourceSkipCallback : IDisposable
     {

--- a/CefSharp/CefLibraryHandle.cs
+++ b/CefSharp/CefLibraryHandle.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace CefSharp
@@ -31,17 +32,39 @@ namespace CefSharp
             LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
         }
 
-        public CefLibraryHandle(string filename) : base(IntPtr.Zero, true)
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="path">libcef.dll full path.</param>
+        public CefLibraryHandle(string path) : base(IntPtr.Zero, true)
         {
-            var handle = LoadLibraryEx(filename, IntPtr.Zero, LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH);
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException("NotFound", path);
+            }
+
+            var handle = LoadLibraryEx(path, IntPtr.Zero, LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH);
             base.SetHandle(handle);
         }
 
+        /// <summary>
+        /// When overridden in a derived class, gets a value indicating whether the handle value is invalid.
+        /// </summary>
+        /// <value>
+        /// true if the handle value is invalid; otherwise, false.
+        /// </value>
         public override bool IsInvalid
         {
             get { return this.handle == IntPtr.Zero; }
         }
 
+        /// <summary>
+        /// When overridden in a derived class, executes the code required to free the handle.
+        /// </summary>
+        /// <returns>
+        /// true if the handle is released successfully; otherwise, in the event of a catastrophic failure, false. In this case, it
+        /// generates a releaseHandleFailed MDA Managed Debugging Assistant.
+        /// </returns>
         protected override bool ReleaseHandle()
         {
             return FreeLibrary(this.handle);

--- a/CefSharp/DefaultApp.cs
+++ b/CefSharp/DefaultApp.cs
@@ -7,24 +7,54 @@ using System.Collections.Generic;
 namespace CefSharp
 {
     /// <summary>
-    /// Default implementation of <see cref="IApp"/> which represents the CefApp class
+    /// Default implementation of <see cref="IApp"/> which represents the CefApp class.
     /// </summary>
+    /// <seealso cref="T:CefSharp.IApp"/>
     public class DefaultApp : IApp
     {
+        /// <summary>
+        /// Return the handler for functionality specific to the browser process. This method is called on multiple threads.
+        /// </summary>
+        /// <value>
+        /// The browser process handler.
+        /// </value>
         public IBrowserProcessHandler BrowserProcessHandler { get; private set; }
+        /// <summary>
+        /// Gets or sets the schemes.
+        /// </summary>
+        /// <value>
+        /// The schemes.
+        /// </value>
         public IEnumerable<CefCustomScheme> Schemes { get; private set; }
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="browserProcessHandler">The browser process handler.</param>
+        /// <param name="schemes">The schemes.</param>
         public DefaultApp(IBrowserProcessHandler browserProcessHandler, IEnumerable<CefCustomScheme> schemes)
         {
             BrowserProcessHandler = browserProcessHandler;
             Schemes = schemes;
         }
 
+        /// <summary>
+        /// Provides an opportunity to register custom schemes. Do not keep a reference to the <paramref name="registrar"/> object. This
+        /// method is called on the main thread for each process and the registered schemes should be the same across all processes.
+        /// 
+        /// </summary>
+        /// <param name="registrar">scheme registra.</param>
         void IApp.OnRegisterCustomSchemes(ISchemeRegistrar registrar)
         {
             OnRegisterCustomSchemes(registrar);
         }
 
+        /// <summary>
+        /// Provides an opportunity to register custom schemes. Do not keep a reference to the <paramref name="registrar"/> object. This
+        /// method is called on the main thread for each process and the registered schemes should be the same across all processes.
+        /// 
+        /// </summary>
+        /// <param name="registrar">scheme registra.</param>
         protected virtual void OnRegisterCustomSchemes(ISchemeRegistrar registrar)
         {
             //Possible we have duplicate scheme names, we'll only register the first one

--- a/CefSharp/DependencyChecker.cs
+++ b/CefSharp/DependencyChecker.cs
@@ -52,6 +52,9 @@ namespace CefSharp
             "cef_200_percent.pak"
         };
 
+        /// <summary>
+        /// List of Optional CEF Dependencies
+        /// </summary>
         public static string[] CefOptionalDependencies =
         {
             // Angle and Direct3D support
@@ -177,7 +180,7 @@ namespace CefSharp
             string path;
 
             Uri pathUri;
-            if(Uri.TryCreate(browserSubProcessPath, UriKind.Absolute, out pathUri) && pathUri.IsAbsoluteUri)
+            if (Uri.TryCreate(browserSubProcessPath, UriKind.Absolute, out pathUri) && pathUri.IsAbsoluteUri)
             {
                 path = Path.GetDirectoryName(browserSubProcessPath);
             }
@@ -186,7 +189,7 @@ namespace CefSharp
                 var executingAssembly = Assembly.GetExecutingAssembly();
 
                 path = Path.GetDirectoryName(executingAssembly.Location);
-            }            
+            }
 
             if (string.IsNullOrEmpty(locale))
             {

--- a/CefSharp/DomNode.cs
+++ b/CefSharp/DomNode.cs
@@ -17,12 +17,23 @@ namespace CefSharp
     {
         private readonly IDictionary<string, string> _attributes;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="attributes">The attributes.</param>
         public DomNode(string tagName, IDictionary<string, string> attributes)
         {
             TagName = tagName;
             _attributes = attributes;
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -47,6 +58,13 @@ namespace CefSharp
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Get the value of an attribute.
+        /// </summary>
+        /// <param name="name">The name of the attribute value to get.</param>
+        /// <returns>
+        /// The attribute value if the name exists in the DomNode's attributes. Null if the name does not exist.
+        /// </returns>
         public string this[string name]
         {
             get
@@ -60,8 +78,20 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// The name of the HTML element.
+        /// </summary>
+        /// <value>
+        /// The name of the tag.
+        /// </value>
         public string TagName { get; private set; }
 
+        /// <summary>
+        /// Get a read only list of the attribute names.
+        /// </summary>
+        /// <value>
+        /// A list of names of the attributes.
+        /// </value>
         public ReadOnlyCollection<string> AttributeNames
         {
             get
@@ -75,6 +105,13 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// Determine if the DomNode has the requested attribute.
+        /// </summary>
+        /// <param name="attributeName">The name of the attribute value.</param>
+        /// <returns>
+        /// True if the attribute exists in the DomNode, false if it does not.
+        /// </returns>
         public bool HasAttribute(string attributeName)
         {
             if (_attributes == null)
@@ -85,6 +122,12 @@ namespace CefSharp
             return _attributes.ContainsKey(attributeName);
         }
 
+        /// <summary>
+        /// Gets the enumerator.
+        /// </summary>
+        /// <returns>
+        /// The enumerator.
+        /// </returns>
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
         {
             if (_attributes == null)

--- a/CefSharp/Enums/CefJsDialogType.cs
+++ b/CefSharp/Enums/CefJsDialogType.cs
@@ -9,8 +9,17 @@ namespace CefSharp
     /// </summary>
     public enum CefJsDialogType
     {
+        /// <summary>
+        /// Alert Dialog
+        /// </summary>
         Alert = 0,
+        /// <summary>
+        /// Confirm Dialog
+        /// </summary>
         Confirm,
+        /// <summary>
+        /// Prompt Dialog
+        /// </summary>
         Prompt
     }
 }

--- a/CefSharp/Enums/CertStatus.cs
+++ b/CefSharp/Enums/CertStatus.cs
@@ -15,29 +15,83 @@ namespace CefSharp
     [Flags]
     public enum CertStatus
     {
+        /// <summary>
+        /// None
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// CommonNameInvalid
+        /// </summary>
         CommonNameInvalid = 1 << 0,
+        /// <summary>
+        /// DateInvalid
+        /// </summary>
         DateInvalid = 1 << 1,
+        /// <summary>
+        /// AuthorityInvalid
+        /// </summary>
         AuthorityInvalid = 1 << 2,
         // 1 << 3 is reserved for ERR_CERT_CONTAINS_ERRORS (not useful with WinHTTP).
+        /// <summary>
+        /// NoRevocation_Mechanism
+        /// </summary>
         NoRevocation_Mechanism = 1 << 4,
+        /// <summary>
+        /// UnableToCheckRevocation
+        /// </summary>
         UnableToCheckRevocation = 1 << 5,
+        /// <summary>
+        /// Revoked
+        /// </summary>
         Revoked = 1 << 6,
+        /// <summary>
+        /// Invalid
+        /// </summary>
         Invalid = 1 << 7,
+        /// <summary>
+        /// WeakSignatureAlgorithm
+        /// </summary>
         WeakSignatureAlgorithm = 1 << 8,
         // 1 << 9 was used for CERT_STATUS_NOT_IN_DNS
+        /// <summary>
+        /// NonUniqueName
+        /// </summary>
         NonUniqueName = 1 << 10,
+        /// <summary>
+        /// WeakKey
+        /// </summary>
         WeakKey = 1 << 11,
         // 1 << 12 was used for CERT_STATUS_WEAK_DH_KEY
+        /// <summary>
+        /// PinnedKeyMissing
+        /// </summary>
         PinnedKeyMissing = 1 << 13,
+        /// <summary>
+        /// NameConstraintViolation
+        /// </summary>
         NameConstraintViolation = 1 << 14,
+        /// <summary>
+        /// ValidityTooLong
+        /// </summary>
         ValidityTooLong = 1 << 15,
 
         // Bits 16 to 31 are for non-error statuses.
+        /// <summary>
+        /// IsEv
+        /// </summary>
         IsEv = 1 << 16,
+        /// <summary>
+        /// RevCheckingEnabled
+        /// </summary>
         RevCheckingEnabled = 1 << 17,
         // Bit 18 was CERT_STATUS_IS_DNSSEC
+        /// <summary>
+        /// Sha1SignaturePresent
+        /// </summary>
         Sha1SignaturePresent = 1 << 19,
+        /// <summary>
+        /// CtComplianceFailed
+        /// </summary>
         CtComplianceFailed = 1 << 20
     }
 }

--- a/CefSharp/Enums/ContextMenuEditState.cs
+++ b/CefSharp/Enums/ContextMenuEditState.cs
@@ -12,14 +12,41 @@ namespace CefSharp
     [Flags]
     public enum ContextMenuEditState
     {
+        /// <summary>
+        /// A binary constant representing the none flag.
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// A binary constant representing the can undo flag.
+        /// </summary>
         CanUndo = 1 << 0,
+        /// <summary>
+        /// A binary constant representing the can redo flag.
+        /// </summary>
         CanRedo = 1 << 1,
+        /// <summary>
+        /// A binary constant representing the can cut flag.
+        /// </summary>
         CanCut = 1 << 2,
+        /// <summary>
+        /// A binary constant representing the can copy flag.
+        /// </summary>
         CanCopy = 1 << 3,
+        /// <summary>
+        /// A binary constant representing the can paste flag.
+        /// </summary>
         CanPaste = 1 << 4,
+        /// <summary>
+        /// A binary constant representing the can delete flag.
+        /// </summary>
         CanDelete = 1 << 5,
+        /// <summary>
+        /// A binary constant representing the can select all flag.
+        /// </summary>
         CanSelectAll = 1 << 6,
+        /// <summary>
+        /// A binary constant representing the can translate flag.
+        /// </summary>
         CanTranslate = 1 << 7,
     }
 }

--- a/CefSharp/Enums/ContextMenuMediaState.cs
+++ b/CefSharp/Enums/ContextMenuMediaState.cs
@@ -12,16 +12,49 @@ namespace CefSharp
     [Flags]
     public enum ContextMenuMediaState
     {
+        /// <summary>
+        /// None
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// Error
+        /// </summary>
         Error = 1 << 0,
+        /// <summary>
+        /// Paused
+        /// </summary>
         Paused = 1 << 1,
+        /// <summary>
+        /// Muted
+        /// </summary>
         Muted = 1 << 2,
+        /// <summary>
+        /// Loop
+        /// </summary>
         Loop = 1 << 3,
+        /// <summary>
+        /// CanSave
+        /// </summary>
         CanSave = 1 << 4,
+        /// <summary>
+        /// HasAudio
+        /// </summary>
         HasAudio = 1 << 5,
+        /// <summary>
+        /// HasVideo
+        /// </summary>
         HasVideo = 1 << 6,
+        /// <summary>
+        /// ControlRootElement
+        /// </summary>
         ControlRootElement = 1 << 7,
+        /// <summary>
+        /// CanPrint
+        /// </summary>
         CanPrint = 1 << 8,
+        /// <summary>
+        /// CanRotate
+        /// </summary>
         CanRotate = 1 << 9,
     }
 }

--- a/CefSharp/Enums/CursorType.cs
+++ b/CefSharp/Enums/CursorType.cs
@@ -9,49 +9,181 @@ namespace CefSharp.Enums
     /// </summary>
     public enum CursorType
     {
+        /// <summary>
+        /// Pointer
+        /// </summary>
         Pointer = 0,
+        /// <summary>
+        /// An enum constant representing the cross option.
+        /// </summary>
         Cross,
+        /// <summary>
+        /// An enum constant representing the hand option.
+        /// </summary>
         Hand,
+        /// <summary>
+        /// An enum constant representing the beam option.
+        /// </summary>
         IBeam,
+        /// <summary>
+        /// An enum constant representing the wait option.
+        /// </summary>
         Wait,
+        /// <summary>
+        /// An enum constant representing the help option.
+        /// </summary>
         Help,
+        /// <summary>
+        /// An enum constant representing the east resize option.
+        /// </summary>
         EastResize,
+        /// <summary>
+        /// An enum constant representing the north resize option.
+        /// </summary>
         NorthResize,
+        /// <summary>
+        /// An enum constant representing the northeast resize option.
+        /// </summary>
         NortheastResize,
+        /// <summary>
+        /// An enum constant representing the northwest resize option.
+        /// </summary>
         NorthwestResize,
+        /// <summary>
+        /// An enum constant representing the south resize option.
+        /// </summary>
         SouthResize,
+        /// <summary>
+        /// An enum constant representing the southeast resize option.
+        /// </summary>
         SoutheastResize,
+        /// <summary>
+        /// An enum constant representing the southwest resize option.
+        /// </summary>
         SouthwestResize,
+        /// <summary>
+        /// An enum constant representing the west resize option.
+        /// </summary>
         WestResize,
+        /// <summary>
+        /// An enum constant representing the north south resize option.
+        /// </summary>
         NorthSouthResize,
+        /// <summary>
+        /// An enum constant representing the east west resize option.
+        /// </summary>
         EastWestResize,
+        /// <summary>
+        /// An enum constant representing the northeast southwest resize option.
+        /// </summary>
         NortheastSouthwestResize,
+        /// <summary>
+        /// An enum constant representing the northwest southeast resize option.
+        /// </summary>
         NorthwestSoutheastResize,
+        /// <summary>
+        /// An enum constant representing the column resize option.
+        /// </summary>
         ColumnResize,
+        /// <summary>
+        /// An enum constant representing the row resize option.
+        /// </summary>
         RowResize,
+        /// <summary>
+        /// An enum constant representing the middle panning option.
+        /// </summary>
         MiddlePanning,
+        /// <summary>
+        /// An enum constant representing the east panning option.
+        /// </summary>
         EastPanning,
+        /// <summary>
+        /// An enum constant representing the north panning option.
+        /// </summary>
         NorthPanning,
+        /// <summary>
+        /// An enum constant representing the northeast panning option.
+        /// </summary>
         NortheastPanning,
+        /// <summary>
+        /// An enum constant representing the northwest panning option.
+        /// </summary>
         NorthwestPanning,
+        /// <summary>
+        /// An enum constant representing the south panning option.
+        /// </summary>
         SouthPanning,
+        /// <summary>
+        /// An enum constant representing the southeast panning option.
+        /// </summary>
         SoutheastPanning,
+        /// <summary>
+        /// An enum constant representing the southwest panning option.
+        /// </summary>
         SouthwestPanning,
+        /// <summary>
+        /// An enum constant representing the west panning option.
+        /// </summary>
         WestPanning,
+        /// <summary>
+        /// An enum constant representing the move option.
+        /// </summary>
         Move,
+        /// <summary>
+        /// An enum constant representing the vertical text option.
+        /// </summary>
         VerticalText,
+        /// <summary>
+        /// An enum constant representing the cell option.
+        /// </summary>
         Cell,
+        /// <summary>
+        /// An enum constant representing the context menu option.
+        /// </summary>
         ContextMenu,
+        /// <summary>
+        /// An enum constant representing the alias option.
+        /// </summary>
         Alias,
+        /// <summary>
+        /// An enum constant representing the progress option.
+        /// </summary>
         Progress,
+        /// <summary>
+        /// An enum constant representing the no drop option.
+        /// </summary>
         NoDrop,
+        /// <summary>
+        /// An enum constant representing the copy option.
+        /// </summary>
         Copy,
+        /// <summary>
+        /// An enum constant representing the none option.
+        /// </summary>
         None,
+        /// <summary>
+        /// An enum constant representing the not allowed option.
+        /// </summary>
         NotAllowed,
+        /// <summary>
+        /// An enum constant representing the zoom in option.
+        /// </summary>
         ZoomIn,
+        /// <summary>
+        /// An enum constant representing the zoom out option.
+        /// </summary>
         ZoomOut,
+        /// <summary>
+        /// An enum constant representing the grab option.
+        /// </summary>
         Grab,
+        /// <summary>
+        /// An enum constant representing the grabbing option.
+        /// </summary>
         Grabbing,
+        /// <summary>
+        /// An enum constant representing the custom option.
+        /// </summary>
         Custom,
     }
 }

--- a/CefSharp/Enums/KeyEventType.cs
+++ b/CefSharp/Enums/KeyEventType.cs
@@ -4,6 +4,9 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// Values that represent key event types.
+    /// </summary>
     public enum KeyEventType
     {
         /// <summary>

--- a/CefSharp/Enums/LogSeverity.cs
+++ b/CefSharp/Enums/LogSeverity.cs
@@ -4,6 +4,9 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// LogSeverity
+    /// </summary>
     public enum LogSeverity
     {
         /// <summary>

--- a/CefSharp/Enums/MenuItemType.cs
+++ b/CefSharp/Enums/MenuItemType.cs
@@ -4,13 +4,34 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// Supported menu item types.
+    /// </summary>
     public enum MenuItemType
     {
+        /// <summary>
+        /// An enum constant representing the none option.
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// An enum constant representing the command option.
+        /// </summary>
         Command,
+        /// <summary>
+        /// An enum constant representing the check option.
+        /// </summary>
         Check,
+        /// <summary>
+        /// An enum constant representing the radio option.
+        /// </summary>
         Radio,
+        /// <summary>
+        /// An enum constant representing the separator option.
+        /// </summary>
         Separator,
+        /// <summary>
+        /// An enum constant representing the sub menu option.
+        /// </summary>
         SubMenu
     }
 }

--- a/CefSharp/Enums/MouseButtonType.cs
+++ b/CefSharp/Enums/MouseButtonType.cs
@@ -4,10 +4,22 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// Values that represent mouse button types.
+    /// </summary>
     public enum MouseButtonType
     {
+        /// <summary>
+        /// Left Mouse Button
+        /// </summary>
         Left = 0,
+        /// <summary>
+        /// Middle Mouse Button
+        /// </summary>
         Middle,
+        /// <summary>
+        /// Right Mouse Button
+        /// </summary>
         Right
     }
 }

--- a/CefSharp/Enums/PaintElementType.cs
+++ b/CefSharp/Enums/PaintElementType.cs
@@ -9,7 +9,13 @@ namespace CefSharp
     /// </summary>
     public enum PaintElementType
     {
+        /// <summary>
+        /// An enum constant representing the view option.
+        /// </summary>
         View = 0,
+        /// <summary>
+        /// An enum constant representing the popup option.
+        /// </summary>
         Popup
     };
 }

--- a/CefSharp/Enums/PointerType.cs
+++ b/CefSharp/Enums/PointerType.cs
@@ -9,10 +9,25 @@ namespace CefSharp.Enums
     /// </summary>
     public enum PointerType
     {
+        /// <summary>
+        /// An enum constant representing the touch option.
+        /// </summary>
         Touch = 0,
+        /// <summary>
+        /// An enum constant representing the mouse option.
+        /// </summary>
         Mouse,
+        /// <summary>
+        /// An enum constant representing the pen option.
+        /// </summary>
         Pen,
+        /// <summary>
+        /// An enum constant representing the eraser option.
+        /// </summary>
         Eraser,
+        /// <summary>
+        /// An enum constant representing the unknown option.
+        /// </summary>
         Unknown
     }
 }

--- a/CefSharp/Enums/PostDataElementType.cs
+++ b/CefSharp/Enums/PostDataElementType.cs
@@ -9,8 +9,17 @@ namespace CefSharp
     /// </summary>
     public enum PostDataElementType
     {
+        /// <summary>
+        /// An enum constant representing the empty option.
+        /// </summary>
         Empty = 0,
+        /// <summary>
+        /// An enum constant representing the bytes option.
+        /// </summary>
         Bytes,
+        /// <summary>
+        /// An enum constant representing the file option.
+        /// </summary>
         File
     }
 }

--- a/CefSharp/Enums/ReferrerPolicy.cs
+++ b/CefSharp/Enums/ReferrerPolicy.cs
@@ -5,41 +5,69 @@
 namespace CefSharp
 {
     /// <summary>
-    /// Values that represent referrer policies.
+    /// Policy for how the Referrer HTTP header value will be sent during navigation.
+    /// If the `--no-referrers` command-line flag is specified then the policy value
+    /// will be ignored and the Referrer value will never be sent.
+    /// Must be kept synchronized with net::URLRequest::ReferrerPolicy from Chromium.
     /// </summary>
     public enum ReferrerPolicy
     {
         /// <summary>
-        /// Always send the complete Referrer value.
+        /// Clear the referrer header if the header value is HTTPS but the request
+        /// destination is HTTP. This is the default behavior.
         /// </summary>
-        Always = 0,
+        ClearReferrerOnTransitionFromSecureToInsecure,
 
         /// <summary>
-        /// Use the default policy. This is OriginWhenCrossOrigin
-        /// when the `--reduced-referrer-granularity` command-line flag is specified
-        /// and NoReferrerWhenDowngrade otherwise.
+        /// Default which is equivilent to <see cref="ClearReferrerOnTransitionFromSecureToInsecure"/>
         /// </summary>
-        Default,
+        Default = ClearReferrerOnTransitionFromSecureToInsecure,
 
         /// <summary>
-        /// When navigating from HTTPS to HTTP do not send the Referrer value.
-        /// Otherwise, send the complete Referrer value.
+        /// A slight variant on <see cref="ClearReferrerOnTransitionFromSecureToInsecure"/>:
+        /// If the request destination is HTTP, an HTTPS referrer will be cleared. If
+        /// the request's destination is cross-origin with the referrer (but does not
+        /// downgrade), the referrer's granularity will be stripped down to an origin
+        /// rather than a full URL. Same-origin requests will send the full referrer.
         /// </summary>
-        NoReferrerWhenDowngrade,
+        ReduceReferrerGranularityOnTransitionCrossOrigin,
 
         /// <summary>
-        /// Never send the Referrer value.
+        /// Strip the referrer down to an origin when the origin of the referrer is
+        /// different from the destination's origin.
         /// </summary>
-        Never,
+        OriginOnlyOnTransitionCrossOrigin,
 
         /// <summary>
-        /// Only send the origin component of the Referrer value.
+        /// Never change the referrer.
+        /// </summary>
+        NeverClearReferrer,
+
+        /// <summary>
+        /// Strip the referrer down to the origin regardless of the redirect location.
         /// </summary>
         Origin,
 
         /// <summary>
-        /// When navigating cross-origin only send the origin component of the Referrer value. Otherwise, send the complete Referrer value.
+        /// Clear the referrer when the request's referrer is cross-origin with the
+        /// request's destination.
         /// </summary>
-        OriginWhenCrossOrigin
+        ClearReferrerOnTransitionCrossOrigin,
+
+        /// <summary>
+        /// Strip the referrer down to the origin, but clear it entirely if the
+        /// referrer value is HTTPS and the destination is HTTP.
+        /// </summary>
+        OriginClearOnTransitionFromSecureToInsecure,
+
+        /// <summary>
+        /// Always clear the referrer regardless of the request destination.
+        /// </summary>
+        NoReferrer,
+
+        /// <summary>
+        /// Always the last value in this enumeration.
+        /// </summary>
+        LastValue = NoReferrer,
     }
 }

--- a/CefSharp/Enums/ReferrerPolicy.cs
+++ b/CefSharp/Enums/ReferrerPolicy.cs
@@ -4,6 +4,9 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// Values that represent referrer policies.
+    /// </summary>
     public enum ReferrerPolicy
     {
         /// <summary>

--- a/CefSharp/Enums/SslContentStatus.cs
+++ b/CefSharp/Enums/SslContentStatus.cs
@@ -10,8 +10,17 @@ namespace CefSharp
     /// </summary>
     public enum SslContentStatus
     {
+        /// <summary>
+        /// HTTP page, or HTTPS page with no insecure content..
+        /// </summary>
         NormalContent = 0,
+        /// <summary>
+        /// HTTPS page containing "displayed" HTTP resources (e.g. images, CSS).
+        /// </summary>
         DisplayedInsecureContent = 1 << 0,
+        /// <summary>
+        /// HTTPS page containing "executed" HTTP resources (i.e. script)
+        /// </summary>
         RanInsecureContent = 1 << 1,
     }
 }

--- a/CefSharp/Enums/SslVersion.cs
+++ b/CefSharp/Enums/SslVersion.cs
@@ -10,13 +10,37 @@ namespace CefSharp
     /// </summary>
     public enum SslVersion
     {
-        Unknown = 0,  // Unknown SSL version.
+        /// <summary>
+        /// Unknown SSL version.
+        /// </summary>
+        Unknown = 0,
+        /// <summary>
+        /// An enum constant representing the ssl 2 option.
+        /// </summary>
         Ssl2 = 1,
+        /// <summary>
+        /// An enum constant representing the ssl 3 option.
+        /// </summary>
         Ssl3 = 2,
+        /// <summary>
+        /// An enum constant representing the TLS 1.0 option.
+        /// </summary>
         Tls1 = 3,
+        /// <summary>
+        /// An enum constant representing the TLS 1.1 option.
+        /// </summary>
         Tls1_1 = 4,
+        /// <summary>
+        /// An enum constant representing the TLS 1.2 option.
+        /// </summary>
         Tls1_2 = 5,
+        /// <summary>
+        /// An enum constant representing the TLS 1.3 option.
+        /// </summary>
         Tls1_3 = 6,
+        /// <summary>
+        /// An enum constant representing the QUIC option.
+        /// </summary>
         Quic = 7,
     }
 }

--- a/CefSharp/Enums/TextInputMode.cs
+++ b/CefSharp/Enums/TextInputMode.cs
@@ -11,15 +11,45 @@ namespace CefSharp.Enums
     /// </summary>
     public enum TextInputMode
     {
+        /// <summary>
+        /// An enum constant representing the default option.
+        /// </summary>
         Default = 0,
+        /// <summary>
+        /// An enum constant representing the none option.
+        /// </summary>
         None,
+        /// <summary>
+        /// An enum constant representing the text option.
+        /// </summary>
         Text,
+        /// <summary>
+        /// An enum constant representing the tel option.
+        /// </summary>
         Tel,
+        /// <summary>
+        /// An enum constant representing the URL option.
+        /// </summary>
         Url,
+        /// <summary>
+        /// An enum constant representing the mail option.
+        /// </summary>
         EMail,
+        /// <summary>
+        /// An enum constant representing the numeric option.
+        /// </summary>
         Numeric,
+        /// <summary>
+        /// An enum constant representing the decimal option.
+        /// </summary>
         Decimal,
+        /// <summary>
+        /// An enum constant representing the search option.
+        /// </summary>
         Search,
+        /// <summary>
+        /// An enum constant representing the Maximum option.
+        /// </summary>
         Max = Search
     }
 }

--- a/CefSharp/Enums/TouchEventType.cs
+++ b/CefSharp/Enums/TouchEventType.cs
@@ -9,9 +9,21 @@ namespace CefSharp.Enums
     /// </summary>
     public enum TouchEventType
     {
+        /// <summary>
+        /// An enum constant representing the released option.
+        /// </summary>
         Released = 0,
+        /// <summary>
+        /// An enum constant representing the pressed option.
+        /// </summary>
         Pressed,
+        /// <summary>
+        /// An enum constant representing the moved option.
+        /// </summary>
         Moved,
+        /// <summary>
+        /// An enum constant representing the cancelled option.
+        /// </summary>
         Cancelled
     }
 }

--- a/CefSharp/Enums/WindowOpenDisposition.cs
+++ b/CefSharp/Enums/WindowOpenDisposition.cs
@@ -9,15 +9,45 @@ namespace CefSharp
     /// </summary>
     public enum WindowOpenDisposition
     {
+        /// <summary>
+        /// An enum constant representing the unknown option.
+        /// </summary>
         Unknown,
+        /// <summary>
+        /// An enum constant representing the current tab option.
+        /// </summary>
         CurrentTab,
+        /// <summary>
+        /// Indicates that only one tab with the url should exist in the same window
+        /// </summary>
         SingletonTab,
+        /// <summary>
+        /// An enum constant representing the new foreground tab option.
+        /// </summary>
         NewForegroundTab,
+        /// <summary>
+        /// An enum constant representing the new background tab option.
+        /// </summary>
         NewBackgroundTab,
+        /// <summary>
+        /// An enum constant representing the new popup option.
+        /// </summary>
         NewPopup,
+        /// <summary>
+        /// An enum constant representing the new window option.
+        /// </summary>
         NewWindow,
+        /// <summary>
+        /// An enum constant representing the save to disk option.
+        /// </summary>
         SaveToDisk,
+        /// <summary>
+        /// An enum constant representing the off the record option.
+        /// </summary>
         OffTheRecord,
+        /// <summary>
+        /// An enum constant representing the ignore action option.
+        /// </summary>
         IgnoreAction
     }
 }

--- a/CefSharp/Event/JavascriptMessageReceivedEventArgs.cs
+++ b/CefSharp/Event/JavascriptMessageReceivedEventArgs.cs
@@ -15,10 +15,30 @@ namespace CefSharp
     {
         private static readonly IBinder Binder = new DefaultBinder();
 
+
+        /// <summary>
+        /// The frame that called CefSharp.PostMessage in Javascript
+        /// </summary>
         public IFrame Frame { get; private set; }
+
+        /// <summary>
+        /// The browser that hosts the <see cref="IFrame"/>
+        /// </summary>
         public IBrowser Browser { get; private set; }
+
+        /// <summary>
+        /// Message can be a primative type or a simple object that represents a copy
+        /// of the data sent from the browser
+        /// </summary>
         public object Message { get; private set; }
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="browser">The browser that hosts the <see cref="IFrame"/></param>
+        /// <param name="frame">The frame that called CefSharp.PostMessage in Javascript.</param>
+        /// <param name="message">Message can be a primative type or a simple object that represents a copy of the data sent from the
+        /// browser.</param>
         public JavascriptMessageReceivedEventArgs(IBrowser browser, IFrame frame, object message)
         {
             Browser = browser;

--- a/CefSharp/Handler/IDisplayHandler.cs
+++ b/CefSharp/Handler/IDisplayHandler.cs
@@ -59,7 +59,7 @@ namespace CefSharp
         /// </summary>
         /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
         /// <param name="browser">the browser object</param>
-        /// <param name="process">ranges from 0.0 to 1.0.</param>
+        /// <param name="progress">ranges from 0.0 to 1.0.</param>
         void OnLoadingProgressChange(IWebBrowser chromiumWebBrowser, IBrowser browser, double progress);
 
         /// <summary>

--- a/CefSharp/Handler/IRequestContextHandler.cs
+++ b/CefSharp/Handler/IRequestContextHandler.cs
@@ -35,7 +35,7 @@ namespace CefSharp
         /// <summary>
         /// Called on the CEF IO thread before a resource request is initiated.
         /// This method will not be called if the client associated with <paramref name="browser"/> returns a non-NULL value
-        /// from <see cref="IRequestHandler.GetResourceRequestHandler"/> for the same request (identified by <see cref="IRequest.GetIdentifier"/>).
+        /// from <see cref="IRequestHandler.GetResourceRequestHandler"/> for the same request (identified by <see cref="IRequest.Identifier"/>).
         /// </summary>
         /// <param name="browser">represent the source browser of the request, and may be null for requests originating from service workers.</param>
         /// <param name="frame">represent the source frame of the request, and may be null for requests originating from service workers.</param>

--- a/CefSharp/Handler/IResourceRequestHandler.cs
+++ b/CefSharp/Handler/IResourceRequestHandler.cs
@@ -11,7 +11,8 @@ namespace CefSharp
     public interface IResourceRequestHandler
     {
         /// <summary>
-        /// Called on the CEF IO thread before a resource request is loaded. . 
+        /// Called on the CEF IO thread before a resource request is loaded.
+        /// To optionally filter cookies for the request return a <see cref="ICookieAccessFilter"/> object.
         /// </summary>
         /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
         /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest</param>

--- a/CefSharp/Handler/RequestHandler.cs
+++ b/CefSharp/Handler/RequestHandler.cs
@@ -7,38 +7,40 @@ using System.Security.Cryptography.X509Certificates;
 namespace CefSharp.Handler
 {
     /// <summary>
-    /// Default implementation of <see cref="IRequestHandler"/>.
-    /// This class provides default implementations of the methods from <see cref="IRequestHandler"/>,
-    /// therefore providing a convenience base class for any custom request handler.
+    /// Default implementation of <see cref="IRequestHandler"/>. This class provides default implementations of the methods from
+    /// <see cref="IRequestHandler"/>, therefore providing a convenience base class for any custom request handler.
     /// </summary>
+    /// <seealso cref="T:CefSharp.IRequestHandler"/>
     public class RequestHandler : IRequestHandler
     {
-        /// <inheritdoc />
+        /// <inheritdoc/>
         bool IRequestHandler.OnBeforeBrowse(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, bool userGesture, bool isRedirect)
         {
             return OnBeforeBrowse(chromiumWebBrowser, browser, frame, request, userGesture, isRedirect);
         }
 
         /// <summary>
-        /// Called before browser navigation.
-        /// If the navigation is allowed <see cref="IWebBrowser.FrameLoadStart"/> and <see cref="IWebBrowser.FrameLoadEnd"/>
-        /// will be called. If the navigation is canceled <see cref="IWebBrowser.LoadError"/> will be called with an ErrorCode
-        /// value of <see cref="CefErrorCode.Aborted"/>. 
+        /// Called before browser navigation. If the navigation is allowed <see cref="IWebBrowser.FrameLoadStart"/> and
+        /// <see cref="IWebBrowser.FrameLoadEnd"/>
+        /// will be called. If the navigation is canceled <see cref="IWebBrowser.LoadError"/> will be called with an ErrorCode value of
+        /// <see cref="CefErrorCode.Aborted"/>.
         /// </summary>
-        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="frame">The frame the request is coming from</param>
-        /// <param name="request">the request object - cannot be modified in this callback</param>
-        /// <param name="userGesture">The value will be true if the browser navigated via explicit user gesture
-        /// (e.g. clicking a link) or false if it navigated automatically (e.g. via the DomContentLoaded event).</param>
-        /// <param name="isRedirect">has the request been redirected</param>
-        /// <returns>Return true to cancel the navigation or false to allow the navigation to proceed.</returns>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="frame">The frame the request is coming from.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="userGesture">The value will be true if the browser navigated via explicit user gesture (e.g. clicking a link) or
+        /// false if it navigated automatically (e.g. via the DomContentLoaded event).</param>
+        /// <param name="isRedirect">has the request been redirected.</param>
+        /// <returns>
+        /// Return true to cancel the navigation or false to allow the navigation to proceed.
+        /// </returns>
         protected virtual bool OnBeforeBrowse(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, bool userGesture, bool isRedirect)
         {
             return false;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         bool IRequestHandler.OnOpenUrlFromTab(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string targetUrl,
             WindowOpenDisposition targetDisposition, bool userGesture)
         {
@@ -46,30 +48,29 @@ namespace CefSharp.Handler
         }
 
         /// <summary>
-        /// Called on the UI thread before OnBeforeBrowse in certain limited cases
-        /// where navigating a new or different browser might be desirable. This
-        /// includes user-initiated navigation that might open in a special way (e.g.
-        /// links clicked via middle-click or ctrl + left-click) and certain types of
-        /// cross-origin navigation initiated from the renderer process (e.g.
-        /// navigating the top-level frame to/from a file URL).
+        /// Called on the UI thread before OnBeforeBrowse in certain limited cases where navigating a new or different browser might be
+        /// desirable. This includes user-initiated navigation that might open in a special way (e.g. links clicked via middle-click or
+        /// ctrl + left-click) and certain types of cross-origin navigation initiated from the renderer process (e.g. navigating the top-
+        /// level frame to/from a file URL).
         /// </summary>
-        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="frame">The frame object</param>
-        /// <param name="targetUrl">target url</param>
-        /// <param name="targetDisposition">The value indicates where the user intended to navigate the browser based
-        /// on standard Chromium behaviors (e.g. current tab, new tab, etc). </param>
-        /// <param name="userGesture">The value will be true if the browser navigated via explicit user gesture
-        /// (e.g. clicking a link) or false if it navigated automatically (e.g. via the DomContentLoaded event).</param>
-        /// <returns>Return true to cancel the navigation or false to allow the navigation
-        /// to proceed in the source browser's top-level frame.</returns>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="frame">The frame object.</param>
+        /// <param name="targetUrl">target url.</param>
+        /// <param name="targetDisposition">The value indicates where the user intended to navigate the browser based on standard
+        /// Chromium behaviors (e.g. current tab, new tab, etc).</param>
+        /// <param name="userGesture">The value will be true if the browser navigated via explicit user gesture (e.g. clicking a link) or
+        /// false if it navigated automatically (e.g. via the DomContentLoaded event).</param>
+        /// <returns>
+        /// Return true to cancel the navigation or false to allow the navigation to proceed in the source browser's top-level frame.
+        /// </returns>
         protected virtual bool OnOpenUrlFromTab(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string targetUrl,
             WindowOpenDisposition targetDisposition, bool userGesture)
         {
             return false;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         IResourceRequestHandler IRequestHandler.GetResourceRequestHandler(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
         {
             return GetResourceRequestHandler(chromiumWebBrowser, browser, frame, request, isNavigation, isDownload, requestInitiator, ref disableDefaultHandling);
@@ -78,21 +79,26 @@ namespace CefSharp.Handler
         /// <summary>
         /// Called on the CEF IO thread before a resource request is initiated.
         /// </summary>
-        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
-        /// <param name="browser">represent the source browser of the request</param>
-        /// <param name="frame">represent the source frame of the request</param>
-        /// <param name="request">represents the request contents and cannot be modified in this callback</param>
-        /// <param name="isNavigation">will be true if the resource request is a navigation</param>
-        /// <param name="isDownload">will be true if the resource request is a download</param>
-        /// <param name="requestInitiator">is the origin (scheme + domain) of the page that initiated the request</param>
-        /// <param name="disableDefaultHandling">to true to disable default handling of the request, in which case it will need to be handled via <see cref="IResourceRequestHandler.GetResourceHandler"/> or it will be canceled</param>
-        /// <returns>To allow the resource load to proceed with default handling return null. To specify a handler for the resource return a <see cref="IResourceRequestHandler"/> object. If this callback returns null the same method will be called on the associated <see cref="IRequestContextHandler"/>, if any</returns>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control.</param>
+        /// <param name="browser">represent the source browser of the request.</param>
+        /// <param name="frame">represent the source frame of the request.</param>
+        /// <param name="request">represents the request contents and cannot be modified in this callback.</param>
+        /// <param name="isNavigation">will be true if the resource request is a navigation.</param>
+        /// <param name="isDownload">will be true if the resource request is a download.</param>
+        /// <param name="requestInitiator">is the origin (scheme + domain) of the page that initiated the request.</param>
+        /// <param name="disableDefaultHandling">[in,out] to true to disable default handling of the request, in which case it will need
+        /// to be handled via <see cref="IResourceRequestHandler.GetResourceHandler"/> or it will be canceled.</param>
+        /// <returns>
+        /// To allow the resource load to proceed with default handling return null. To specify a handler for the resource return a
+        /// <see cref="IResourceRequestHandler"/> object. If this callback returns null the same method will be called on the associated
+        /// <see cref="IRequestContextHandler"/>, if any.
+        /// </returns>
         protected virtual IResourceRequestHandler GetResourceRequestHandler(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
         {
             return null;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         bool IRequestHandler.GetAuthCredentials(IWebBrowser chromiumWebBrowser, IBrowser browser, string originUrl, bool isProxy, string host,
             int port, string realm, string scheme, IAuthCallback callback)
         {
@@ -102,16 +108,19 @@ namespace CefSharp.Handler
         /// <summary>
         /// Called when the browser needs credentials from the user.
         /// </summary>
-        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="originUrl">is the origin making this authentication request</param>
-        /// <param name="isProxy">indicates whether the host is a proxy server</param>
-        /// <param name="host">hostname</param>
-        /// <param name="port">port number</param>
-        /// <param name="realm">realm</param>
-        /// <param name="scheme">scheme</param>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="originUrl">is the origin making this authentication request.</param>
+        /// <param name="isProxy">indicates whether the host is a proxy server.</param>
+        /// <param name="host">hostname.</param>
+        /// <param name="port">port number.</param>
+        /// <param name="realm">realm.</param>
+        /// <param name="scheme">scheme.</param>
         /// <param name="callback">Callback interface used for asynchronous continuation of authentication requests.</param>
-        /// <returns>Return true to continue the request and call <see cref="IAuthCallback.Continue(string, string)"/> when the authentication information is available. Return false to cancel the request. </returns>
+        /// <returns>
+        /// Return true to continue the request and call <see cref="IAuthCallback.Continue(string, string)"/> when the authentication
+        /// information is available. Return false to cancel the request.
+        /// </returns>
         protected virtual bool GetAuthCredentials(IWebBrowser chromiumWebBrowser, IBrowser browser, string originUrl, bool isProxy, string host,
             int port, string realm, string scheme, IAuthCallback callback)
         {
@@ -119,7 +128,7 @@ namespace CefSharp.Handler
             return false;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         bool IRequestHandler.OnQuotaRequest(IWebBrowser chromiumWebBrowser, IBrowser browser, string originUrl, long newSize,
             IRequestCallback callback)
         {
@@ -127,18 +136,19 @@ namespace CefSharp.Handler
         }
 
         /// <summary>
-        /// Called when JavaScript requests a specific storage quota size via the webkitStorageInfo.requestQuota function.
-        /// For async processing return true and execute <see cref="IRequestCallback.Continue"/> at a later time to 
-        /// grant or deny the request or <see cref="IRequestCallback.Cancel"/> to cancel.
+        /// Called when JavaScript requests a specific storage quota size via the webkitStorageInfo.requestQuota function. For async
+        /// processing return true and execute <see cref="IRequestCallback.Continue"/> at a later time to grant or deny the request or
+        /// <see cref="IRequestCallback.Cancel"/> to cancel.
         /// </summary>
-        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="originUrl">the origin of the page making the request</param>
-        /// <param name="newSize">is the requested quota size in bytes</param>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="originUrl">the origin of the page making the request.</param>
+        /// <param name="newSize">is the requested quota size in bytes.</param>
         /// <param name="callback">Callback interface used for asynchronous continuation of url requests.</param>
-        /// <returns>Return false to cancel the request immediately. Return true to continue the request
-        /// and call <see cref="IRequestCallback.Continue"/> either in this method or at a later time to
-        /// grant or deny the request.</returns>
+        /// <returns>
+        /// Return false to cancel the request immediately. Return true to continue the request and call
+        /// <see cref="IRequestCallback.Continue"/> either in this method or at a later time to grant or deny the request.
+        /// </returns>
         protected virtual bool OnQuotaRequest(IWebBrowser chromiumWebBrowser, IBrowser browser, string originUrl, long newSize,
             IRequestCallback callback)
         {
@@ -146,7 +156,7 @@ namespace CefSharp.Handler
             return false;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         bool IRequestHandler.OnCertificateError(IWebBrowser chromiumWebBrowser, IBrowser browser, CefErrorCode errorCode, string requestUrl,
            ISslInfo sslInfo, IRequestCallback callback)
         {
@@ -154,21 +164,21 @@ namespace CefSharp.Handler
         }
 
         /// <summary>
-        /// Called to handle requests for URLs with an invalid SSL certificate.
-        /// Return true and call <see cref="IRequestCallback.Continue"/> either
-        /// in this method or at a later time to continue or cancel the request.  
-        /// If CefSettings.IgnoreCertificateErrors is set all invalid certificates
-        /// will be accepted without calling this method.
+        /// Called to handle requests for URLs with an invalid SSL certificate. Return true and call
+        /// <see cref="IRequestCallback.Continue"/> either in this method or at a later time to continue or cancel the request.  
+        /// If CefSettings.IgnoreCertificateErrors is set all invalid certificates will be accepted without calling this method.
         /// </summary>
-        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="errorCode">the error code for this invalid certificate</param>
-        /// <param name="requestUrl">the url of the request for the invalid certificate</param>
-        /// <param name="sslInfo">ssl certificate information</param>
-        /// <param name="callback">Callback interface used for asynchronous continuation of url requests.
-        /// If empty the error cannot be recovered from and the request will be canceled automatically.</param>
-        /// <returns>Return false to cancel the request immediately. Return true and use <see cref="IRequestCallback"/> to
-        /// execute in an async fashion.</returns>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="errorCode">the error code for this invalid certificate.</param>
+        /// <param name="requestUrl">the url of the request for the invalid certificate.</param>
+        /// <param name="sslInfo">ssl certificate information.</param>
+        /// <param name="callback">Callback interface used for asynchronous continuation of url requests. If empty the error cannot be
+        /// recovered from and the request will be canceled automatically.</param>
+        /// <returns>
+        /// Return false to cancel the request immediately. Return true and use <see cref="IRequestCallback"/> to execute in an async
+        /// fashion.
+        /// </returns>
         protected virtual bool OnCertificateError(IWebBrowser chromiumWebBrowser, IBrowser browser, CefErrorCode errorCode, string requestUrl,
             ISslInfo sslInfo, IRequestCallback callback)
         {
@@ -176,7 +186,7 @@ namespace CefSharp.Handler
             return false;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         bool IRequestHandler.OnSelectClientCertificate(IWebBrowser chromiumWebBrowser, IBrowser browser, bool isProxy, string host, int port,
             X509Certificate2Collection certificates, ISelectClientCertificateCallback callback)
         {
@@ -186,15 +196,19 @@ namespace CefSharp.Handler
         /// <summary>
         /// Called when the browser needs user to select Client Certificate for authentication requests (eg. PKI authentication).
         /// </summary>
-        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="isProxy">indicates whether the host is a proxy server</param>
-        /// <param name="host">hostname</param>
-        /// <param name="port">port number</param>
-        /// <param name="certificates">List of Client certificates for selection</param>
-        /// <param name="callback">Callback interface used for asynchronous continuation of client certificate selection for authentication requests.</param>
-        /// <returns>Return true to continue the request and call ISelectClientCertificateCallback.Select() with the selected certificate for authentication. 
-        /// Return false to use the default behavior where the browser selects the first certificate from the list. </returns>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="isProxy">indicates whether the host is a proxy server.</param>
+        /// <param name="host">hostname.</param>
+        /// <param name="port">port number.</param>
+        /// <param name="certificates">List of Client certificates for selection.</param>
+        /// <param name="callback">Callback interface used for asynchronous continuation of client certificate selection for
+        /// authentication requests.</param>
+        /// <returns>
+        /// Return true to continue the request and call ISelectClientCertificateCallback.Select() with the selected certificate for
+        /// authentication. Return false to use the default behavior where the browser selects the first certificate from the list.
+        /// 
+        /// </returns>
         protected virtual bool OnSelectClientCertificate(IWebBrowser chromiumWebBrowser, IBrowser browser, bool isProxy, string host, int port,
             X509Certificate2Collection certificates, ISelectClientCertificateCallback callback)
         {
@@ -202,40 +216,39 @@ namespace CefSharp.Handler
             return false;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         void IRequestHandler.OnPluginCrashed(IWebBrowser chromiumWebBrowser, IBrowser browser, string pluginPath)
         {
             OnPluginCrashed(chromiumWebBrowser, browser, pluginPath);
         }
 
         /// <summary>
-        /// Called when a plugin has crashed
+        /// Called when a plugin has crashed.
         /// </summary>
-        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
-        /// <param name="pluginPath">path of the plugin that crashed</param>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
+        /// <param name="pluginPath">path of the plugin that crashed.</param>
         protected virtual void OnPluginCrashed(IWebBrowser chromiumWebBrowser, IBrowser browser, string pluginPath)
         {
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         void IRequestHandler.OnRenderViewReady(IWebBrowser chromiumWebBrowser, IBrowser browser)
         {
             OnRenderViewReady(chromiumWebBrowser, browser);
         }
 
         /// <summary>
-        /// Called on the CEF UI thread when the render view associated
-        /// with browser is ready to receive/handle IPC messages in the render
-        /// process.
+        /// Called on the CEF UI thread when the render view associated with browser is ready to receive/handle IPC messages in the
+        /// render process.
         /// </summary>
-        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
         protected virtual void OnRenderViewReady(IWebBrowser chromiumWebBrowser, IBrowser browser)
         {
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         void IRequestHandler.OnRenderProcessTerminated(IWebBrowser chromiumWebBrowser, IBrowser browser, CefTerminationStatus status)
         {
             OnRenderProcessTerminated(chromiumWebBrowser, browser, status);
@@ -244,8 +257,8 @@ namespace CefSharp.Handler
         /// <summary>
         /// Called when the render process terminates unexpectedly.
         /// </summary>
-        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control</param>
-        /// <param name="browser">the browser object</param>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object.</param>
         /// <param name="status">indicates how the process terminated.</param>
         protected virtual void OnRenderProcessTerminated(IWebBrowser chromiumWebBrowser, IBrowser browser, CefTerminationStatus status)
         {

--- a/CefSharp/Handler/ResourceRequestHandler.cs
+++ b/CefSharp/Handler/ResourceRequestHandler.cs
@@ -5,87 +5,284 @@
 namespace CefSharp.Handler
 {
     /// <summary>
-    /// Default implementation of <see cref="IResourceRequestHandler"/>.
-    /// This class provides default implementations of the methods from <see cref="IResourceRequestHandler"/>,
-    /// therefore providing a convenience base class for any custom resource request handler.
+    /// Default implementation of <see cref="IResourceRequestHandler"/>. This class provides default implementations of the methods
+    /// from <see cref="IResourceRequestHandler"/>, therefore providing a convenience base class for any custom resource request
+    /// handler.
     /// </summary>
+    /// <seealso cref="T:CefSharp.IResourceRequestHandler"/>
     public class ResourceRequestHandler : IResourceRequestHandler
     {
+        /// <summary>
+        /// Called on the CEF IO thread before a resource request is loaded. To optionally filter cookies for the request return a
+        /// <see cref="ICookieAccessFilter"/> object.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - can be modified in this callback.</param>
+        /// <returns>To optionally filter cookies for the request return a ICookieAccessFilter instance otherwise return null.</returns>
         ICookieAccessFilter IResourceRequestHandler.GetCookieAccessFilter(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request)
         {
             return GetCookieAccessFilter(chromiumWebBrowser, browser, frame, request);
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread before a resource request is loaded. To optionally filter cookies for the request return a
+        /// <see cref="ICookieAccessFilter"/> object.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - can be modified in this callback.</param>
+        /// <returns>To optionally filter cookies for the request return a ICookieAccessFilter instance otherwise return null.</returns>
         protected virtual ICookieAccessFilter GetCookieAccessFilter(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request)
         {
             return null;
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread before a resource is loaded. To specify a handler for the resource return a
+        /// <see cref="IResourceHandler"/> object.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The browser UI control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <returns>
+        /// To allow the resource to load using the default network loader return null otherwise return an instance of
+        /// <see cref="IResourceHandler"/> with a valid stream.
+        /// </returns>
         IResourceHandler IResourceRequestHandler.GetResourceHandler(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request)
         {
             return GetResourceHandler(chromiumWebBrowser, browser, frame, request);
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread before a resource is loaded. To specify a handler for the resource return a
+        /// <see cref="IResourceHandler"/> object.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The browser UI control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <returns>
+        /// To allow the resource to load using the default network loader return null otherwise return an instance of
+        /// <see cref="IResourceHandler"/> with a valid stream.
+        /// </returns>
         protected virtual IResourceHandler GetResourceHandler(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request)
         {
             return null;
         }
 
+        /// <summary>Called on the CEF IO thread to optionally filter resource response content.</summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <returns>Return an IResponseFilter to intercept this response, otherwise return null.</returns>
         IResponseFilter IResourceRequestHandler.GetResourceResponseFilter(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response)
         {
             return GetResourceResponseFilter(chromiumWebBrowser, browser, frame, request, response);
         }
 
+        /// <summary>Called on the CEF IO thread to optionally filter resource response content.</summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <returns>Return an IResponseFilter to intercept this response, otherwise return null.</returns>
         protected virtual IResponseFilter GetResourceResponseFilter(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response)
         {
             return null;
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread before a resource request is loaded. To redirect or change the resource load optionally modify
+        /// <paramref name="request"/>. Modification of the request URL will be treated as a redirect.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - can be modified in this callback.</param>
+        /// <param name="callback">Callback interface used for asynchronous continuation of url requests.</param>
+        /// <returns>
+        /// Return <see cref="CefReturnValue.Continue"/> to continue the request immediately. Return
+        /// <see cref="CefReturnValue.ContinueAsync"/> and call <see cref="IRequestCallback.Continue"/> or
+        /// <see cref="IRequestCallback.Cancel"/> at a later time to continue or the cancel the request asynchronously. Return
+        /// <see cref="CefReturnValue.Cancel"/> to cancel the request immediately.
+        /// </returns>
         CefReturnValue IResourceRequestHandler.OnBeforeResourceLoad(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IRequestCallback callback)
         {
             return OnBeforeResourceLoad(chromiumWebBrowser, browser, frame, request, callback);
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread before a resource request is loaded. To redirect or change the resource load optionally modify
+        /// <paramref name="request"/>. Modification of the request URL will be treated as a redirect.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - can be modified in this callback.</param>
+        /// <param name="callback">Callback interface used for asynchronous continuation of url requests.</param>
+        /// <returns>
+        /// Return <see cref="CefReturnValue.Continue"/> to continue the request immediately. Return
+        /// <see cref="CefReturnValue.ContinueAsync"/> and call <see cref="IRequestCallback.Continue"/> or
+        /// <see cref="IRequestCallback.Cancel"/> at a later time to continue or the cancel the request asynchronously. Return
+        /// <see cref="CefReturnValue.Cancel"/> to cancel the request immediately.
+        /// </returns>
         protected virtual CefReturnValue OnBeforeResourceLoad(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IRequestCallback callback)
         {
             return CefReturnValue.Continue;
         }
 
+        /// <summary>
+        /// Called on the CEF UI thread to handle requests for URLs with an unknown protocol component. SECURITY WARNING: YOU SHOULD USE
+        /// THIS METHOD TO ENFORCE RESTRICTIONS BASED ON SCHEME, HOST OR OTHER URL ANALYSIS BEFORE ALLOWING OS EXECUTION.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <returns>
+        /// return to true to attempt execution via the registered OS protocol handler, if any. Otherwise return false.
+        /// </returns>
         bool IResourceRequestHandler.OnProtocolExecution(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request)
         {
             return OnProtocolExecution(chromiumWebBrowser, browser, frame, request);
         }
 
+        /// <summary>
+        /// Called on the CEF UI thread to handle requests for URLs with an unknown protocol component. SECURITY WARNING: YOU SHOULD USE
+        /// THIS METHOD TO ENFORCE RESTRICTIONS BASED ON SCHEME, HOST OR OTHER URL ANALYSIS BEFORE ALLOWING OS EXECUTION.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <returns>
+        /// return to true to attempt execution via the registered OS protocol handler, if any. Otherwise return false.
+        /// </returns>
         protected virtual bool OnProtocolExecution(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request)
         {
             return false;
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread when a resource load has completed. This method will be called for all requests, including
+        /// requests that are aborted due to CEF shutdown or destruction of the associated browser. In cases where the associated browser
+        /// is destroyed this callback may arrive after the <see cref="ILifeSpanHandler.OnBeforeClose"/> callback for that browser. The
+        /// <see cref="IFrame.IsValid"/> method can be used to test for this situation, and care
+        /// should be taken not to call <paramref name="browser"/> or <paramref name="frame"/> methods that modify state (like LoadURL,
+        /// SendProcessMessage, etc.) if the frame is invalid.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <param name="status">indicates the load completion status.</param>
+        /// <param name="receivedContentLength">is the number of response bytes actually read.</param>
         void IResourceRequestHandler.OnResourceLoadComplete(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response, UrlRequestStatus status, long receivedContentLength)
         {
             OnResourceLoadComplete(chromiumWebBrowser, browser, frame, request, response, status, receivedContentLength);
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread when a resource load has completed. This method will be called for all requests, including
+        /// requests that are aborted due to CEF shutdown or destruction of the associated browser. In cases where the associated browser
+        /// is destroyed this callback may arrive after the <see cref="ILifeSpanHandler.OnBeforeClose"/> callback for that browser. The
+        /// <see cref="IFrame.IsValid"/> method can be used to test for this situation, and care
+        /// should be taken not to call <paramref name="browser"/> or <paramref name="frame"/> methods that modify state (like LoadURL,
+        /// SendProcessMessage, etc.) if the frame is invalid.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <param name="status">indicates the load completion status.</param>
+        /// <param name="receivedContentLength">is the number of response bytes actually read.</param>
         protected virtual void OnResourceLoadComplete(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response, UrlRequestStatus status, long receivedContentLength)
         {
 
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread when a resource load is redirected. The <paramref name="request"/> parameter will contain the old
+        /// URL and other request-related information. The <paramref name="response"/> parameter will contain the response that resulted
+        /// in the redirect. The <paramref name="newUrl"/> parameter will contain the new URL and can be changed if desired.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <param name="newUrl">[in,out] the new URL and can be changed if desired.</param>
         void IResourceRequestHandler.OnResourceRedirect(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response, ref string newUrl)
         {
             OnResourceRedirect(chromiumWebBrowser, browser, frame, request, response, ref newUrl);
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread when a resource load is redirected. The <paramref name="request"/> parameter will contain the old
+        /// URL and other request-related information. The <paramref name="response"/> parameter will contain the response that resulted
+        /// in the redirect. The <paramref name="newUrl"/> parameter will contain the new URL and can be changed if desired.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object - cannot be modified in this callback.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <param name="newUrl">[in,out] the new URL and can be changed if desired.</param>
         protected virtual void OnResourceRedirect(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response, ref string newUrl)
         {
 
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread when a resource response is received. To allow the resource load to proceed without modification
+        /// return false. To redirect or retry the resource load optionally modify <paramref name="request"/> and return true.
+        /// Modification of the request URL will be treated as a redirect. Requests handled using the default network loader cannot be
+        /// redirected in this callback.
+        /// 
+        /// WARNING: Redirecting using this method is deprecated. Use OnBeforeResourceLoad or GetResourceHandler to perform redirects.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <returns>
+        /// To allow the resource load to proceed without modification return false. To redirect or retry the resource load optionally
+        /// modify <paramref name="request"/> and return true. Modification of the request URL will be treated as a redirect. Requests
+        /// handled using the default network loader cannot be redirected in this callback.
+        /// </returns>
         bool IResourceRequestHandler.OnResourceResponse(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response)
         {
             return OnResourceResponse(chromiumWebBrowser, browser, frame, request, response);
         }
 
+        /// <summary>
+        /// Called on the CEF IO thread when a resource response is received. To allow the resource load to proceed without modification
+        /// return false. To redirect or retry the resource load optionally modify <paramref name="request"/> and return true.
+        /// Modification of the request URL will be treated as a redirect. Requests handled using the default network loader cannot be
+        /// redirected in this callback.
+        /// 
+        /// WARNING: Redirecting using this method is deprecated. Use OnBeforeResourceLoad or GetResourceHandler to perform redirects.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">The ChromiumWebBrowser control.</param>
+        /// <param name="browser">the browser object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="frame">the frame object - may be null if originating from ServiceWorker or CefURLRequest.</param>
+        /// <param name="request">the request object.</param>
+        /// <param name="response">the response object - cannot be modified in this callback.</param>
+        /// <returns>
+        /// To allow the resource load to proceed without modification return false. To redirect or retry the resource load optionally
+        /// modify <paramref name="request"/> and return true. Modification of the request URL will be treated as a redirect. Requests
+        /// handled using the default network loader cannot be redirected in this callback.
+        /// </returns>
         protected virtual bool OnResourceResponse(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response)
         {
             return false;

--- a/CefSharp/IBrowser.cs
+++ b/CefSharp/IBrowser.cs
@@ -44,15 +44,15 @@ namespace CefSharp
         bool IsLoading { get; }
 
         /// <summary>
-        /// Request that the browser close. The JavaScript 'onbeforeunload' event will
-        /// be fired. If |forceClose| is false the event handler, if any, will be
-        /// allowed to prompt the user and the user can optionally cancel the close.
-        /// If |force_close| is true the prompt will not be displayed and the close
-        /// will proceed. Results in a call to CefLifeSpanHandler::DoClose() if the
-        /// event handler allows the close or if |force_close| is true. See
-        /// CefLifeSpanHandler::DoClose() documentation for additional usage
-        /// information.
+        /// Request that the browser close. The JavaScript 'onbeforeunload' event will be fired.
         /// </summary>
+        /// <param name="forceClose">
+        /// If forceClose is false the event handler, if any, will be allowed to prompt the user and the
+        /// user can optionally cancel the close. If forceClose is true the prompt will not be displayed
+        /// and the close will proceed. Results in a call to <see cref="ILifeSpanHandler.DoClose"/> if
+        /// the event handler allows the close or if forceClose is true
+        /// See <see cref="ILifeSpanHandler.DoClose"/> documentation for additional usage information.
+        /// </param>
         void CloseBrowser(bool forceClose);
 
         /// <summary>

--- a/CefSharp/IBrowserHost.cs
+++ b/CefSharp/IBrowserHost.cs
@@ -37,6 +37,15 @@ namespace CefSharp
         void CloseBrowser(bool forceClose);
 
         /// <summary>
+        /// Helper for closing a browser. Call this method from the top-level window close handler. Internally this calls CloseBrowser(false) if the close has not yet been initiated. This method returns false while the close is pending and true after the close has completed.
+        /// See <see cref="CloseBrowser(bool)"/> and <see cref="ILifeSpanHandler.DoClose(IWebBrowser, IBrowser)"/> documentation for additional usage information. This method must be called on the CEF UI thread.
+        /// </summary>
+        /// <returns>
+        /// This method returns false while the close is pending and true after the close has completed
+        /// </returns>
+        bool TryCloseBrowser();
+
+        /// <summary>
         /// Explicitly close the developer tools window if one exists for this browser instance.
         /// </summary>
         void CloseDevTools();

--- a/CefSharp/IBrowserHost.cs
+++ b/CefSharp/IBrowserHost.cs
@@ -21,7 +21,7 @@ namespace CefSharp
         /// <summary>
         /// Add the specified word to the spelling dictionary.
         /// </summary>
-        /// <param name="word"></param>
+        /// <param name="word">custom word to be added to dictionary</param>
         void AddWordToDictionary(string word);
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace CefSharp
         void DragTargetDragDrop(MouseEvent mouseEvent);
 
         /// <summary>
-        /// Call this method when the drag operation started by a <see cref="CefSharp.Internals.IRenderWebBrowser.StartDragging"/> call has ended either in a drop or by being cancelled.
+        /// Call this method when the drag operation started by a <see cref="CefSharp.Internals.IRenderWebBrowser.StartDragging(IDragData, DragOperationsMask, int, int)"/> call has ended either in a drop or by being cancelled.
         /// If the web view is both the drag source and the drag target then all DragTarget* methods should be called before DragSource* methods.
         /// This method is only used when window rendering is disabled. 
         /// </summary>
@@ -82,7 +82,7 @@ namespace CefSharp
         void DragTargetDragLeave();
 
         /// <summary>
-        /// Call this method when the drag operation started by a <see cref="CefSharp.Internals.IRenderWebBrowser.StartDragging"/> call has completed.
+        /// Call this method when the drag operation started by a <see cref="CefSharp.Internals.IRenderWebBrowser.StartDragging(IDragData, DragOperationsMask, int, int)"/> call has completed.
         /// This method may be called immediately without first calling DragSourceEndedAt to cancel a drag operation.
         /// If the web view is both the drag source and the drag target then all DragTarget* methods should be called before DragSource* mthods.
         /// This method is only used when window rendering is disabled. 

--- a/CefSharp/IDragData.cs
+++ b/CefSharp/IDragData.cs
@@ -17,7 +17,7 @@ namespace CefSharp
         /// <summary>
         /// Gets a copy of the current drag data
         /// </summary>
-        /// <returns></returns>
+        /// <returns>a clone of the current object</returns>
         IDragData Clone();
 
         /// <summary>

--- a/CefSharp/IFrame.cs
+++ b/CefSharp/IFrame.cs
@@ -195,6 +195,8 @@ namespace CefSharp
         ///
         /// The request object will be marked as read-only after calling this method. 
         /// </summary>
+        /// <param name="request">the web request</param>
+        /// <param name="client">the client</param>
         IUrlRequest CreateUrlRequest(IRequest request, IUrlRequestClient client);
     }
 }

--- a/CefSharp/IPopupFeatures.cs
+++ b/CefSharp/IPopupFeatures.cs
@@ -9,17 +9,89 @@ namespace CefSharp
     /// </summary>
     public interface IPopupFeatures
     {
+        /// <summary>
+        /// Gets the x coordinate.
+        /// </summary>
+        /// <value>
+        /// The x coordinate.
+        /// </value>
         int X { get; }
+        /// <summary>
+        /// Gets the set.
+        /// </summary>
+        /// <value>
+        /// The x coordinate set.
+        /// </value>
         int XSet { get; }
+        /// <summary>
+        /// Gets the y coordinate.
+        /// </summary>
+        /// <value>
+        /// The y coordinate.
+        /// </value>
         int Y { get; }
+        /// <summary>
+        /// Gets the set.
+        /// </summary>
+        /// <value>
+        /// The y coordinate set.
+        /// </value>
         int YSet { get; }
+        /// <summary>
+        /// Gets the width.
+        /// </summary>
+        /// <value>
+        /// The width.
+        /// </value>
         int Width { get; }
+        /// <summary>
+        /// Gets the set the width belongs to.
+        /// </summary>
+        /// <value>
+        /// The width set.
+        /// </value>
         int WidthSet { get; }
+        /// <summary>
+        /// Gets the height.
+        /// </summary>
+        /// <value>
+        /// The height.
+        /// </value>
         int Height { get; }
+        /// <summary>
+        /// Gets the set the height belongs to.
+        /// </summary>
+        /// <value>
+        /// The height set.
+        /// </value>
         int HeightSet { get; }
+        /// <summary>
+        /// Gets a value indicating whether the menu bar is visible.
+        /// </summary>
+        /// <value>
+        /// True if menu bar visible, false if not.
+        /// </value>
         bool MenuBarVisible { get; }
+        /// <summary>
+        /// Gets a value indicating whether the status bar is visible.
+        /// </summary>
+        /// <value>
+        /// True if status bar visible, false if not.
+        /// </value>
         bool StatusBarVisible { get; }
+        /// <summary>
+        /// Gets a value indicating whether the tool bar is visible.
+        /// </summary>
+        /// <value>
+        /// True if tool bar visible, false if not.
+        /// </value>
         bool ToolBarVisible { get; }
+        /// <summary>
+        /// Gets a value indicating whether the scrollbars is visible.
+        /// </summary>
+        /// <value>
+        /// True if scrollbars visible, false if not.
+        /// </value>
         bool ScrollbarsVisible { get; }
     }
 }

--- a/CefSharp/IPostData.cs
+++ b/CefSharp/IPostData.cs
@@ -16,7 +16,7 @@ namespace CefSharp
         /// Add the specified <see cref="IPostDataElement"/>.
         /// </summary>
         /// <param name="element">element to be added.</param>
-        /// <returns> Returns true if the add succeeds.</returns>
+        /// <returns>Returns true if the add succeeds.</returns>
         bool AddElement(IPostDataElement element);
 
         /// <summary>

--- a/CefSharp/JavascriptStackFrame.cs
+++ b/CefSharp/JavascriptStackFrame.cs
@@ -4,14 +4,42 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// A Javascript(V8) stack frame
+    /// </summary>
+    /// TODO: Refactor to pass params in throw constructor and make properties readonly
     public class JavascriptStackFrame
     {
+        /// <summary>
+        /// Gets or sets the name of the function.
+        /// </summary>
+        /// <value>
+        /// The name of the function.
+        /// </value>
         public string FunctionName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the line number.
+        /// </summary>
+        /// <value>
+        /// The line number.
+        /// </value>
         public int LineNumber { get; set; }
 
+        /// <summary>
+        /// Gets or sets the column number.
+        /// </summary>
+        /// <value>
+        /// The column number.
+        /// </value>
         public int ColumnNumber { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the source.
+        /// </summary>
+        /// <value>
+        /// The name of the source.
+        /// </value>
         public string SourceName { get; set; }
     }
 }

--- a/CefSharp/ModelBinding/DefaultBinder.cs
+++ b/CefSharp/ModelBinding/DefaultBinder.cs
@@ -61,6 +61,15 @@ namespace CefSharp.ModelBinding
             return BindObject(targetType, objType, obj);
         }
 
+        /// <summary>
+        /// Bind collection.
+        /// </summary>
+        /// <param name="targetType">the target param type.</param>
+        /// <param name="objType">Type of the object.</param>
+        /// <param name="obj">object to be converted into a model.</param>
+        /// <returns>
+        /// An object.
+        /// </returns>
         protected virtual object BindCollection(Type targetType, Type objType, object obj)
         {
             var collection = obj as ICollection;
@@ -129,6 +138,15 @@ namespace CefSharp.ModelBinding
             return model;
         }
 
+        /// <summary>
+        /// Bind object.
+        /// </summary>
+        /// <param name="targetType">the target param type.</param>
+        /// <param name="objType">Type of the object.</param>
+        /// <param name="obj">object to be converted into a model.</param>
+        /// <returns>
+        /// An object.
+        /// </returns>
         protected virtual object BindObject(Type targetType, Type objType, object obj)
         {
             var model = Activator.CreateInstance(targetType, true);

--- a/CefSharp/Properties/AssemblyInfo.cs
+++ b/CefSharp/Properties/AssemblyInfo.cs
@@ -28,6 +28,7 @@ using CefSharp;
 
 namespace CefSharp
 {
+    /// <exclude />
     public static class AssemblyInfo
     {
         public const bool ClsCompliant = false;

--- a/CefSharp/RequestContextExtensions.cs
+++ b/CefSharp/RequestContextExtensions.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace CefSharp
 {
+    /// <summary>
+    /// RequestContext extensions.
+    /// </summary>
     public static class RequestContextExtensions
     {
         /// <summary>

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -202,10 +202,17 @@ namespace CefSharp
             {
                 responseLength = ResponseLength.Value;
             }
-            else if (Stream != null && Stream.CanSeek)
+
+            if (Stream != null && Stream.CanSeek)
             {
-                //If no ResponseLength provided then attempt to infer the length
-                responseLength = Stream.Length;
+                //ResponseLength property has higher precedence over Stream.Length
+                if (ResponseLength == null || responseLength == 0)
+                {
+                    //If no ResponseLength provided then attempt to infer the length
+                    responseLength = Stream.Length;
+                }
+
+                Stream.Position = 0;
             };
         }
 

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -168,7 +168,8 @@ namespace CefSharp
                 tempBuffer = new byte[dataOut.Length];
             }
 
-            bytesRead = Stream.Read(tempBuffer, 0, tempBuffer.Length);
+            //Only read the number of bytes that can be written to dataOut
+            bytesRead = Stream.Read(tempBuffer, 0, (int)dataOut.Length);
 
             // To indicate response completion set bytesRead to 0 and return false
             if (bytesRead == 0)

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -963,7 +963,31 @@ namespace CefSharp
             {".xtp", "application/octet-stream"},
             {".xwd", "image/x-xwindowdump"},
             {".z", "application/x-compress"},
-            {".zip", "application/x-zip-compressed"}
+            {".zip", "application/x-zip-compressed"},
+
+            // Recently added entries from 
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
+            // https://cs.chromium.org/chromium/src/net/base/mime_util.cc?sq=package:chromium&g=0&l=147
+            {".wasm", "application/wasm"},
+            {".ogg", "audio/ogg"},
+            {".oga", "audio/ogg"},
+            {".ogv", "video/ogg"},
+            {".opus", "audio/opus"},
+            {".webm", "video/webm"},
+            {".weba", "audio/webm"},
+            //https://developers.google.com/speed/webp
+            {".webp", "image/webp"},
+            {".epub", "application/epub+zip"},
+            // We'll map .woff to font/woff as application/font-woff is deprecated
+            // https://tools.ietf.org/html/rfc8081#section-4.4.5
+            // Deprecated Alias:  The existing registration "application/font-woff" is deprecated in favor of "font/woff".
+            {".woff", "font/woff"},
+            // https://www.w3.org/TR/WOFF2/#IMT
+            // https://tools.ietf.org/html/rfc8081#section-4.4.6
+            {".woff2", "font/woff2"},
+            //TODO: Mapping should be updated (exists above)
+            //{".ttf", "font/ttf"},
+            {".otf", "font/otf"}
         };
 
         /// <summary>

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -219,8 +219,14 @@ namespace CefSharp
 
         void IResourceHandler.Cancel()
         {
-            Stream = null;
-            tempBuffer = null;
+            // Prior to Prior to https://bitbucket.org/chromiumembedded/cef/commits/90301bdb7fd0b32137c221f38e8785b3a8ad8aa4
+            // This method was unexpectedly being called during Read (from a different thread),
+            // changes to the threading model were made and I haven't confirmed if this is still
+            // the case.
+            // 
+            // The documentation for Cancel is vaigue and there aren't any examples that
+            // illustrage it's intended use case so for now we'll just keep things
+            // simple and free our resources in Dispose
         }
 
         bool IResourceHandler.ProcessRequest(IRequest request, ICallback callback)
@@ -988,8 +994,10 @@ namespace CefSharp
             if (AutoDisposeStream && Stream != null)
             {
                 Stream.Dispose();
-                Stream = null;
             }
+
+            Stream = null;
+            tempBuffer = null;
         }
     }
 }

--- a/CefSharp/ResourceRequestHandlerFactory.cs
+++ b/CefSharp/ResourceRequestHandlerFactory.cs
@@ -79,7 +79,7 @@ namespace CefSharp
         /// <summary>
         /// Called before a resource is loaded. To specify a handler for the resource return a <see cref="ResourceHandler"/> object
         /// </summary>
-        /// <param name="browserControl">The browser UI control</param>
+        /// <param name="chromiumWebBrowser">The browser UI control</param>
         /// <param name="browser">the browser object</param>
         /// <param name="frame">the frame object</param>
         /// <param name="request">the request object - cannot be modified in this callback</param>

--- a/CefSharp/ResourceRequestHandlerFactoryItem.cs
+++ b/CefSharp/ResourceRequestHandlerFactoryItem.cs
@@ -4,6 +4,9 @@
 
 namespace CefSharp
 {
+    /// <summary>
+    /// A resource request handler factory item.
+    /// </summary>
     public class ResourceRequestHandlerFactoryItem
     {
         /// <summary>

--- a/CefSharp/Structs/CompositionUnderline.cs
+++ b/CefSharp/Structs/CompositionUnderline.cs
@@ -30,6 +30,15 @@ namespace CefSharp.Structs
         /// </summary>
         public bool Thick { get; private set; }
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="range">Underline character range.</param>
+        /// <param name="color">Text color. 32-bit ARGB color value, not premultiplied. The color components are always in a known order.
+        /// Equivalent to the SkColor type.</param>
+        /// <param name="backGroundColor">Background color. 32-bit ARGB color value, not premultiplied. The color components are always in
+        /// a known order. Equivalent to the SkColor type.</param>
+        /// <param name="thick">True for thickunderline.</param>
         public CompositionUnderline(Range range, uint color, uint backGroundColor, bool thick)
             : this()
         {

--- a/CefSharp/V8Extension.cs
+++ b/CefSharp/V8Extension.cs
@@ -42,6 +42,13 @@ namespace CefSharp
             JavascriptCode = javascriptCode;
         }
 
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (obj == null || GetType() != obj.GetType())
@@ -52,6 +59,12 @@ namespace CefSharp
             return Name.Equals(ext.Name);
         }
 
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
         public override int GetHashCode()
         {
             return Name.GetHashCode();

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -18,6 +18,11 @@ namespace CefSharp
     /// </summary>
     public static class WebBrowserExtensions
     {
+        internal const string BrowserNotInitializedExceptionErrorMessage =
+            "The ChromiumWebBrowser instance creates the underlying Chromium Embedded Framework (CEF) browser instance in an async fashion. " +
+            "The undelying CefBrowser instance is not yet initialized. Use the IsBrowserInitializedChanged event and check " +
+            "the IsBrowserInitialized property to determine when the browser has been initialized."
+
         #region Legacy Javascript Binding
         /// <summary>
         /// Registers a Javascript object in this specific browser instance.
@@ -1158,15 +1163,17 @@ namespace CefSharp
         /// <summary>
         /// An IWebBrowser extension method that throw exception if browser not initialized.
         /// </summary>
+        /// <remarks>
+        /// Not used in WPF as IsBrowserInitialized is a dependency property and can only be checked on the UI thread(throws
+        /// InvalidOperationException if called on another Thread).
+        /// </remarks>
         /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
         /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         internal static void ThrowExceptionIfBrowserNotInitialized(this IWebBrowser browser)
         {
             if (!browser.IsBrowserInitialized)
             {
-                throw new Exception("The ChromiumWebBrowser instance creates the underlying Chromium Embedded Framework (CEF) browser instance in an async fashion. " +
-                                    "The undelying CefBrowser instance is not yet initialized. Use the IsBrowserInitializedChanged event and check " +
-                                    "the IsBrowserInitialized property to determine when the browser has been initialized.");
+                throw new Exception(BrowserNotInitializedExceptionErrorMessage);
             }
         }
 

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -57,7 +57,7 @@ namespace CefSharp
         /// <summary>
         /// Returns the main (top-level) frame for the browser window.
         /// </summary>
-        /// <param name="webBrowser">the ChromiumWebBrowser instance</param>
+        /// <param name="browser">the ChromiumWebBrowser instance</param>
         /// <returns>Frame</returns>
         public static IFrame GetMainFrame(this IWebBrowser browser)
         {
@@ -874,6 +874,15 @@ namespace CefSharp
             cefBrowser.AddWordToDictionary(word);
         }
 
+        /// <summary>
+        /// Send a mouse wheel event to the browser.
+        /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="x">The x coordinate relative to upper-left corner of view.</param>
+        /// <param name="y">The y coordinate relative to upper-left corner of view.</param>
+        /// <param name="deltaX">The delta x coordinate.</param>
+        /// <param name="deltaY">The delta y coordinate.</param>
+        /// <param name="modifiers">The modifiers.</param>
         public static void SendMouseWheelEvent(this IWebBrowser browser, int x, int y, int deltaX, int deltaY, CefEventFlags modifiers)
         {
             var cefBrowser = browser.GetBrowser();
@@ -882,6 +891,15 @@ namespace CefSharp
             cefBrowser.SendMouseWheelEvent(x, y, deltaX, deltaY, modifiers);
         }
 
+        /// <summary>
+        /// Send a mouse wheel event to the browser.
+        /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="x">The x coordinate relative to upper-left corner of view.</param>
+        /// <param name="y">The y coordinate relative to upper-left corner of view.</param>
+        /// <param name="deltaX">The delta x coordinate.</param>
+        /// <param name="deltaY">The delta y coordinate.</param>
+        /// <param name="modifiers">The modifiers.</param>
         public static void SendMouseWheelEvent(this IBrowser browser, int x, int y, int deltaX, int deltaY, CefEventFlags modifiers)
         {
             browser.ThrowExceptionIfBrowserNull();
@@ -892,6 +910,15 @@ namespace CefSharp
             host.SendMouseWheelEvent(new MouseEvent(x, y, modifiers), deltaX, deltaY);
         }
 
+        /// <summary>
+        /// Send a mouse wheel event to the browser.
+        /// </summary>
+        /// <param name="host">browserHost.</param>
+        /// <param name="x">The x coordinate relative to upper-left corner of view.</param>
+        /// <param name="y">The y coordinate relative to upper-left corner of view.</param>
+        /// <param name="deltaX">The delta x coordinate.</param>
+        /// <param name="deltaY">The delta y coordinate.</param>
+        /// <param name="modifiers">The modifiers.</param>
         public static void SendMouseWheelEvent(this IBrowserHost host, int x, int y, int deltaX, int deltaY, CefEventFlags modifiers)
         {
             ThrowExceptionIfBrowserHostNull(host);
@@ -899,6 +926,16 @@ namespace CefSharp
             host.SendMouseWheelEvent(new MouseEvent(x, y, modifiers), deltaX, deltaY);
         }
 
+        /// <summary>
+        /// Send a mouse click event to the browser.
+        /// </summary>
+        /// <param name="host">browserHost.</param>
+        /// <param name="x">The x coordinate relative to upper-left corner of view.</param>
+        /// <param name="y">The y coordinate relative to upper-left corner of view.</param>
+        /// <param name="mouseButtonType">Type of the mouse button.</param>
+        /// <param name="mouseUp">True to mouse up.</param>
+        /// <param name="clickCount">Number of clicks.</param>
+        /// <param name="modifiers">The modifiers.</param>
         public static void SendMouseClickEvent(this IBrowserHost host, int x, int y, MouseButtonType mouseButtonType, bool mouseUp, int clickCount, CefEventFlags modifiers)
         {
             ThrowExceptionIfBrowserHostNull(host);
@@ -906,6 +943,14 @@ namespace CefSharp
             host.SendMouseClickEvent(new MouseEvent(x, y, modifiers), mouseButtonType, mouseUp, clickCount);
         }
 
+        /// <summary>
+        /// Send a mouse move event to the browser
+        /// </summary>
+        /// <param name="host">browserHost.</param>
+        /// <param name="x">The x coordinate relative to upper-left corner of view.</param>
+        /// <param name="y">The y coordinate relative to upper-left corner of view.</param>
+        /// <param name="mouseLeave">mouse leave</param>
+        /// <param name="modifiers">The modifiers.</param>
         public static void SendMouseMoveEvent(this IBrowserHost host, int x, int y, bool mouseLeave, CefEventFlags modifiers)
         {
             ThrowExceptionIfBrowserHostNull(host);
@@ -913,6 +958,18 @@ namespace CefSharp
             host.SendMouseMoveEvent(new MouseEvent(x, y, modifiers), mouseLeave);
         }
 
+        /// <summary>
+        /// Evaluate some Javascript code in the context of the MainFrame of the ChromiumWebBrowser. The script will be executed
+        /// asynchronously and the method returns a Task encapsulating the response from the Javascript This simple helper extension will
+        /// encapsulate params in single quotes (unless int, uint, etc)
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when one or more arguments are outside the required range.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="script">The Javascript code that should be executed.</param>
+        /// <param name="timeout">(Optional) The timeout after which the Javascript code execution should be aborted.</param>
+        /// <returns>
+        /// <see cref="Task{JavascriptResponse}"/> that can be awaited to perform the script execution.
+        /// </returns>
         public static Task<JavascriptResponse> EvaluateScriptAsync(this IWebBrowser browser, string script, TimeSpan? timeout = null)
         {
             if (timeout.HasValue && timeout.Value.TotalMilliseconds > UInt32.MaxValue)
@@ -965,6 +1022,11 @@ namespace CefSharp
             return browser.EvaluateScriptAsync(script, timeout);
         }
 
+        /// <summary>
+        /// An IWebBrowser extension method that sets the <see cref="IWebBrowserInternal.HasParent"/>
+        /// property used when passing a ChromiumWebBrowser instance to <see cref="ILifeSpanHandler.OnBeforePopup"/>
+        /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void SetAsPopup(this IWebBrowser browser)
         {
             var internalBrowser = (IWebBrowserInternal)browser;

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -21,7 +21,7 @@ namespace CefSharp
         internal const string BrowserNotInitializedExceptionErrorMessage =
             "The ChromiumWebBrowser instance creates the underlying Chromium Embedded Framework (CEF) browser instance in an async fashion. " +
             "The undelying CefBrowser instance is not yet initialized. Use the IsBrowserInitializedChanged event and check " +
-            "the IsBrowserInitialized property to determine when the browser has been initialized."
+            "the IsBrowserInitialized property to determine when the browser has been initialized.";
 
         #region Legacy Javascript Binding
         /// <summary>

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -14,8 +14,7 @@ using CefSharp.Web;
 namespace CefSharp
 {
     /// <summary>
-    /// WebBrowser extensions - These methods make performing common tasks
-    /// easier.
+    /// WebBrowser extensions - These methods make performing common tasks easier.
     /// </summary>
     public static class WebBrowserExtensions
     {
@@ -23,10 +22,10 @@ namespace CefSharp
         /// <summary>
         /// Registers a Javascript object in this specific browser instance.
         /// </summary>
-        /// <param name="webBrowser">The browser to perform the registering on</param>
+        /// <param name="webBrowser">The browser to perform the registering on.</param>
         /// <param name="name">The name of the object. (e.g. "foo", if you want the object to be accessible as window.foo).</param>
         /// <param name="objectToBind">The object to be made accessible to Javascript.</param>
-        /// <param name="options">binding options - camelCaseJavascriptNames default to true </param>
+        /// <param name="options">(Optional) binding options - camelCaseJavascriptNames default to true.</param>
         /// <exception cref="Exception">Browser is already initialized. RegisterJsObject must be +
         ///                                     called before the underlying CEF browser is created.</exception>
         [Obsolete("This method has been removed, see https://github.com/cefsharp/CefSharp/issues/2990 for details on migrating your code.")]
@@ -57,8 +56,8 @@ namespace CefSharp
         /// <summary>
         /// Returns the main (top-level) frame for the browser window.
         /// </summary>
-        /// <param name="browser">the ChromiumWebBrowser instance</param>
-        /// <returns>Frame</returns>
+        /// <param name="browser">the ChromiumWebBrowser instance.</param>
+        /// <returns> the main frame. </returns>
         public static IFrame GetMainFrame(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -71,7 +70,8 @@ namespace CefSharp
         /// <summary>
         /// Returns the focused frame for the browser window.
         /// </summary>
-        /// <returns>Frame</returns>
+        /// <param name="browser">the ChromiumWebBrowser instance.</param>
+        /// <returns>the focused frame.</returns>
         public static IFrame GetFocusedFrame(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -82,9 +82,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Undo on the focused frame
+        /// Execute Undo on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Undo(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -96,9 +96,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Redo on the focused frame
+        /// Execute Redo on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Redo(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -110,9 +110,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Cut on the focused frame
+        /// Execute Cut on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Cut(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -124,9 +124,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Copy on the focused frame
+        /// Execute Copy on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Copy(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -138,9 +138,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Paste on the focused frame
+        /// Execute Paste on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Paste(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -152,9 +152,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Delete on the focused frame
+        /// Execute Delete on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Delete(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -166,9 +166,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute SelectAll on the focused frame
+        /// Execute SelectAll on the focused frame.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void SelectAll(this IWebBrowser browser)
         {
             using (var frame = browser.GetFocusedFrame())
@@ -180,10 +180,10 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Opens up a new program window (using the default text editor) where the source code of the currently displayed web
-        /// page is shown.
+        /// Opens up a new program window (using the default text editor) where the source code of the currently displayed web page is
+        /// shown.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void ViewSource(this IWebBrowser browser)
         {
             using (var frame = browser.GetMainFrame())
@@ -197,8 +197,10 @@ namespace CefSharp
         /// <summary>
         /// Retrieve the main frame's HTML source using a <see cref="Task{String}"/>.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <returns><see cref="Task{String}"/> that when executed returns the frame source as a string</returns>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <returns>
+        /// <see cref="Task{String}"/> that when executed returns the main frame source as a string.
+        /// </returns>
         public static Task<string> GetSourceAsync(this IWebBrowser browser)
         {
             using (var frame = browser.GetMainFrame())
@@ -212,8 +214,10 @@ namespace CefSharp
         /// <summary>
         /// Retrieve the main frame's display text using a <see cref="Task{String}"/>.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <returns><see cref="Task{String}"/> that when executed returns the frame display text as a string.</returns>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <returns>
+        /// <see cref="Task{String}"/> that when executed returns the main frame display text as a string.
+        /// </returns>
         public static Task<string> GetTextAsync(this IWebBrowser browser)
         {
             using (var frame = browser.GetMainFrame())
@@ -225,14 +229,14 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute some Javascript code in the context of this WebBrowser. As the method name implies, the script will be
-        /// executed asynchronously, and the method therefore returns before the script has actually been executed.
-        /// This simple helper extension will encapsulate params in single quotes (unless int, uint, etc)
+        /// Execute some Javascript code in the context of this WebBrowser. As the method name implies, the script will be executed
+        /// asynchronously, and the method therefore returns before the script has actually been executed. This simple helper extension
+        /// will encapsulate params in single quotes (unless int, uint, etc)
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="methodName">The javascript method name to execute</param>
-        /// <param name="args">the arguments to be passed as params to the method. Args are encoded using <see cref="EncodeScriptParam"/>,
-        /// you can provide a custom implementation if you require a custom implementation</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="methodName">The javascript method name to execute.</param>
+        /// <param name="args">the arguments to be passed as params to the method. Args are encoded using
+        /// <see cref="EncodeScriptParam"/>, you can provide a custom implementation if you require a custom implementation.</param>
         public static void ExecuteScriptAsync(this IWebBrowser browser, string methodName, params object[] args)
         {
             var script = GetScriptForJavascriptMethodWithArgs(methodName, args);
@@ -241,10 +245,10 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute some Javascript code in the context of this WebBrowser. As the method name implies, the script will be
-        /// executed asynchronously, and the method therefore returns before the script has actually been executed.
+        /// Execute some Javascript code in the context of this WebBrowser. As the method name implies, the script will be executed
+        /// asynchronously, and the method therefore returns before the script has actually been executed.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="script">The Javascript code that should be executed.</param>
         public static void ExecuteScriptAsync(this IWebBrowser browser, string script)
         {
@@ -262,16 +266,18 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Execute Javascript code in the context of this WebBrowser. This extension method uses the LoadingStateChanged event.
-        /// As the method name implies, the script will be executed asynchronously, and the method therefore returns before the
-        /// script has actually been executed.
+        /// Execute Javascript code in the context of this WebBrowser. This extension method uses the LoadingStateChanged event. As the
+        /// method name implies, the script will be executed asynchronously, and the method therefore returns before the script has
+        /// actually been executed.
         /// </summary>
-        /// <param name="webBrowser">The ChromiumWebBrowser instance this method extends</param>
+        /// <remarks>
+        /// Best effort is made to make sure the script is executed, there are likely a few edge cases where the script won't be executed,
+        /// if you suspect your script isn't being executed, then try executing in the LoadingStateChanged event handler to confirm that
+        /// it does indeed get executed.
+        /// </remarks>
+        /// <param name="webBrowser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="script">The Javascript code that should be executed.</param>
-        /// <param name="oneTime">The script will only be executed on first page load, subsiquent page loads will be ignored</param>
-        /// <remarks>Best effort is made to make sure the script is executed, there are likely a few edge cases where the script
-        /// won't be executed, if you suspect your script isn't being executed, then try executing in the LoadingStateChanged
-        /// event handler to confirm that it does indeed get executed.</remarks>
+        /// <param name="oneTime">(Optional) The script will only be executed on first page load, subsiquent page loads will be ignored.</param>
         public static void ExecuteScriptAsyncWhenPageLoaded(this IWebBrowser webBrowser, string script, bool oneTime = true)
         {
             var useLoadingStateChangedEventHandler = webBrowser.IsBrowserInitialized == false || oneTime == false;
@@ -316,18 +322,16 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Creates a new instance of IRequest with the specified Url and Method = POST
-        /// and then calls <see cref="IFrame.LoadRequest(IRequest)"/>.
+        /// Creates a new instance of IRequest with the specified Url and Method = POST and then calls
+        /// <see cref="IFrame.LoadRequest(IRequest)"/>.
         /// <see cref="IFrame.LoadRequest(IRequest)"/> can only be used if a renderer process already exists.
-        /// In newer versions initially loading about:blank no longer creates a renderer process. You
-        /// can load a Data Uri initially then call this method.
-        /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+        /// In newer versions initially loading about:blank no longer creates a renderer process. You can load a Data Uri initially then
+        /// call this method. https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs.
         /// </summary>
-        /// <param name="browser"></param>
-        /// <param name="url"></param>
-        /// <param name="postDataBytes"></param>
-        /// <param name="contentType"></param>
-        /// <remarks>This is an extension method</remarks>
+        /// <param name="browser">browser this method extends</param>
+        /// <param name="url">url to load</param>
+        /// <param name="postDataBytes">post data as byte array</param>
+        /// <param name="contentType">(Optional) if set the Content-Type header will be set</param>
         [Obsolete("This method will be removed in version 75 as it has become unreliable see https://github.com/cefsharp/CefSharp/issues/2705 for details.")]
         public static void LoadUrlWithPostData(this IWebBrowser browser, string url, byte[] postDataBytes, string contentType = null)
         {
@@ -361,30 +365,29 @@ namespace CefSharp
         /// Registers and loads a <see cref="ResourceHandler"/> that represents the HTML content.
         /// </summary>
         /// <remarks>
-        /// `Cef` Native `LoadHtml` is unpredictable and only works sometimes, this method wraps
-        /// the provided HTML in a <see cref="ResourceHandler"/> and loads the provided url using
-        /// the <see cref="IWebBrowser.Load"/> method.
-        /// Defaults to using <see cref="Encoding.UTF8"/> for character encoding 
-        /// The url must start with a valid schema, other uri's such as about:blank are invalid
-        /// A valid example looks like http://test/page
+        /// `Cef` Native `LoadHtml` is unpredictable and only works sometimes, this method wraps the provided HTML in a
+        /// <see cref="ResourceHandler"/> and loads the provided url using the <see cref="IWebBrowser.Load"/> method. Defaults to using
+        /// <see cref="Encoding.UTF8"/> for character encoding The url must start with a valid schema, other uri's such as about:blank
+        /// are invalid A valid example looks like http://test/page.
         /// </remarks>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="html">The HTML content.</param>
         /// <param name="url">The URL that will be treated as the address of the content.</param>
-        /// <returns>returns false if the Url was not successfully parsed into a Uri</returns>
+        /// <returns>
+        /// returns false if the Url was not successfully parsed into a Uri.
+        /// </returns>
         public static bool LoadHtml(this IWebBrowser browser, string html, string url)
         {
             return browser.LoadHtml(html, url, Encoding.UTF8);
         }
 
         /// <summary>
-        /// Loads html as Data Uri
-        /// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs for details
-        /// If base64Encode is false then html will be Uri encoded
+        /// Loads html as Data Uri See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs for details If
+        /// base64Encode is false then html will be Uri encoded.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="html">Html to load as data uri.</param>
-        /// <param name="base64Encode">if true the html string will be base64 encoded using UTF8 encoding.</param>
+        /// <param name="base64Encode">(Optional) if true the html string will be base64 encoded using UTF8 encoding.</param>
         public static void LoadHtml(this IWebBrowser browser, string html, bool base64Encode = false)
         {
             var htmlString = new HtmlString(html, base64Encode);
@@ -393,13 +396,12 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Loads html as Data Uri
-        /// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs for details
-        /// If base64Encode is false then html will be Uri encoded
+        /// Loads html as Data Uri See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs for details If
+        /// base64Encode is false then html will be Uri encoded.
         /// </summary>
-        /// <param name="frame">The <seealso cref="IFrame"/> instance this method extends</param>
+        /// <param name="frame">The <seealso cref="IFrame"/> instance this method extends.</param>
         /// <param name="html">Html to load as data uri.</param>
-        /// <param name="base64Encode">if true the html string will be base64 encoded using UTF8 encoding.</param>
+        /// <param name="base64Encode">(Optional) if true the html string will be base64 encoded using UTF8 encoding.</param>
         public static void LoadHtml(this IFrame frame, string html, bool base64Encode = false)
         {
             var htmlString = new HtmlString(html, base64Encode);
@@ -411,16 +413,19 @@ namespace CefSharp
         /// Registers and loads a <see cref="ResourceHandler"/> that represents the HTML content.
         /// </summary>
         /// <remarks>
-        /// `Cef` Native `LoadHtml` is unpredictable and only works sometimes, this method wraps
-        /// the provided HTML in a <see cref="ResourceHandler"/> and loads the provided url using
-        /// the <see cref="IWebBrowser.Load"/> method.
+        /// `Cef` Native `LoadHtml` is unpredictable and only works sometimes, this method wraps the provided HTML in a
+        /// <see cref="ResourceHandler"/> and loads the provided url using the <see cref="IWebBrowser.Load"/> method.
         /// </remarks>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="html">The HTML content.</param>
         /// <param name="url">The URL that will be treated as the address of the content.</param>
-        /// <param name="encoding">Character Encoding</param>
-        /// <param name="oneTimeUse">Whether or not the handler should be used once (true) or until manually unregistered (false)</param>
-        /// <returns>returns false if the Url was not successfully parsed into a Uri</returns>
+        /// <param name="encoding">Character Encoding.</param>
+        /// <param name="oneTimeUse">(Optional) Whether or not the handler should be used once (true) or until manually unregistered
+        /// (false)</param>
+        /// <returns>
+        /// returns false if the Url was not successfully parsed into a Uri.
+        /// </returns>
         public static bool LoadHtml(this IWebBrowser browser, string html, string url, Encoding encoding, bool oneTimeUse = false)
         {
             if (browser.ResourceRequestHandlerFactory == null)
@@ -444,14 +449,17 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Register a ResourceHandler. Can only be used when browser.ResourceHandlerFactory is an instance of DefaultResourceHandlerFactory
+        /// Register a ResourceHandler. Can only be used when browser.ResourceHandlerFactory is an instance of
+        /// DefaultResourceHandlerFactory.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="url">the url of the resource to unregister</param>
-        /// <param name="stream">Stream to be registered, the stream should not be shared with any other instances of DefaultResourceHandlerFactory</param>
-        /// <param name="mimeType">the mimeType</param>
-        /// <param name="oneTimeUse">Whether or not the handler should be used once (true) or until manually unregistered (false). If true the Stream
-        /// will be Diposed of when finished.</param>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="url">the url of the resource to unregister.</param>
+        /// <param name="stream">Stream to be registered, the stream should not be shared with any other instances of
+        /// DefaultResourceHandlerFactory.</param>
+        /// <param name="mimeType">(Optional) the mimeType.</param>
+        /// <param name="oneTimeUse">(Optional) Whether or not the handler should be used once (true) or until manually unregistered
+        /// (false). If true the Stream will be Diposed of when finished.</param>
         public static void RegisterResourceHandler(this IWebBrowser browser, string url, Stream stream, string mimeType = ResourceHandler.DefaultMimeType,
             bool oneTimeUse = false)
         {
@@ -476,10 +484,12 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Unregister a ResourceHandler. Can only be used when browser.ResourceHandlerFactory is an instance of DefaultResourceHandlerFactory
+        /// Unregister a ResourceHandler. Can only be used when browser.ResourceHandlerFactory is an instance of
+        /// DefaultResourceHandlerFactory.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="url">the url of the resource to unregister</param>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="url">the url of the resource to unregister.</param>
         public static void UnRegisterResourceHandler(this IWebBrowser browser, string url)
         {
             var handler = browser.ResourceRequestHandlerFactory as ResourceRequestHandlerFactory;
@@ -495,6 +505,7 @@ namespace CefSharp
         /// <summary>
         /// Stops loading the current page.
         /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Stop(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -507,6 +518,7 @@ namespace CefSharp
         /// <summary>
         /// Navigates back, must check <see cref="IWebBrowser.CanGoBack"/> before calling this method.
         /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Back(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -519,6 +531,7 @@ namespace CefSharp
         /// <summary>
         /// Navigates forward, must check <see cref="IWebBrowser.CanGoForward"/> before calling this method.
         /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Forward(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -531,18 +544,19 @@ namespace CefSharp
         /// <summary>
         /// Reloads the page being displayed. This method will use data from the browser's cache, if available.
         /// </summary>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Reload(this IWebBrowser browser)
         {
             browser.Reload(false);
         }
 
         /// <summary>
-        /// Reloads the page being displayed, optionally ignoring the cache (which means the whole page including all .css, .js
-        /// etc. resources will be re-fetched).
+        /// Reloads the page being displayed, optionally ignoring the cache (which means the whole page including all .css, .js etc.
+        /// resources will be re-fetched).
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="ignoreCache"><c>true</c> A reload is performed ignoring browser cache; <c>false</c> A reload is
-        /// performed using files from the browser cache, if available.</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="ignoreCache"><c>true</c> A reload is performed ignoring browser cache; <c>false</c> A reload is performed using
+        /// files from the browser cache, if available.</param>
         public static void Reload(this IWebBrowser browser, bool ignoreCache)
         {
             var cefBrowser = browser.GetBrowser();
@@ -553,12 +567,15 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Gets the default cookie manager associated with the IWebBrowser
+        /// Gets the default cookie manager associated with the IWebBrowser.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="callback">If not null it will be executed asnychronously on the
-        /// CEF IO thread after the manager's storage has been initialized.</param>
-        /// <returns>Cookie Manager</returns>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="callback">(Optional) If not null it will be executed asnychronously on the CEF IO thread after the manager's
+        /// storage has been initialized.</param>
+        /// <returns>
+        /// Cookie Manager.
+        /// </returns>
         public static ICookieManager GetCookieManager(this IWebBrowser browser, ICompletionCallback callback = null)
         {
             var host = browser.GetBrowserHost();
@@ -578,6 +595,10 @@ namespace CefSharp
         /// <summary>
         /// Asynchronously gets the current Zoom Level.
         /// </summary>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <returns>
+        /// An asynchronous result that yields the zoom level.
+        /// </returns>
         public static Task<double> GetZoomLevelAsync(this IBrowser cefBrowser)
         {
             var host = cefBrowser.GetHost();
@@ -589,6 +610,10 @@ namespace CefSharp
         /// <summary>
         /// Asynchronously gets the current Zoom Level.
         /// </summary>
+        /// <param name="browser">the ChromiumWebBrowser instance.</param>
+        /// <returns>
+        /// An asynchronous result that yields the zoom level.
+        /// </returns>
         public static Task<double> GetZoomLevelAsync(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -599,12 +624,11 @@ namespace CefSharp
         /// Change the ZoomLevel to the specified value. Can be set to 0.0 to clear the zoom level.
         /// </summary>
         /// <remarks>
-        /// If called on the CEF UI thread the change will be applied immediately.
-        /// Otherwise, the change will be applied asynchronously on the CEF UI thread.
-        /// The CEF UI thread is different to the WPF/WinForms UI Thread
+        /// If called on the CEF UI thread the change will be applied immediately. Otherwise, the change will be applied asynchronously
+        /// on the CEF UI thread. The CEF UI thread is different to the WPF/WinForms UI Thread.
         /// </remarks>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="zoomLevel">zoom level</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="zoomLevel">zoom level.</param>
         public static void SetZoomLevel(this IBrowser cefBrowser, double zoomLevel)
         {
             cefBrowser.ThrowExceptionIfBrowserNull();
@@ -619,12 +643,11 @@ namespace CefSharp
         /// Change the ZoomLevel to the specified value. Can be set to 0.0 to clear the zoom level.
         /// </summary>
         /// <remarks>
-        /// If called on the CEF UI thread the change will be applied immediately.
-        /// Otherwise, the change will be applied asynchronously on the CEF UI thread.
-        /// The CEF UI thread is different to the WPF/WinForms UI Thread
+        /// If called on the CEF UI thread the change will be applied immediately. Otherwise, the change will be applied asynchronously
+        /// on the CEF UI thread. The CEF UI thread is different to the WPF/WinForms UI Thread.
         /// </remarks>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="zoomLevel">zoom level</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="zoomLevel">zoom level.</param>
         public static void SetZoomLevel(this IWebBrowser browser, double zoomLevel)
         {
             var cefBrowser = browser.GetBrowser();
@@ -634,12 +657,11 @@ namespace CefSharp
         /// <summary>
         /// Search for text within the current page.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="identifier">Can be used in can conjunction with searchText to have multiple
-        /// searches running simultaneously.</param>
-        /// <param name="searchText">search text</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="identifier">Can be used in can conjunction with searchText to have multiple searches running simultaneously.</param>
+        /// <param name="searchText">search text.</param>
         /// <param name="forward">indicates whether to search forward or backward within the page.</param>
-        /// <param name="matchCase">indicates whether the search should be case-sensitive. </param>
+        /// <param name="matchCase">indicates whether the search should be case-sensitive.</param>
         /// <param name="findNext">indicates whether this is the first request or a follow-up.</param>
         public static void Find(this IBrowser cefBrowser, int identifier, string searchText, bool forward, bool matchCase, bool findNext)
         {
@@ -652,12 +674,11 @@ namespace CefSharp
         /// <summary>
         /// Search for text within the current page.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="identifier">Can be used in can conjunction with searchText to have multiple
-        /// searches running simultaneously.</param>
-        /// <param name="searchText">search text</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="identifier">Can be used in can conjunction with searchText to have multiple searches running simultaneously.</param>
+        /// <param name="searchText">search text.</param>
         /// <param name="forward">indicates whether to search forward or backward within the page.</param>
-        /// <param name="matchCase">indicates whether the search should be case-sensitive. </param>
+        /// <param name="matchCase">indicates whether the search should be case-sensitive.</param>
         /// <param name="findNext">indicates whether this is the first request or a follow-up.</param>
         public static void Find(this IWebBrowser browser, int identifier, string searchText, bool forward, bool matchCase, bool findNext)
         {
@@ -670,8 +691,8 @@ namespace CefSharp
         /// <summary>
         /// Cancel all searches that are currently going on.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="clearSelection">clear the current search selection</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="clearSelection">clear the current search selection.</param>
         public static void StopFinding(this IBrowser cefBrowser, bool clearSelection)
         {
             cefBrowser.ThrowExceptionIfBrowserNull();
@@ -685,8 +706,8 @@ namespace CefSharp
         /// <summary>
         /// Cancel all searches that are currently going on.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="clearSelection">clear the current search selection</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="clearSelection">clear the current search selection.</param>
         public static void StopFinding(this IWebBrowser browser, bool clearSelection)
         {
             var cefBrowser = browser.GetBrowser();
@@ -698,7 +719,7 @@ namespace CefSharp
         /// <summary>
         /// Opens a Print Dialog which if used (can be user cancelled) will print the browser contents.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Print(this IBrowser cefBrowser)
         {
             var host = cefBrowser.GetHost();
@@ -708,14 +729,16 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Asynchronously prints the current browser contents to the PDF file specified.
-        /// The caller is responsible for deleting the file when done.
+        /// Asynchronously prints the current browser contents to the PDF file specified. The caller is responsible for deleting the file
+        /// when done.
         /// </summary>
         /// <param name="cefBrowser">The <see cref="IBrowser"/> object this method extends.</param>
         /// <param name="path">Output file location.</param>
-        /// <param name="settings">Print Settings.</param>
-        /// <returns>A task that represents the asynchronous print operation.
-        /// The result is true on success or false on failure to generate the Pdf.</returns>
+        /// <param name="settings">(Optional) Print Settings.</param>
+        /// <returns>
+        /// A task that represents the asynchronous print operation. The result is true on success or false on failure to generate the
+        /// Pdf.
+        /// </returns>
         public static Task<bool> PrintToPdfAsync(this IBrowser cefBrowser, string path, PdfPrintSettings settings = null)
         {
             var host = cefBrowser.GetHost();
@@ -730,7 +753,7 @@ namespace CefSharp
         /// <summary>
         /// Opens a Print Dialog which if used (can be user cancelled) will print the browser contents.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void Print(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -740,14 +763,16 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Asynchronously prints the current browser contents to the PDF file specified.
-        /// The caller is responsible for deleting the file when done.
+        /// Asynchronously prints the current browser contents to the PDF file specified. The caller is responsible for deleting the file
+        /// when done.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="path">Output file location.</param>
-        /// <param name="settings">Print Settings.</param>
-        /// <returns>A task that represents the asynchronous print operation.
-        /// The result is true on success or false on failure to generate the Pdf.</returns>
+        /// <param name="settings">(Optional) Print Settings.</param>
+        /// <returns>
+        /// A task that represents the asynchronous print operation. The result is true on success or false on failure to generate the
+        /// Pdf.
+        /// </returns>
         public static Task<bool> PrintToPdfAsync(this IWebBrowser browser, string path, PdfPrintSettings settings = null)
         {
             var cefBrowser = browser.GetBrowser();
@@ -757,12 +782,12 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Open developer tools in its own window. 
+        /// Open developer tools in its own window.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="windowInfo">window info used for showing dev tools</param>
-        /// <param name="inspectElementAtX">x coordinate (used for inspectElement)</param>
-        /// <param name="inspectElementAtY">y coordinate (used for inspectElement)</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="windowInfo">(Optional) window info used for showing dev tools.</param>
+        /// <param name="inspectElementAtX">(Optional) x coordinate (used for inspectElement)</param>
+        /// <param name="inspectElementAtY">(Optional) y coordinate (used for inspectElement)</param>
         public static void ShowDevTools(this IBrowser cefBrowser, IWindowInfo windowInfo = null, int inspectElementAtX = 0, int inspectElementAtY = 0)
         {
             var host = cefBrowser.GetHost();
@@ -772,12 +797,12 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Open developer tools in its own window. 
+        /// Open developer tools in its own window.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="windowInfo">window info used for showing dev tools</param>
-        /// <param name="inspectElementAtX">x coordinate (used for inspectElement)</param>
-        /// <param name="inspectElementAtY">y coordinate (used for inspectElement)</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="windowInfo">(Optional) window info used for showing dev tools.</param>
+        /// <param name="inspectElementAtX">(Optional) x coordinate (used for inspectElement)</param>
+        /// <param name="inspectElementAtY">(Optional) y coordinate (used for inspectElement)</param>
         public static void ShowDevTools(this IWebBrowser browser, IWindowInfo windowInfo = null, int inspectElementAtX = 0, int inspectElementAtY = 0)
         {
             var cefBrowser = browser.GetBrowser();
@@ -788,7 +813,7 @@ namespace CefSharp
         /// <summary>
         /// Explicitly close the developer tools window if one exists for this browser instance.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
         public static void CloseDevTools(this IBrowser cefBrowser)
         {
             var host = cefBrowser.GetHost();
@@ -800,7 +825,7 @@ namespace CefSharp
         /// <summary>
         /// Explicitly close the developer tools window if one exists for this browser instance.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         public static void CloseDevTools(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -809,10 +834,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// If a misspelled word is currently selected in an editable node calling
-        /// this method will replace it with the specified word. 
+        /// If a misspelled word is currently selected in an editable node calling this method will replace it with the specified word.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="word">The new word that will replace the currently selected word.</param>
         public static void ReplaceMisspelling(this IBrowser cefBrowser, string word)
         {
@@ -823,10 +847,9 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// If a misspelled word is currently selected in an editable node calling
-        /// this method will replace it with the specified word. 
+        /// If a misspelled word is currently selected in an editable node calling this method will replace it with the specified word.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="word">The new word that will replace the currently selected word.</param>
         public static void ReplaceMisspelling(this IWebBrowser browser, string word)
         {
@@ -839,7 +862,7 @@ namespace CefSharp
         /// <summary>
         /// Add the specified word to the spelling dictionary.
         /// </summary>
-        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="cefBrowser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="word">The new word that will be added to the dictionary.</param>
         public static void AddWordToDictionary(this IBrowser cefBrowser, string word)
         {
@@ -850,10 +873,12 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Shortcut method to get the browser IBrowserHost
+        /// Shortcut method to get the browser IBrowserHost.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <returns>browserHost or null</returns>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <returns>
+        /// browserHost or null.
+        /// </returns>
         public static IBrowserHost GetBrowserHost(this IWebBrowser browser)
         {
             var cefBrowser = browser.GetBrowser();
@@ -864,7 +889,7 @@ namespace CefSharp
         /// <summary>
         /// Add the specified word to the spelling dictionary.
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="word">The new word that will be added to the dictionary.</param>
         public static void AddWordToDictionary(this IWebBrowser browser, string word)
         {
@@ -944,12 +969,12 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Send a mouse move event to the browser
+        /// Send a mouse move event to the browser.
         /// </summary>
         /// <param name="host">browserHost.</param>
         /// <param name="x">The x coordinate relative to upper-left corner of view.</param>
         /// <param name="y">The y coordinate relative to upper-left corner of view.</param>
-        /// <param name="mouseLeave">mouse leave</param>
+        /// <param name="mouseLeave">mouse leave.</param>
         /// <param name="modifiers">The modifiers.</param>
         public static void SendMouseMoveEvent(this IBrowserHost host, int x, int y, bool mouseLeave, CefEventFlags modifiers)
         {
@@ -991,30 +1016,34 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Evaluate some Javascript code in the context of this WebBrowser. The script will be executed asynchronously and the
-        /// method returns a Task encapsulating the response from the Javascript 
-        /// This simple helper extension will encapsulate params in single quotes (unless int, uint, etc)
+        /// Evaluate some Javascript code in the context of this WebBrowser. The script will be executed asynchronously and the method
+        /// returns a Task encapsulating the response from the Javascript This simple helper extension will encapsulate params in single
+        /// quotes (unless int, uint, etc)
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
-        /// <param name="methodName">The javascript method name to execute</param>
-        /// <param name="args">the arguments to be passed as params to the method</param>
-        /// <returns><see cref="Task{JavascriptResponse}"/> that can be awaited to perform the script execution</returns>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
+        /// <param name="methodName">The javascript method name to execute.</param>
+        /// <param name="args">the arguments to be passed as params to the method.</param>
+        /// <returns>
+        /// <see cref="Task{JavascriptResponse}"/> that can be awaited to perform the script execution.
+        /// </returns>
         public static Task<JavascriptResponse> EvaluateScriptAsync(this IWebBrowser browser, string methodName, params object[] args)
         {
             return browser.EvaluateScriptAsync(null, methodName, args);
         }
 
         /// <summary>
-        /// Evaluate some Javascript code in the context of this WebBrowser using the specified timeout. The script will be executed asynchronously and the
-        /// method returns a Task encapsulating the response from the Javascript 
-        /// This simple helper extension will encapsulate params in single quotes (unless int, uint, etc).
+        /// Evaluate some Javascript code in the context of this WebBrowser using the specified timeout. The script will be executed
+        /// asynchronously and the method returns a Task encapsulating the response from the Javascript This simple helper extension will
+        /// encapsulate params in single quotes (unless int, uint, etc).
         /// </summary>
-        /// <param name="browser">The ChromiumWebBrowser instance this method extends</param>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         /// <param name="timeout">The timeout after which the Javascript code execution should be aborted.</param>
-        /// <param name="methodName">The javascript method name to execute</param>
-        /// <param name="args">the arguments to be passed as params to the method. Args are encoded using <see cref="EncodeScriptParam"/>,
-        /// you can provide a custom implementation if you require a custom implementation</param>
-        /// <returns><see cref="Task{JavascriptResponse}"/> that can be awaited to perform the script execution</returns>
+        /// <param name="methodName">The javascript method name to execute.</param>
+        /// <param name="args">the arguments to be passed as params to the method. Args are encoded using
+        /// <see cref="EncodeScriptParam"/>, you can provide a custom implementation if you require a custom implementation.</param>
+        /// <returns>
+        /// <see cref="Task{JavascriptResponse}"/> that can be awaited to perform the script execution.
+        /// </returns>
         public static Task<JavascriptResponse> EvaluateScriptAsync(this IWebBrowser browser, TimeSpan? timeout, string methodName, params object[] args)
         {
             var script = GetScriptForJavascriptMethodWithArgs(methodName, args);
@@ -1036,10 +1065,14 @@ namespace CefSharp
 
         /// <summary>
         /// Function used to encode the params passed to <see cref="ExecuteScriptAsync(IWebBrowser, string, object[])"/>,
-        /// <see cref="EvaluateScriptAsync(IWebBrowser, string, object[])"/> and <see cref="EvaluateScriptAsync(IWebBrowser, TimeSpan?, string, object[])"/>
-        /// Provide your own custom function to perform custom encoding. You can use your choice
-        /// of JSON encoder here if you should so choose.
+        /// <see cref="EvaluateScriptAsync(IWebBrowser, string, object[])"/> and
+        /// <see cref="EvaluateScriptAsync(IWebBrowser, TimeSpan?, string, object[])"/>
+        /// Provide your own custom function to perform custom encoding. You can use your choice of JSON encoder here if you should so
+        /// choose.
         /// </summary>
+        /// <value>
+        /// A function delegate that yields a string.
+        /// </value>
         public static Func<string, string> EncodeScriptParam { get; set; } = (str) =>
         {
             return str.Replace("\\", "\\\\")
@@ -1050,10 +1083,12 @@ namespace CefSharp
         };
 
         /// <summary>
-        /// Checks if the given object is a numerical object
+        /// Checks if the given object is a numerical object.
         /// </summary>
-        /// <param name="value">The object to check</param>
-        /// <returns>True if numeric, otherwise false</returns>
+        /// <param name="value">The object to check.</param>
+        /// <returns>
+        /// True if numeric, otherwise false.
+        /// </returns>
         private static bool IsNumeric(this object value)
         {
             return value is sbyte
@@ -1070,11 +1105,14 @@ namespace CefSharp
         }
 
         /// <summary>
-        /// Transforms the methodName and arguments into valid Javascript code. Will encapsulate params in single quotes (unless int, uint, etc)
+        /// Transforms the methodName and arguments into valid Javascript code. Will encapsulate params in single quotes (unless int,
+        /// uint, etc)
         /// </summary>
-        /// <param name="methodName">The javascript method name to execute</param>
-        /// <param name="args">the arguments to be passed as params to the method</param>
-        /// <returns>The Javascript code</returns>
+        /// <param name="methodName">The javascript method name to execute.</param>
+        /// <param name="args">the arguments to be passed as params to the method.</param>
+        /// <returns>
+        /// The Javascript code.
+        /// </returns>
         public static string GetScriptForJavascriptMethodWithArgs(string methodName, object[] args)
         {
             var stringBuilder = new StringBuilder();
@@ -1117,6 +1155,11 @@ namespace CefSharp
             return stringBuilder.ToString();
         }
 
+        /// <summary>
+        /// An IWebBrowser extension method that throw exception if browser not initialized.
+        /// </summary>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         internal static void ThrowExceptionIfBrowserNotInitialized(this IWebBrowser browser)
         {
             if (!browser.IsBrowserInitialized)
@@ -1127,6 +1170,11 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// An IWebBrowser extension method that throw exception if disposed.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown when a supplied object has been disposed.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         internal static void ThrowExceptionIfDisposed(this IWebBrowser browser)
         {
             if (browser.IsDisposed)
@@ -1135,6 +1183,11 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// Throw exception if frame null.
+        /// </summary>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="frame">The <seealso cref="IFrame"/> instance this method extends.</param>
         private static void ThrowExceptionIfFrameNull(IFrame frame)
         {
             if (frame == null)
@@ -1143,6 +1196,11 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// An IBrowser extension method that throw exception if browser null.
+        /// </summary>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browser">The ChromiumWebBrowser instance this method extends.</param>
         private static void ThrowExceptionIfBrowserNull(this IBrowser browser)
         {
             if (browser == null)
@@ -1151,6 +1209,11 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// Throw exception if browser host null.
+        /// </summary>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
+        /// <param name="browserHost">The browser host.</param>
         private static void ThrowExceptionIfBrowserHostNull(IBrowserHost browserHost)
         {
             if (browserHost == null)
@@ -1159,6 +1222,10 @@ namespace CefSharp
             }
         }
 
+        /// <summary>
+        /// Throw exception if can execute javascript in main frame false.
+        /// </summary>
+        /// <exception cref="Exception">Thrown when an exception error condition occurs.</exception>
         private static void ThrowExceptionIfCanExecuteJavascriptInMainFrameFalse()
         {
             throw new Exception("Unable to execute javascript at this time, scripts can only be executed within a V8Context. " +

--- a/NuGet/CefSharp.OffScreen.nuspec
+++ b/NuGet/CefSharp.OffScreen.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://raw.github.com/cefsharp/CefSharp/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component (OffScreen control).</description>
-    <tags>osr chrome browser</tags>
+    <tags>osr chrome browser chromium-embedded cefsharp</tags>
     <copyright>Copyright © The CefSharp Authors</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">

--- a/NuGet/CefSharp.WinForms.nuspec
+++ b/NuGet/CefSharp.WinForms.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://raw.github.com/cefsharp/CefSharp/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component (WinForms control).</description>
-    <tags>winforms chrome browser</tags>
+    <tags>winforms chrome browser chromium-embedded cefsharp</tags>
     <copyright>Copyright © The CefSharp Authors</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">

--- a/NuGet/CefSharp.Wpf.nuspec
+++ b/NuGet/CefSharp.Wpf.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://raw.github.com/cefsharp/CefSharp/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The CefSharp Chromium-based browser component (WPF control).</description>
-    <tags>wpf chrome browser</tags>
+    <tags>wpf chrome browser chromium-embedded cefsharp</tags>
     <copyright>Copyright © The CefSharp Authors</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ If you're new to `CefSharp` and are downloading the source to check it out, plea
 | Branch                                                               | CEF Version | VC++ Version | .Net Version | Status |
 |----------------------------------------------------------------------|------|------|-------|-----------------|
 | [master](https://github.com/cefsharp/CefSharp/)                      | 3945 | 2015 | 4.5.2 | Development     |
-| [cefsharp/79](https://github.com/cefsharp/CefSharp/tree/cefsharp/79) | 3945 | 2015 | 4.5.2 | **Pre-Release** |
-| [cefsharp/77](https://github.com/cefsharp/CefSharp/tree/cefsharp/77) | 3865 | 2015 | 4.5.2 | [Unsupported](https://github.com/cefsharp/CefSharp/issues/2953)     |
-| [cefsharp/75](https://github.com/cefsharp/CefSharp/tree/cefsharp/75) | 3770 | 2015 | 4.5.2 | **Release**     |
+| [cefsharp/79](https://github.com/cefsharp/CefSharp/tree/cefsharp/79) | 3945 | 2015 | 4.5.2 | **Release**     |
+| [cefsharp/77](https://github.com/cefsharp/CefSharp/tree/cefsharp/77) | 3865 | 2015 | 4.5.2 | Unsupported     |
+| [cefsharp/75](https://github.com/cefsharp/CefSharp/tree/cefsharp/75) | 3770 | 2015 | 4.5.2 | Unsupported     |
 | [cefsharp/73](https://github.com/cefsharp/CefSharp/tree/cefsharp/73) | 3683 | 2015 | 4.5.2 | Unsupported     |
 | [cefsharp/71](https://github.com/cefsharp/CefSharp/tree/cefsharp/71) | 3578 | 2015 | 4.5.2 | Unsupported     |
 | [cefsharp/69](https://github.com/cefsharp/CefSharp/tree/cefsharp/69) | 3497 | 2015 | 4.5.2 | Unsupported     |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2015
 
-version: 79.1.310-CI{build}
+version: 79.1.350-CI{build}
 
 clone_depth: 10
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2015
 
-version: 79.1.350-CI{build}
+version: 79.1.360-CI{build}
 
 clone_depth: 10
 

--- a/build.ps1
+++ b/build.ps1
@@ -3,9 +3,9 @@
     [Parameter(Position = 0)] 
     [string] $Target = "vs2015",
     [Parameter(Position = 1)]
-    [string] $Version = "79.1.350",
+    [string] $Version = "79.1.360",
     [Parameter(Position = 2)]
-    [string] $AssemblyVersion = "79.1.350"
+    [string] $AssemblyVersion = "79.1.360"
 )
 
 $WorkingDir = split-path -parent $MyInvocation.MyCommand.Definition

--- a/build.ps1
+++ b/build.ps1
@@ -3,9 +3,9 @@
     [Parameter(Position = 0)] 
     [string] $Target = "vs2015",
     [Parameter(Position = 1)]
-    [string] $Version = "79.1.310",
+    [string] $Version = "79.1.350",
     [Parameter(Position = 2)]
-    [string] $AssemblyVersion = "79.1.310"
+    [string] $AssemblyVersion = "79.1.350"
 )
 
 $WorkingDir = split-path -parent $MyInvocation.MyCommand.Definition


### PR DESCRIPTION
Fixes [issue-number] 
   - (Partially) fixes #1262

**Summary:** [summary of the change and which issue is fixed here]
   - I have added a small code to WpfImeKeyboardHandler.cs to address a Hangul character (Korean alphabet) is not emitting to the current input box after a Hangul is composed by IME. In other words, a user cannot make a word or a sentence using Korean IME because every time a single character is composed, it disappears and start 'composing' mode all over again.
  - According to my inspection, it seems that Korean IME keeps producing characters while IME is in IME_COMPOSITION mode even before IME_ENDCOMPOSITION is sent. It is like laying eggs while a chicken is walking. Current approach to IME implemented in CefSharp.Wpf seems that in order to "finalize" composing a text, ImeSetComposition() must be first called, and then ImeFinishComposingText() must be called.
 - I am not an expert to IME programming so I cannot guarantee my solution (together with CefSharp.Wpf's approach to IME implementation) is appropriate. But I am a native Korean and it works as expected while not creating any side effects to Japanese or Chinese IME. I can speak/write Japanese or Chinese a little bit, so I also tested those IMEs as well.

**Changes:** [specify the structures changed] 
   - I have modified CefSharp.Wpf.Experimental.WpfImeKeyboardHandler.cs like below:
   1) add the following code:

```
if (languageCodeId == ImeNative.LANG_KOREAN)
{
    owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(), new Range(int.MaxValue, int.MaxValue), new Range(compositionStart, compositionStart));
    owner.GetBrowserHost().ImeFinishComposingText(false);
}
```
just below the following line inside the function OnImeComposition()

`owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);`

2) move the following declarations to the top of the function (preferrably under `string text = string.Empty;` in order to reference 'underlines' and 'compositionStart' in the newly-added code above:

```
var underlines = new List<CompositionUnderline>();
int compositionStart = 0;
```

I also figured out there is no side effects to Japanese or Chinese IME even if I skipped the `if` test (`if (languageCodeId == ImeNative.LANG_KOREAN)`) but I don't want to make any side effects not found during my own test. It is 'experimental' anyway and we need to improve the WPF IME problem over time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Using CefSharp.Wpf.Example.SimpleMainWindow.xaml, (and plugging in the experimental IME keyboard handler of course) I typed several Korean, Japanese, and Chinese sentences.
<!--- Include details of your testing environment, operating system, and the tests you ran to -->
Windows 10.0.18363.592 (x64) - Korean, Japanese, and Chinese IME installed
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
