### PR TITLE
WPF - IME Fix Korean character emitting issue

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -241,16 +241,20 @@ namespace CefSharp.Wpf.Experimental
         private void OnImeComposition(IntPtr hwnd, int lParam)
         {
             string text = string.Empty;
-
+            var underlines = new List<CompositionUnderline>();
+            int compositionStart = 0;
+                
             if (ImeHandler.GetResult(hwnd, (uint)lParam, out text))
             {
                 owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);
+                if (languageCodeId == ImeNative.LANG_KOREAN)
+                {
+                    owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(), new Range(int.MaxValue, int.MaxValue), new Range(compositionStart, compositionStart));
+                    owner.GetBrowserHost().ImeFinishComposingText(false);
+                }
             }
             else
             {
-                var underlines = new List<CompositionUnderline>();
-                int compositionStart = 0;
-
                 if (ImeHandler.GetComposition(hwnd, (uint)lParam, underlines, ref compositionStart, out text))
                 {
                     owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(),

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -241,7 +241,7 @@ namespace CefSharp.Wpf.Experimental
         private void OnImeComposition(IntPtr hwnd, int lParam)
         {
             string text = string.Empty;
-                
+
             if (ImeHandler.GetResult(hwnd, (uint)lParam, out text))
             {
                 owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);
@@ -255,7 +255,7 @@ namespace CefSharp.Wpf.Experimental
             {
                 var underlines = new List<CompositionUnderline>();
                 int compositionStart = 0;
-                
+
                 if (ImeHandler.GetComposition(hwnd, (uint)lParam, underlines, ref compositionStart, out text))
                 {
                     owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(),

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -241,20 +241,21 @@ namespace CefSharp.Wpf.Experimental
         private void OnImeComposition(IntPtr hwnd, int lParam)
         {
             string text = string.Empty;
-            var underlines = new List<CompositionUnderline>();
-            int compositionStart = 0;
                 
             if (ImeHandler.GetResult(hwnd, (uint)lParam, out text))
             {
                 owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);
                 if (languageCodeId == ImeNative.LANG_KOREAN)
                 {
-                    owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(), new Range(int.MaxValue, int.MaxValue), new Range(compositionStart, compositionStart));
+                    owner.GetBrowserHost().ImeSetComposition(text, new CompositionUnderline[0], new Range(int.MaxValue, int.MaxValue), new Range(0, 0));
                     owner.GetBrowserHost().ImeFinishComposingText(false);
                 }
             }
             else
             {
+                var underlines = new List<CompositionUnderline>();
+                int compositionStart = 0;
+                
                 if (ImeHandler.GetComposition(hwnd, (uint)lParam, underlines, ref compositionStart, out text))
                 {
                     owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(),


### PR DESCRIPTION
Fixes [issue-number] 
   - (Partially) fixes #1262

**Summary:** [summary of the change and which issue is fixed here]
   - I have added a small code to WpfImeKeyboardHandler.cs to address a Hangul character (Korean alphabet) is not emitting to the current input box after a Hangul is composed by IME. In other words, a user cannot make a word or a sentence using Korean IME because every time a single character is composed, it disappears and start 'composing' mode all over again.
  - According to my inspection, it seems that Korean IME keeps producing characters while IME is in IME_COMPOSITION mode even before IME_ENDCOMPOSITION is sent. It is like laying eggs while a chicken is walking. Current approach to IME implemented in CefSharp.Wpf seems that in order to "finalize" composing a text, ImeSetComposition() must be first called, and then ImeFinishComposingText() must be called.
 - I am not an expert to IME programming so I cannot guarantee my solution (together with CefSharp.Wpf's approach to IME implementation) is appropriate. But I am a native Korean and it works as expected while not creating any side effects to Japanese or Chinese IME. I can speak/write Japanese or Chinese a little bit, so I also tested those IMEs as well.

**Changes:** [specify the structures changed] 
   - I have modified CefSharp.Wpf.Experimental.WpfImeKeyboardHandler.cs like below:
   1) add the following code:

```
if (languageCodeId == ImeNative.LANG_KOREAN)
{
    owner.GetBrowserHost().ImeSetComposition(text, underlines.ToArray(), new Range(int.MaxValue, int.MaxValue), new Range(compositionStart, compositionStart));
    owner.GetBrowserHost().ImeFinishComposingText(false);
}
```
just below the following line inside the function `OnImeComposition()`

`owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);`

2) move the following declarations to the top of the function (preferrably under `string text = string.Empty;`) in order to reference 'underlines' and 'compositionStart' in the newly-added code above:

```
var underlines = new List<CompositionUnderline>();
int compositionStart = 0;
```

I also figured out there is no side effects to Japanese or Chinese IME even if I skipped the `if` test (`if (languageCodeId == ImeNative.LANG_KOREAN)`) but I don't want to make any side effects not found during my own test. It is 'experimental' anyway and we need to improve the WPF IME problem over time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Using CefSharp.Wpf.Example.SimpleMainWindow.xaml, (and plugging in the experimental IME keyboard handler of course) I typed several Korean, Japanese, and Chinese sentences.
<!--- Include details of your testing environment, operating system, and the tests you ran to -->
Windows 10.0.18363.592 (x64) - Korean, Japanese, and Chinese IME installed
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
