### PR TITLE
Remove project reference to CefSharp.BrowserSubprocess for consistency

### DIFF
--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\cef.redist.x86.80.0.4\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.80.0.4\build\cef.redist.x86.props')" />
   <Import Project="..\packages\cef.redist.x64.80.0.4\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.80.0.4\build\cef.redist.x64.props')" />

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\cef.redist.x86.80.0.4\build\cef.redist.x86.props" Condition="Exists('..\packages\cef.redist.x86.80.0.4\build\cef.redist.x86.props')" />
   <Import Project="..\packages\cef.redist.x64.80.0.4\build\cef.redist.x64.props" Condition="Exists('..\packages\cef.redist.x64.80.0.4\build\cef.redist.x64.props')" />
@@ -192,10 +192,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CefSharp.BrowserSubprocess\CefSharp.BrowserSubprocess.csproj">
-      <Project>{23ee5140-2c2c-4b53-a954-10b08dca6bd6}</Project>
-      <Name>CefSharp.BrowserSubprocess</Name>
-    </ProjectReference>
     <ProjectReference Include="..\CefSharp.Core\CefSharp.Core.vcxproj">
       <Project>{7b495581-2271-4f41-9476-acb86e8c864f}</Project>
       <Name>CefSharp.Core</Name>


### PR DESCRIPTION
**Summary:**
   - remove project reference to CefSharp.BrowserSubprocess for consistency. a solution dependency does already exists.

https://github.com/cefsharp/CefSharp/blob/749ec15972d332ce0fc59f3785184f884df748ae/CefSharp3.sln#L9-L12

**Changes:**
  - see https://github.com/cefsharp/CefSharp/pull/3065#discussion_r385986521 and https://github.com/cefsharp/CefSharp/pull/3065#discussion_r385990844

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
