### PR TITLE
WPF - Implement AltGr support.

### DIFF
--- a/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
@@ -286,6 +286,7 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
     keyEvent.is_system_key = message == WM_SYSCHAR ||
         message == WM_SYSKEYDOWN ||
         message == WM_SYSKEYUP;
+    keyEvent.modifiers = GetCefKeyboardModifiers(wParam, lParam);
 
     if (message == WM_KEYDOWN || message == WM_SYSKEYDOWN)
     {
@@ -298,30 +299,29 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
     else
     {
         keyEvent.type = KEYEVENT_CHAR;
-    }
-    keyEvent.modifiers = GetCefKeyboardModifiers(wParam, lParam);
 
-    // mimic alt-gr check behaviour from
-    // src/ui/events/win/events_win_utils.cc: GetModifiersFromKeyState
-    if ((keyEvent.type == KEYEVENT_CHAR) && IsKeyDown(VK_RMENU))
-    {
-        // reverse AltGr detection taken from PlatformKeyMap::UsesAltGraph
-        // instead of checking all combination for ctrl-alt, just check current char
-        HKL current_layout = ::GetKeyboardLayout(0);
+        // mimic alt-gr check behaviour from
+        // src/ui/events/win/events_win_utils.cc: GetModifiersFromKeyState
+        if (IsKeyDown(VK_RMENU))
+        {
+            // reverse AltGr detection taken from PlatformKeyMap::UsesAltGraph
+            // instead of checking all combination for ctrl-alt, just check current char
+            HKL current_layout = ::GetKeyboardLayout(0);
 
-        // https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-vkkeyscanexw
-        // ... high-order byte contains the shift state,
-        // which can be a combination of the following flag bits.
-        // 2 Either CTRL key is pressed.
-        // 4 Either ALT key is pressed.
-        SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
-        if (((scan_res >> 8) & 0xFF) == (2 | 4)) // ctrl-alt pressed
-        {  
-            keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
-            keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
+            // https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-vkkeyscanexw
+            // ... high-order byte contains the shift state,
+            // which can be a combination of the following flag bits.
+            // 2 Either CTRL key is pressed.
+            // 4 Either ALT key is pressed.
+            SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
+            if (((scan_res >> 8) & 0xFF) == (2 | 4)) // ctrl-alt pressed
+            {
+                keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
+                keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
+            }
         }
     }
-
+    
     _browserHost->SendKeyEvent(keyEvent);
 }
 

--- a/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
@@ -303,7 +303,8 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
 
     // mimic alt-gr check behaviour from
     // src/ui/events/win/events_win_utils.cc: GetModifiersFromKeyState
-    if ((keyEvent.type == KEYEVENT_CHAR) && IsKeyDown(VK_RMENU)) {
+    if ((keyEvent.type == KEYEVENT_CHAR) && IsKeyDown(VK_RMENU))
+    {
         // reverse AltGr detection taken from PlatformKeyMap::UsesAltGraph
         // instead of checking all combination for ctrl-alt, just check current char
         HKL current_layout = ::GetKeyboardLayout(0);
@@ -314,7 +315,8 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
         // 2 Either CTRL key is pressed.
         // 4 Either ALT key is pressed.
         SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
-        if (((scan_res >> 8) & 0xFF) == (2 | 4)) {  // ctrl-alt pressed
+        if (((scan_res >> 8) & 0xFF) == (2 | 4)) // ctrl-alt pressed
+        {  
             keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
             keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
         }

--- a/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core/Internals/CefBrowserHostWrapper.cpp
@@ -301,6 +301,25 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
     }
     keyEvent.modifiers = GetCefKeyboardModifiers(wParam, lParam);
 
+    // mimic alt-gr check behaviour from
+    // src/ui/events/win/events_win_utils.cc: GetModifiersFromKeyState
+    if ((keyEvent.type == KEYEVENT_CHAR) && IsKeyDown(VK_RMENU)) {
+        // reverse AltGr detection taken from PlatformKeyMap::UsesAltGraph
+        // instead of checking all combination for ctrl-alt, just check current char
+        HKL current_layout = ::GetKeyboardLayout(0);
+
+        // https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-vkkeyscanexw
+        // ... high-order byte contains the shift state,
+        // which can be a combination of the following flag bits.
+        // 2 Either CTRL key is pressed.
+        // 4 Either ALT key is pressed.
+        SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
+        if (((scan_res >> 8) & 0xFF) == (2 | 4)) {  // ctrl-alt pressed
+            keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
+            keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
+        }
+    }
+
     _browserHost->SendKeyEvent(keyEvent);
 }
 


### PR DESCRIPTION
**Fixes:** #3104 
<!-- e.g Fixes: #2345 -->

**Summary:** 
   - AltGr support added.

**Changes:**
   - copied and adjusted code from linked cef commit
      
**How Has This Been Tested?**  
- started CefSharp.Wpf.Example
- navigated to https://jsfiddle.net
- typed the following characters into the CSS text field using a german keyboard layout
`{@[³²\~]}µ`

All these characters requiring AltGr modifier on german keyboard. None of them worked before the fix.

**Types of changes**
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
