### PR TITLE
Test - Call Cef.Shutdown on same thread as Cef.Initialize

### DIFF
--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -73,7 +73,20 @@
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="netstandard" />
+    <Reference Include="Nito.AsyncEx.Context, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Context.5.0.0\lib\netstandard2.0\Nito.AsyncEx.Context.dll</HintPath>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Tasks, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Tasks.5.0.0\lib\netstandard2.0\Nito.AsyncEx.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Nito.Disposables, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Disposables.2.0.0\lib\netstandard2.0\Nito.Disposables.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/CefSharp.Test/CefSharpFixture.cs
+++ b/CefSharp.Test/CefSharpFixture.cs
@@ -7,10 +7,11 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CefSharp.OffScreen;
+using Xunit;
 
 namespace CefSharp.Test
 {
-    public class CefSharpFixture : IDisposable
+    public class CefSharpFixture : IAsyncLifetime
     {
         private readonly TaskScheduler scheduler;
         private readonly Thread thread;
@@ -40,13 +41,18 @@ namespace CefSharp.Test
             }
         }
 
-        public void Dispose()
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
         {
             var factory = new TaskFactory(scheduler);
 
             if (thread.IsAlive)
             {
-                factory.StartNew(() =>
+                return factory.StartNew(() =>
                 {
                     if (Cef.IsInitialized)
                     {
@@ -54,6 +60,7 @@ namespace CefSharp.Test
                     }
                 });
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/CefSharp.Test/packages.config
+++ b/CefSharp.Test/packages.config
@@ -4,6 +4,10 @@
   <package id="cef.redist.x64" version="80.0.4" targetFramework="net462" />
   <package id="cef.redist.x86" version="80.0.4" targetFramework="net462" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />
+  <package id="Nito.AsyncEx.Context" version="5.0.0" targetFramework="net462" />
+  <package id="Nito.AsyncEx.Tasks" version="5.0.0" targetFramework="net462" />
+  <package id="Nito.Disposables" version="2.0.0" targetFramework="net462" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />


### PR DESCRIPTION
**Summary:**
   - Ensure that `Cef.Shutdown` is called on the same thread as `Cef.Initialize` in tests

**Changes:**
- `Cef.Shutdown` wasn't called on the same thread but the exception didn't showed up in tests because it was called asynchron in a sync `Dispose` method.
- The first commit shows the bug by implementing the async dispose from xunit. Here is a test which shows the exception: https://ci.appveyor.com/project/campersau/cefsharp/builds/31148092#L374
 I also observed it when debugging tests in VS 2019.
- The second commit fixes the problem by making sure that these methods get called on the same thread.
      
## How Has This Been Tested?
https://ci.appveyor.com/project/campersau/cefsharp/builds/31148152

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
