### PR TITLE
Type Safe Marshaling of Objects Between .NET and Javascript

### DIFF
--- a/CefSharp/BindingOptions.cs
+++ b/CefSharp/BindingOptions.cs
@@ -12,11 +12,24 @@ namespace CefSharp
     public class BindingOptions
     {
         /// <summary>
+        /// Returns the default binder based on the current <see cref="CefSharpSettings"/> that are defined
+        /// </summary>
+        /// <returns>An instance of the default binder.</returns>
+        private static IBinder GetDefaultBinder()
+        {
+            if (CefSharpSettings.TypeSafeMarshaling)
+            {
+                return new TypeSafeBinder();
+            }
+            return new DefaultBinder();
+        }
+
+        /// <summary>
         /// Set of options with the default binding
         /// </summary>
         public static BindingOptions DefaultBinder
         {
-            get { return new BindingOptions { Binder = new DefaultBinder() }; }
+            get { return new BindingOptions { Binder = GetDefaultBinder() }; }
         }
 
         /// <summary>

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -118,7 +118,8 @@
     <Compile Include="IUrlRequest.cs" />
     <Compile Include="IUrlRequestClient.cs" />
     <Compile Include="Lagacy\ResourceHandler.cs" />
-    <Compile Include="ModelBinding\BindingGuidConverter.cs" />
+    <Compile Include="ModelBinding\Converters\BinderGuidConverter.cs" />
+    <Compile Include="ModelBinding\Converters\BinderVersionConverter.cs" />
     <Compile Include="ModelBinding\TypeSafeInterceptor.cs" />
     <Compile Include="ModelBinding\TypeBindingException.cs" />
     <Compile Include="ModelBinding\TypeSafeBinder.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -118,6 +118,10 @@
     <Compile Include="IUrlRequest.cs" />
     <Compile Include="IUrlRequestClient.cs" />
     <Compile Include="Lagacy\ResourceHandler.cs" />
+    <Compile Include="ModelBinding\BindingGuidConverter.cs" />
+    <Compile Include="ModelBinding\TypeSafeInterceptor.cs" />
+    <Compile Include="ModelBinding\TypeBindingException.cs" />
+    <Compile Include="ModelBinding\TypeSafeBinder.cs" />
     <Compile Include="ResourceRequestHandlerFactory.cs" />
     <Compile Include="ResourceRequestHandlerFactoryItem.cs" />
     <Compile Include="Enums\AlphaType.cs" />

--- a/CefSharp/CefSharpSettings.cs
+++ b/CefSharp/CefSharpSettings.cs
@@ -79,6 +79,29 @@ namespace CefSharp
         /// </summary>
         public static bool ConcurrentTaskExecution { get; set; }
 
+
+        /// <summary>
+        /// This changes the behavior of CefSharp so that marshaling of data between .NET and Javascript is type-safe. <br/> <br/>
+        /// 
+        /// Javascript objects passed to .NET will be run through a strict type binder that validates their structure. <br/> <br/>
+        /// 
+        /// .NET objects returned to Javascript are properly serialized so that .NET only types like <see cref="Guid"/> and <see cref="Tuple"/> become available in Javascript. <br/> <br/>
+        ///
+        /// This means if you have a class with a <see cref="Guid"/> property, it will automatically be handled when you return that class to Javascript. <br/> <br/>
+        /// And when you pass the same object back to .NET as the parameter of a method, it will be marshaled back to the original class with the correct values. <br/> <br/>
+        ///
+        /// It will also enable asynchronous task to be ran without <see cref="ConcurrentTaskExecution"/> being set to true. <br/> <br/>
+        ///
+        /// When this setting is enabled any failures to marshal data will raise exceptions so you can catch errors in your code. <br/> <br/>
+        ///
+        /// The best part is your .NET code can continue to use .NET coding conventions without forcing your Javascript and TypeScript code to drop theirs.  <br/> <br/>
+        /// Please note, returning Structs to Javascript when this mode is enabled for security reasons.   <br/>
+        ///
+        ///  This setting has no backwards compatibility with the default binding behavior, so if you built code around it enabling this will probably break app. <br/> <br/>
+        ///  All bound objects and CefSharp post will use a internal TypeSafe binder and interceptor to passively handle objects.
+        /// </summary>
+        public static bool TypeSafeMarshaling { get; set; }
+
         /// <summary>
         /// If true a message will be sent from the render subprocess to the
         /// browser when a DOM node (or no node) gets focus. The default is

--- a/CefSharp/ModelBinding/BindingGuidConverter.cs
+++ b/CefSharp/ModelBinding/BindingGuidConverter.cs
@@ -1,0 +1,81 @@
+using System;
+using System.ComponentModel;
+
+namespace CefSharp.ModelBinding
+{
+    /// <summary>
+    /// A special <see cref="Guid"/> type converter that is registered to allow for easy conversion between Javascript & .NET bridge.
+    /// </summary>
+    internal class BinderGuidConverter : GuidConverter
+    {
+        /// <summary>
+        /// Guid to string? That is okay!
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="sourceType"></param>
+        /// <returns></returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(Guid) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// String to Guid? You know it!
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="destinationType"></param>
+        /// <returns></returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(Guid) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Guid"/> instance into a string using <see cref="Guid.ToString"/> with the format specifier "N"
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="culture"></param>
+        /// <param name="value">the <see cref="Guid"/> structure that will be converted to a string.</param>
+        /// <returns>The <see cref="Guid"/> converted to a string.</returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value is Guid guid)
+            {
+                return guid.ToString("N");
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Allows for conversions from a string to a <see cref="Guid"/>.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="culture"></param>
+        /// <param name="value">the string that will be parsed</param>
+        /// <param name="destinationType"></param>
+        /// <returns>The parsed structure or <see cref="Guid.Empty"/> on failure</returns>
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(Guid) && value is string stringValue)
+            {
+                if (string.IsNullOrWhiteSpace(stringValue))
+                {
+                    // this seems most appropriate 
+                    return Guid.Empty;
+                }
+                return Guid.TryParse(stringValue, out var result) ? result : Guid.Empty;
+            }
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+
+        /// <summary>
+        /// Adds the converter for handling bidirectional conversion between <see cref="string"/> and <see cref="Guid"/> objects to the global TypeDescriptor.
+        /// It is safe to call this multiple times as subsequent calls just overwrite a previously created instance.
+        /// </summary>
+        internal static void Register()
+        {
+           TypeDescriptor.AddAttributes(typeof(string), new TypeConverterAttribute(typeof(BinderGuidConverter)));
+        }
+    }
+}

--- a/CefSharp/ModelBinding/BindingMemberInfo.cs
+++ b/CefSharp/ModelBinding/BindingMemberInfo.cs
@@ -80,20 +80,17 @@ namespace CefSharp.ModelBinding
 
 
         /// <summary>
-        /// Builds a collection of the public and instance based <see cref="PropertyInfo"/> members for a <see cref="Type"/>. 
+        /// Builds a <see cref="BindingMemberInfo"/> collection from all of the valid properties returned from <see cref="ModelBindingExtensions.GetValidProperties(Type)"/>
         /// </summary>
-        /// <param name="type">The type to enumerate for properties.</param>
-        /// <returns>All valid properties for the provided type.</returns>
+        /// <param name="type">The type the collection will be based on..</param>
+        /// <returns>The <see cref="BindingMemberInfo"/> collection.</returns>
         /// <remarks>
         /// <see cref="Collect"/> is slightly misleading in it's description, as fields are quite different than properties.
-        /// This method only returns properties which is more aligned with how something like JSON.NET works.
+        /// This method only returns properties that allow for encapsulation which is more aligned with how something like JSON.NET works.
         /// </remarks>
-        public static IEnumerable<BindingMemberInfo> CollectProperties(Type type)
+        public static IEnumerable<BindingMemberInfo> CollectEncapsulatedProperties(Type type)
         {
-            return type
-                .GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanRead && p.CanWrite)
-                .Where(property => !property.GetIndexParameters().Any())
-                .Select(property => new BindingMemberInfo(property));
+            return type.GetValidProperties().Select(property => new BindingMemberInfo(property));
         }
 
         /// <summary>

--- a/CefSharp/ModelBinding/BindingMemberInfo.cs
+++ b/CefSharp/ModelBinding/BindingMemberInfo.cs
@@ -78,8 +78,26 @@ namespace CefSharp.ModelBinding
             }
         }
 
+
         /// <summary>
-        /// Returns an enumerable sequence of bindable properties for the specified type.
+        /// Builds a collection of the public and instance based <see cref="PropertyInfo"/> members for a <see cref="Type"/>. 
+        /// </summary>
+        /// <param name="type">The type to enumerate for properties.</param>
+        /// <returns>All valid properties for the provided type.</returns>
+        /// <remarks>
+        /// <see cref="Collect"/> is slightly misleading in it's description, as fields are quite different than properties.
+        /// This method only returns properties which is more aligned with how something like JSON.NET works.
+        /// </remarks>
+        public static IEnumerable<BindingMemberInfo> CollectProperties(Type type)
+        {
+            return type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanRead && p.CanWrite)
+                .Where(property => !property.GetIndexParameters().Any())
+                .Select(property => new BindingMemberInfo(property));
+        }
+
+        /// <summary>
+        ///     Returns an enumerable sequence of bindable properties for the specified type.
         /// </summary>
         /// <param name="type">The type to enumerate.</param>
         /// <returns>Bindable properties.</returns>

--- a/CefSharp/ModelBinding/Converters/BinderGuidConverter.cs
+++ b/CefSharp/ModelBinding/Converters/BinderGuidConverter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel;
 
-namespace CefSharp.ModelBinding
+namespace CefSharp.ModelBinding.Converters
 {
     /// <summary>
     /// A special <see cref="Guid"/> type converter that is registered to allow for easy conversion between Javascript & .NET bridge.

--- a/CefSharp/ModelBinding/Converters/BinderVersionConverter.cs
+++ b/CefSharp/ModelBinding/Converters/BinderVersionConverter.cs
@@ -1,0 +1,80 @@
+using System;
+using System.ComponentModel;
+
+namespace CefSharp.ModelBinding.Converters
+{
+    /// <summary>
+    ///A converter for <see cref="Version"/>
+    /// </summary>
+    public class BinderVersionConverter : TypeConverter
+    {
+        /// <summary>
+        /// Allow for <see cref="Version"/> to <see cref="string"/>
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="sourceType"></param>
+        /// <returns></returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(Version) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Allow for <see cref="string"/> to <see cref="Version"/>
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="destinationType"></param>
+        /// <returns></returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(Version) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Version"/> instance into a <see cref="string"/> 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="culture"></param>
+        /// <param name="value">the <see cref="Version"/> instance that will be converted to a string.</param>
+        /// <returns>The <see cref="Version"/> converted to a string.</returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value is Version version)
+            {
+                return version.ToString();
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Allows for conversions from a <see cref="string"/> to a <see cref="Version"/>.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="culture"></param>
+        /// <param name="value">the string that will be parsed</param>
+        /// <param name="destinationType"></param>
+        /// <returns>The parsed version</returns>
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType != typeof(Version) || !(value is string stringValue))
+            {
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+            return Version.TryParse(stringValue, out var v) ? v : base.ConvertTo(context, culture, value, destinationType);
+        }
+
+
+        /// <summary>
+        /// Adds the converter for handling bidirectional conversion between <see cref="string"/> and <see cref="Version"/> objects to the global TypeDescriptor.
+        /// It is safe to call this multiple times as subsequent calls just overwrite a previously created instance.
+        /// </summary>
+        internal static void Register()
+        {
+            TypeDescriptor.AddAttributes(typeof(string), new TypeConverterAttribute(typeof(BinderVersionConverter)));
+        }
+    }
+}

--- a/CefSharp/ModelBinding/IMethodInterceptor.cs
+++ b/CefSharp/ModelBinding/IMethodInterceptor.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Threading.Tasks;
 
 namespace CefSharp.ModelBinding
 {
@@ -12,6 +13,24 @@ namespace CefSharp.ModelBinding
     /// </summary>
     public interface IMethodInterceptor
     {
+        /// <summary>
+        /// To avoid forcing users to use <see cref="Task.GetAwaiter()"/> for interception calls, this call informs the <see cref="IJavascriptObjectRepository"/> to use <see cref="InterceptAsync"/>
+        /// </summary>
+        bool IsAsynchronous { get; }
+
+        /// <summary>
+        /// When <see cref="IMethodInterceptor.IsAsynchronous"/> is set to true, this is called before the method is invoked. You are now responsible for evaluating
+        /// the function and returning the result.
+        /// </summary>
+        /// <param name="method">A Func that represents the method to be called</param>
+        /// <param name="parameters">parameters to be passed to <paramref name="method"/></param>
+        /// <param name="methodName">Name of the method to be called</param>
+        /// <returns>The method result</returns>
+        /// <example>
+        /// <see cref="TypeSafeInterceptor"/>
+        /// </example>
+        Task<object> InterceptAsync(Func<object[], object> method, object[] parameters, string methodName);
+
         /// <summary>
         /// Called before the method is invokved. You are now responsible for evaluating
         /// the function and returning the result.

--- a/CefSharp/ModelBinding/ModelBindingExtensions.cs
+++ b/CefSharp/ModelBinding/ModelBindingExtensions.cs
@@ -4,16 +4,402 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
 namespace CefSharp.ModelBinding
 {
     /// <summary>
-    /// Containing extensions for the <see cref="Type"/> object.
+    /// Contains extension methods for data marshaling.
     /// </summary>
     internal static class ModelBindingExtensions
     {
+
+        /// <summary>
+        /// The custom parser below supports converting strings into a <see cref="Enum"/> that has the <see cref="FlagsAttribute"/> defined.
+        /// These are commonly used separators to assist that process.
+        /// </summary>
+        private static readonly char[] EnumSeparators = { '|', ',', ';', '+', ' ' };
+
+        /// <summary>
+        /// Attempts to convert a string or number representation of an <see cref="Enum"/> field to an actual instance. 
+        /// <br>Please note, this method will NOT fallback to the default value of the destination enum.</br>
+        /// <br>If the source object cannot be marshaled, then this method will throw exceptions to prevent undefined behavior.</br>
+        /// </summary>
+        /// <param name="nativeType">The type of the <see cref="Enum"/> to create an instance of.</param>
+        /// <param name="javaScriptObject">The object that will be marshaled into the destination type.</param>
+        /// <returns>
+        /// The a member on the destination <see cref="Enum"/> the corresponds to the source object.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the destination type or source object are null.</exception>
+        /// <exception cref="TypeBindingException">Thrown when the source object cannot be bound to the destination enum.</exception>
+        /// <remarks>
+        /// This method does not rely on Enum.Parse and therefore will never raise any first or second chance exception.
+        /// </remarks>
+        public static object CreateEnumMember(this Type nativeType, object javaScriptObject)
+        {
+            if (nativeType == null)
+            {
+                throw new ArgumentNullException(nameof(nativeType));
+            }
+
+            if (javaScriptObject == null)
+            {
+                throw new ArgumentNullException(nameof(javaScriptObject));
+            }
+
+            if (!nativeType.IsEnum)
+            {
+                throw new TypeBindingException(javaScriptObject.GetType(), nativeType, BindingFailureCode.NoEnumAtDestinationType);
+            }
+
+            if (!(javaScriptObject is string) && !javaScriptObject.IsEnumIntegral())
+            {
+                throw new TypeBindingException(javaScriptObject.GetType(), nativeType, BindingFailureCode.SourceNotAssignable);
+            }
+
+            // if the source object is a number, then these is the only steps we need to run
+            if (javaScriptObject.IsEnumIntegral())
+            {
+                // checks if the number exist within the destination enumeration 
+                if (Enum.IsDefined(nativeType, javaScriptObject))
+                {
+                    // and if it does convert and return it.
+                    return Enum.ToObject(nativeType, javaScriptObject);
+                }
+                // we're throwing because the number is not defined in the enumeration and defaulting to the first member
+                // can cause some serious unintended side effects if a method relies on the enum member to be accurate.
+                throw new TypeBindingException(javaScriptObject.GetType(), nativeType, BindingFailureCode.NumberNotDefinedInEnum);
+            }
+
+            var javaScriptString = ((string)javaScriptObject).Trim();
+            // empty strings are not supported 
+            if (javaScriptString.Length == 0)
+            {
+                throw new TypeBindingException(javaScriptObject.GetType(), nativeType, BindingFailureCode.StringNotDefinedInEnum);
+            }
+            var destinationMembers = Enum.GetNames(nativeType);
+            // make sure the enum is actually defined and has members
+            if (destinationMembers.Length == 0)
+            {
+                throw new TypeBindingException(javaScriptObject.GetType(), nativeType, BindingFailureCode.DestinationEnumEmpty);
+            }
+            // the underlying integral type is important as enums can be things other than int
+            var underlyingType = Enum.GetUnderlyingType(nativeType);
+            // these are all the values of all the members, they have matching indexs
+            var destinationValues = Enum.GetValues(nativeType);
+
+            // it is expected that someone might improperly implement their enum with flags and not explicitly define it. 
+            // so to prevent crashing or invalid values from being returned, we don't try to parse flags unless the type has the flags attribute. 
+            if (!nativeType.IsDefined(typeof(FlagsAttribute), true) && javaScriptString.IndexOfAny(EnumSeparators) < 0)
+            {
+                return StringToEnumMember(nativeType, underlyingType, destinationMembers, destinationValues, javaScriptString);
+            }
+
+            // split the string by the default separators so we can parse the tokens 
+            var tokens = javaScriptString.Split(EnumSeparators, StringSplitOptions.RemoveEmptyEntries);
+            // the source string is malformed or doesn't contain entries, so we cannot continue.
+            if (tokens.Length == 0)
+            {
+                throw new TypeBindingException(javaScriptString.GetType(), nativeType, BindingFailureCode.SourceObjectNullOrEmpty);
+            }
+
+            ulong ul = 0;
+            foreach (var tok in tokens)
+            {
+                var token = tok.Trim();
+                // we should never experience an empty token given the code above, but if we do skip.
+                if (token.Length == 0)
+                    continue;
+
+                // either we're going to get back the enum because the string had separator but one token
+                // or the integral representation of a token, which leads to us forming the actual enum member after all tokens are parsed.
+                var tokenValue = StringToEnumMember(nativeType, underlyingType, destinationMembers, destinationValues, token);
+
+                ulong tokenUl;
+                // for flags we need to do bitwise operations on the found values.
+                // to save effort we just use a ulong for storing the token since Enum.ToObject will internally cast.
+                var typeCode = Convert.GetTypeCode(tokenValue);
+                switch (Convert.GetTypeCode(tokenValue))
+                {
+                    case TypeCode.SByte:
+                    case TypeCode.Int16:
+                    case TypeCode.Int32:
+                    case TypeCode.Int64:
+                        tokenUl = (ulong)Convert.ToInt64(tokenValue, CultureInfo.InvariantCulture);
+                        break;
+                    case TypeCode.Byte:
+                    case TypeCode.UInt16:
+                    case TypeCode.UInt32:
+                    case TypeCode.UInt64:
+                        tokenUl = Convert.ToUInt64(tokenValue, CultureInfo.InvariantCulture);
+                        break;
+                    default:
+                        throw new TypeBindingException(typeCode.ToType(), nativeType, BindingFailureCode.EnumIntegralNotFound);
+                }
+                // append the token to the overall value
+                ul |= tokenUl;
+            }
+            // convert the flag to the value of our destination enum
+            return Enum.ToObject(nativeType, ul);
+        }
+
+        /// <summary>
+        /// Attempts to convert a string into a valid value of one of the destination <see cref="Enum"/> fields.
+        /// </summary>
+        /// <param name="destinationType">The type that the source string will be bound to.</param>
+        /// <param name="underlyingType">The underlying type of the enum as .NET allow explicit specification of other integral numeric besides int.</param>
+        /// <param name="members">The human-readable members of the destination enum.</param>
+        /// <param name="values">The integral values of each enum field.</param>
+        /// <param name="sourceString">A string that contains values within the destination enum.</param>
+        /// <returns>The value of the enum field that corresponds to the provided string.</returns>
+        /// <exception cref="TypeBindingException">Thrown when the sourceString cannot be assigned to any of the destination enum fields.</exception>
+        private static object StringToEnumMember(Type destinationType, Type underlyingType, IReadOnlyList<string> members, Array values, string sourceString)
+        {
+            // loop over the enums members
+            for (var i = 0; i < members.Count; i++)
+            {
+                // if the source string does not match the member name skip.
+                // casing is ignored for compatibility with Javascript and Typescript naming conventions
+                if (string.Compare(members[i], sourceString, StringComparison.InvariantCulture) != 0)
+                {
+                    continue;
+                }
+                // return the value for the matching enum member. 
+                return values.GetValue(i);
+            }
+            //  now try parsing the string for numbers. 
+            //  500 --> 500
+            //  +13230 --> 13230
+            //  -5 --> -5
+            if (char.IsDigit(sourceString[0]) || sourceString[0] == '-' || sourceString[0] == '+')
+            {
+                // can never be null or the underlying types default value because StringToEnumIntegral throws on failure
+                return StringToEnumIntegral(underlyingType, sourceString);
+            }
+            // if the source string is not present in the enum, throw.
+            throw new TypeBindingException(sourceString.GetType(), destinationType, BindingFailureCode.StringNotDefinedInEnum);
+        }
+
+
+        /// <summary>
+        /// Attempts to convert a string to an Enum integral type.
+        /// </summary>
+        /// <param name="destinationType">the type the string should be converted into.</param>
+        /// <param name="sourceString">a string that is parseable to a number.</param>
+        /// <returns>the converted string as the integral destination type.</returns>
+        /// <exception cref="TypeBindingException">Thrown when the destination type is not a number, or the source string cannot be parsed.</exception>
+        private static object StringToEnumIntegral(Type destinationType, string sourceString)
+        {
+            // activate an instance of the the destination Type to verify it is a number.
+            var instance = Activator.CreateInstance(destinationType);
+            if (!instance.IsEnumIntegral())
+            {
+                throw new TypeBindingException(typeof(string), destinationType, BindingFailureCode.SourceNotAssignable);
+            }
+            if (instance is int)
+            {
+                if (int.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+
+            if (instance is uint)
+            {
+                if (uint.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+
+            if (instance is ulong)
+            {
+                if (ulong.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+
+            if (instance is long)
+            {
+                if (long.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+
+            if (instance is short)
+            {
+                if (short.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+
+            if (instance is ushort)
+            {
+                if (ushort.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+
+            if (instance is byte)
+            {
+                if (byte.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+            if (instance is sbyte)
+            {
+                if (sbyte.TryParse(sourceString, out var s))
+                {
+                    return s;
+                }
+            }
+            throw new TypeBindingException(typeof(string), destinationType, BindingFailureCode.SourceNotAssignable);
+        }
+
+
+      
+
+        /// <summary>
+        /// ReadOnly Dictionary that maps <see cref="TypeCode"/> members to their corresponding <see cref="Type"/> instance.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<TypeCode, Type> TypeCodeToTypeMap = new Dictionary<TypeCode, Type>
+        {
+            { TypeCode.Boolean, typeof(bool) },
+            { TypeCode.Byte, typeof(byte) },
+            { TypeCode.Char, typeof(char) },
+            { TypeCode.DateTime, typeof(DateTime) },
+            { TypeCode.DBNull, typeof(DBNull) },
+            { TypeCode.Decimal, typeof(decimal) },
+            { TypeCode.Double, typeof(double) },
+            { TypeCode.Empty, null },
+            { TypeCode.Int16, typeof(short) },
+            { TypeCode.Int32, typeof(int) },
+            { TypeCode.Int64, typeof(long) },
+            { TypeCode.Object, typeof(object) },
+            { TypeCode.SByte, typeof(sbyte) },
+            { TypeCode.Single, typeof(float) },
+            { TypeCode.String, typeof(string) },
+            { TypeCode.UInt16, typeof(ushort) },
+            { TypeCode.UInt32, typeof(uint) },
+            { TypeCode.UInt64, typeof(ulong) }
+        };
+
+        /// <summary>
+        /// Convert a TypeCode ordinal into it's corresponding <see cref="Type"/> instance.
+        /// </summary>
+        /// <param name="code">the type code to lookup</param>
+        /// <returns>an instance of <see cref="Type"/> for the given <see cref="TypeCode"/></returns>
+        /// <exception cref="IndexOutOfRangeException">Thrown when the <see cref="TypeCode"/> provided cannot be found in map.</exception>
+        public static Type ToType(this TypeCode code)
+        {
+            if (TypeCodeToTypeMap.TryGetValue(code, out var type))
+            {
+                return type;
+            }
+            throw new IndexOutOfRangeException($"Cannot find TypeCode {code} in TypeCodeToTypeMap");
+        }
+
+        /// <summary>
+        /// Checks if the underlying type of an object is valid for a <see cref="Enum"/>
+        /// </summary>
+        /// <param name="sourceObject">the object of an unknown type</param>
+        /// <returns><see langword="true" /> if the type is a number which is assignable to an <see cref="Enum"/>, otherwise <see langword="false" />.</returns>
+        public static bool IsEnumIntegral(this object sourceObject)
+        {
+            return sourceObject is sbyte
+                || sourceObject is byte
+                || sourceObject is short
+                || sourceObject is ushort
+                || sourceObject is int
+                || sourceObject is uint
+                || sourceObject is long
+                || sourceObject is ulong;
+        }
+
+        /// <summary>
+        /// if the underlying type of an object is a common numeric type
+        /// </summary>
+        /// <param name="sourceObject">the object of an unknown type</param>
+        /// <returns><see langword="true" /> if the object is a number, otherwise <see langword="false" />.</returns>
+        public static bool IsNumber(this object sourceObject)
+        {
+            return sourceObject.IsEnumIntegral()
+                || sourceObject is float
+                || sourceObject is double
+                || sourceObject is decimal;
+        }
+
+
+        /// <summary>
+        /// Checks if a type is a <see cref="Tuple"/>.
+        /// This check wouldn't need to be here if the version was bumped, which should be considered given every other version of .NET is EOL
+        /// </summary>
+        /// <param name="source">The type to check.</param>
+        /// <returns><see langword="true" /> if the type is a <see cref="Tuple"/> of any size, otherwise <see langword="false" />.</returns>
+        public static bool IsTupleType(this Type source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            // if the source is a class, is a generic type, then it might be an old Tuple type
+            if (source.IsClass && source.IsGenericType && TupleTypes.Contains(source))
+            {
+                return true;
+            }
+            return false;
+        }
+
+
+        /// <summary>
+        /// Supports ValueTypes even though CefSharp targets an older version
+        /// </summary>
+        /// <param name="source">The type to check.</param>
+        /// <returns><see langword="true" /> if the type is a ValueTuple of any size, otherwise <see langword="false" />.</returns>
+        public static bool IsValueTupleType(this Type source)
+        {
+            // if the source is a structure. has any generic arguments, and it's name contains ValueTuple then return true.
+            // should allow CefSharp to support newer versions of .NET without the host application downgrading.
+            if (source.IsValueType && source.GetTypeInfo().GetGenericArguments().Any() && (source?.FullName?.Contains($"{nameof(System)}.Value{nameof(Tuple)}") ?? false))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// A HashSet which contains all the different <see cref="Tuple"/> types for quick comparision.
+        /// </summary>
+        private static readonly HashSet<Type> TupleTypes = new HashSet<Type>(
+            new[] {
+                typeof(Tuple<>),
+                typeof(Tuple<,>),
+                typeof(Tuple<,,>),
+                typeof(Tuple<,,,>),
+                typeof(Tuple<,,,,>),
+                typeof(Tuple<,,,,,>),
+                typeof(Tuple<,,,,,,>),
+                typeof(Tuple<,,,,,,,>)}
+        );
+
+
+        /// <summary>
+        /// Checks if a type is a Struct that has been defined outside the standard library.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static bool IsCustomStruct(this Type source)
+        {
+            // not entirely full-proof.
+            return source.Namespace != null && (source.IsValueType && !source.IsPrimitive && !source.IsEnum && !source.Namespace.StartsWith("System."));
+        }
+
         /// <summary>
         /// Checks if a type is an array or not
         /// </summary>
@@ -39,6 +425,16 @@ namespace CefSharp.ModelBinding
         }
 
         /// <summary>
+        /// Returns all the public properties of an underlying type that can be read and written to.
+        /// </summary>
+        /// <param name="source">The type where properties will be pulled from.</param>
+        /// <returns>A collection of all the valid properties found on the <paramref name="source"/> type.</returns>
+        public static IEnumerable<PropertyInfo> GetValidProperties(this Type source)
+        {
+            return source.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.CanRead && p.CanWrite).Where(p => p.GetIndexParameters().Length == 0);
+        }
+
+        /// <summary>
         /// Checks if a type is enumerable or not
         /// </summary>
         /// <param name="source">The type to check.</param>
@@ -48,6 +444,64 @@ namespace CefSharp.ModelBinding
             var enumerableType = typeof(IEnumerable<>);
 
             return source.GetTypeInfo().IsGenericType && source.GetGenericTypeDefinition() == enumerableType;
+        }
+
+        /// <summary>
+        /// Converts the name property of <see cref="BindingMemberInfo"/> into camelCase
+        /// </summary>
+        /// <param name="member">the member info which will have it's name converted</param>
+        /// <returns>the camel case version of the method name.</returns>
+        public static string ConvertNameToCamelCase(this BindingMemberInfo member)
+        {
+            return ConvertNameToCamelCase(member.Name);
+        }
+
+        /// <summary>
+        /// Converts the name of a method into camelCase
+        /// </summary>
+        /// <param name="method">the method which will have it's name converted</param>
+        /// <returns>the camel case version of the method name.</returns>
+        public static string ConvertNameToCamelCase(this MethodInfo method)
+        {
+            return ConvertNameToCamelCase(method.Name);
+        }
+
+        /// <summary>
+        /// Converts the name of a property into camelCase
+        /// </summary>
+        /// <param name="property">the property which will have it's name converted</param>
+        /// <returns>the camel case version of the property name.</returns>
+        public static string ConvertNameToCamelCase(this PropertyInfo property)
+        {
+            return ConvertNameToCamelCase(property.Name);
+        }
+
+        /// <summary>
+        /// Converts a string (usually .NET value of some sort) to a camelCase representation.
+        /// </summary>
+        /// <param name="sourceString"></param>
+        /// <returns>the string converted to camelCase or preserved based on it's original structure.</returns>
+        private static string ConvertNameToCamelCase(this string sourceString)
+        {
+            // don't allow whitespace in property names.
+            // because we use this in the actual binding process, we should be throwing and not allowing invalid entries.
+            if (string.IsNullOrWhiteSpace(sourceString))
+            {
+                throw new TypeBindingException(typeof(string), typeof(string), BindingFailureCode.SourceObjectNullOrEmpty);
+            }
+
+            // camelCase says that if the string is only one character that it is preserved.
+            if (sourceString.Length == 1)
+                return sourceString;
+
+            var firstHalf = sourceString.Substring(0, 1);
+            var remainingHalf = sourceString.Substring(1);
+
+            // camelCase says that if the entire string is uppercase to preserve it.
+            if (char.IsUpper(firstHalf[0]) && char.IsUpper(remainingHalf[0]))
+                return sourceString;
+
+            return firstHalf.ToLowerInvariant() + remainingHalf;
         }
     }
 }

--- a/CefSharp/ModelBinding/ModelBindingExtensions.cs
+++ b/CefSharp/ModelBinding/ModelBindingExtensions.cs
@@ -333,27 +333,6 @@ namespace CefSharp.ModelBinding
                 || sourceObject is decimal;
         }
 
-
-        /// <summary>
-        /// Checks if a type is a <see cref="Tuple"/>.
-        /// This check wouldn't need to be here if the version was bumped, which should be considered given every other version of .NET is EOL
-        /// </summary>
-        /// <param name="source">The type to check.</param>
-        /// <returns><see langword="true" /> if the type is a <see cref="Tuple"/> of any size, otherwise <see langword="false" />.</returns>
-        public static bool IsTupleType(this Type source)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            // if the source is a class, is a generic type, then it might be an old Tuple type
-            if (source.IsClass && source.IsGenericType && TupleTypes.Contains(source))
-            {
-                return true;
-            }
-            return false;
-        }
-
-
         /// <summary>
         /// Supports ValueTypes even though CefSharp targets an older version
         /// </summary>
@@ -361,29 +340,24 @@ namespace CefSharp.ModelBinding
         /// <returns><see langword="true" /> if the type is a ValueTuple of any size, otherwise <see langword="false" />.</returns>
         public static bool IsValueTupleType(this Type source)
         {
-            // if the source is a structure. has any generic arguments, and it's name contains ValueTuple then return true.
-            // should allow CefSharp to support newer versions of .NET without the host application downgrading.
-            if (source.IsValueType && source.GetTypeInfo().GetGenericArguments().Any() && (source?.FullName?.Contains($"{nameof(System)}.Value{nameof(Tuple)}") ?? false))
+            var definition = source?.GetGenericTypeDefinition();
+            if (definition == null)
             {
-                return true;
+                return false;
             }
-            return false;
+            var definitionName = definition.FullName;
+            if (string.IsNullOrWhiteSpace(definitionName))
+            {
+                return false;
+            }
+            return string.Equals(definitionName, "System.ValueTuple`1", StringComparison.InvariantCulture) ||
+                string.Equals(definitionName, "System.ValueTuple`2", StringComparison.InvariantCulture) ||
+                string.Equals(definitionName, "System.ValueTuple`3", StringComparison.InvariantCulture) ||
+                string.Equals(definitionName, "System.ValueTuple`4", StringComparison.InvariantCulture) ||
+                string.Equals(definitionName, "System.ValueTuple`5", StringComparison.InvariantCulture) ||
+                string.Equals(definitionName, "System.ValueTuple`6", StringComparison.InvariantCulture) ||
+                string.Equals(definitionName, "System.ValueTuple`7", StringComparison.InvariantCulture);
         }
-
-        /// <summary>
-        /// A HashSet which contains all the different <see cref="Tuple"/> types for quick comparision.
-        /// </summary>
-        private static readonly HashSet<Type> TupleTypes = new HashSet<Type>(
-            new[] {
-                typeof(Tuple<>),
-                typeof(Tuple<,>),
-                typeof(Tuple<,,>),
-                typeof(Tuple<,,,>),
-                typeof(Tuple<,,,,>),
-                typeof(Tuple<,,,,,>),
-                typeof(Tuple<,,,,,,>),
-                typeof(Tuple<,,,,,,,>)}
-        );
 
 
         /// <summary>

--- a/CefSharp/ModelBinding/ModelBindingExtensions.cs
+++ b/CefSharp/ModelBinding/ModelBindingExtensions.cs
@@ -263,9 +263,6 @@ namespace CefSharp.ModelBinding
             throw new TypeBindingException(typeof(string), destinationType, BindingFailureCode.SourceNotAssignable);
         }
 
-
-      
-
         /// <summary>
         /// ReadOnly Dictionary that maps <see cref="TypeCode"/> members to their corresponding <see cref="Type"/> instance.
         /// </summary>

--- a/CefSharp/ModelBinding/TypeBindingException.cs
+++ b/CefSharp/ModelBinding/TypeBindingException.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+
+namespace CefSharp.ModelBinding
+{
+
+    /// <summary>
+    /// An attribute set on <see cref="BindingFailureCode"/> fields to provide context during an exception
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    internal class BindingFailureContextAttribute : Attribute
+    {
+        /// <summary>
+        /// Create a new instance of <see cref="BindingFailureContextAttribute"/>
+        /// </summary>
+        /// <param name="context">A string that expands upon an error code. Helpful for debugging.</param>
+        public BindingFailureContextAttribute(string context)
+        {
+            Value = context;
+        }
+        /// <summary>
+        /// The context you're looking for.
+        /// </summary>
+        public string Value { get; }
+    }
+
+    /// <summary>
+    /// An enumeration of error codes for why the binding process failed.
+    /// </summary>
+    /// <remarks>
+    /// The inline documentation mirrors the context attribute so it's possible to inspect failure context during development.
+    /// Because XML documentation isn't going to be present at runtime in a Production release, we provide the attribute as well.
+    /// </remarks>
+    public enum BindingFailureCode
+    {
+        /// <summary>
+        /// A default value for when no error code is provided.
+        /// </summary>
+        /// <remarks>
+        /// We use "Unavailable" rather than "None" due to the fact "None" is misleading and can lead to improper error handling.
+        /// </remarks>
+        [BindingFailureContext("No failure code is available for this exception")]
+        Unavailable,
+        /// <summary>
+        /// It was inferred the source object was an <see cref="Enum"/>. field, however the destination type is not an <see cref="Enum"/>.
+        /// </summary>
+        [BindingFailureContext("It was inferred the source object was an Enum field, however the destination type is not an Enum.")]
+        NoEnumAtDestinationType,
+        /// <summary>
+        /// No field exist in the destination enumeration that matches the source integral value.
+        /// </summary>
+        [BindingFailureContext("No field exist in the destination enumeration that matches the source integral value.")]
+        NumberNotDefinedInEnum,
+        /// <summary>
+        /// No field exist in the destination enumeration that matches the source string.
+        /// </summary>
+        [BindingFailureContext("No field exist in the destination enumeration that matches the source string.")]
+        StringNotDefinedInEnum,
+        /// <summary>
+        /// The destination enumeration contains no fields.
+        /// </summary>
+        [BindingFailureContext("The destination enumeration contains no fields.")]
+        DestinationEnumEmpty,
+        /// <summary>
+        /// A string could not be parsed to an underlying integral type compatible with an enum.
+        /// </summary>
+        [BindingFailureContext("A string could not be parsed to an underlying integral type compatible with an enum.")]
+        EnumIntegralNotFound,
+        /// <summary>
+        /// A provided source object was null or an empty collection on a non-nullable destination type.
+        /// </summary>
+        [BindingFailureContext("A provided source object was null on a non-nullable destination type.")]
+        SourceObjectNullOrEmpty,
+        /// <summary>
+        /// The underlying type for the source object cannot be assigned to the destination type or lacks a destination altogether.
+        /// </summary>
+        [BindingFailureContext("The underlying type for the source object cannot be assigned to the destination type or lacks a destination altogether.")]
+        SourceNotAssignable,
+        /// <summary>
+        ///  The Javascript object member does not correspond to any member on the destination type
+        /// </summary>
+        [BindingFailureContext("The Javascript object member {0} does not correspond to any member on the destination type. Are your style conventions correct?")]
+        MemberNotFound,
+        /// <summary>
+        ///  The source type cannot be serialized to a type that is safe for Javascript to use.
+        /// </summary>
+        [BindingFailureContext("The source type {0} cannot be serialized to a type that is safe for Javascript to use. {1}")]
+        UnsupportedJavascriptType
+    }
+
+    /// <summary>
+    /// An exception that is thrown whenever data cannot be properly marshaled.
+    /// </summary>
+    public class TypeBindingException : Exception
+    {
+        /// <summary>
+        /// The underlying type that was inferred for the source object that needed to be bound 
+        /// </summary>
+        public Type SourceObjectType { get; }
+        public Type DestinationType { get; }
+        public string Context { get; }
+        public BindingFailureCode Code { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="TypeBindingException"/> using a backing failure code for which context can be derived.
+        /// </summary>
+        /// <param name="sourceObjectType">the inferred type for the object that was meant to be bound.</param>
+        /// <param name="destinationType">the destination type the object attempted to be marshaled to.</param>
+        /// <param name="code">a failure code that defines the reason the binding process failed.</param>
+        /// <param name="formatValues">if present, any values here will be used to format the context string.</param>
+        public TypeBindingException(Type sourceObjectType, Type destinationType, BindingFailureCode code, params object[] formatValues)
+        {
+            SourceObjectType = sourceObjectType;
+            DestinationType = destinationType;
+            Code = code;
+            Context = FindFailureContext(code);
+            if (formatValues != null && formatValues.Length > 0)
+            {
+                Context = string.Format(Context, formatValues);
+            }
+        }
+
+        /// <summary>
+        /// Attempts to find the <see cref="BindingFailureContextAttribute"/> value of a given <see cref="BindingFailureCode"/> field.
+        /// </summary>
+        /// <param name="value">the field to find context on.</param>
+        /// <returns>the value set on the <see cref="BindingFailureContextAttribute"/>, otherwise a default non-null value.</returns>
+        private static string FindFailureContext(Enum value)
+        {
+            var enumType = value.GetType();
+            var name = Enum.GetName(enumType, value);
+            return enumType.GetField(name).GetCustomAttributes(false).OfType<BindingFailureContextAttribute>().SingleOrDefault()?.Value ?? "No context is available this error code.";
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TypeBindingException"/> without a backing failure code.
+        /// </summary>
+        /// <param name="sourceObjectType">the inferred type for the object that was meant to be bound.</param>
+        /// <param name="destinationType">the destination type the object attempted to be marshaled to.</param>
+        /// <param name="context">in lieu of a failure code, provide a explanation as to why the binding process failed.</param>
+        /// <remarks>
+        /// the <see cref="Code"/> property will automatically be set to <see cref="BindingFailureCode.Unavailable"/>
+        /// </remarks>
+        public TypeBindingException(Type sourceObjectType, Type destinationType, string context)
+        {
+            SourceObjectType = sourceObjectType;
+            DestinationType = destinationType;
+            Context = context;
+            Code = BindingFailureCode.Unavailable;
+        }
+    }
+}

--- a/CefSharp/ModelBinding/TypeSafeBinder.cs
+++ b/CefSharp/ModelBinding/TypeSafeBinder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using CefSharp.ModelBinding.Converters;
 
 namespace CefSharp.ModelBinding
 {
@@ -31,6 +32,7 @@ namespace CefSharp.ModelBinding
         public TypeSafeBinder()
         {
             BinderGuidConverter.Register();
+            BinderVersionConverter.Register();
         }
 
         /// <summary>

--- a/CefSharp/ModelBinding/TypeSafeBinder.cs
+++ b/CefSharp/ModelBinding/TypeSafeBinder.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+namespace CefSharp.ModelBinding
+{
+
+    /// <summary>
+    /// This class is responsible for marshaling Javascript objects into their corresponding .NET type. 
+    /// </summary>
+    /// <remarks>
+    /// This binder has no backwards compatibility with the <see cref="DefaultBinder"/> due to changes in how data member are marshaled.
+    /// </remarks>
+    public class TypeSafeBinder : IBinder
+    {
+        /// <summary>
+        /// Used to try and convert a generic type to an array via Reflection.
+        /// </summary>
+        private static readonly MethodInfo ToArrayMethodInfo = typeof(Enumerable).GetMethod("ToArray", BindingFlags.Public | BindingFlags.Static);
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TypeSafeBinder"/> and registers converters with <see cref="TypeDescriptor"/> <br/>
+        /// This binder can reliably marshal data between the Javascript and .NET domains. <br/>
+        /// For example it provides interoperability for Typescript, Javascript, and C# style conventions without making you drop conventions in one of your languages. <br/>
+        /// It will also handle types like <see cref="Guid"/> or <see cref="Enum"/> fields that have flags. <br/>
+        /// Finally it ensure there is type safety by throwing <see cref="TypeBindingException"/> whenever data is malformed so you can catch issues in your code.
+        /// </summary>
+        public TypeSafeBinder()
+        {
+            BinderGuidConverter.Register();
+        }
+
+        /// <summary>
+        /// Attempts to bind a Javascript object into a corresponding .NET type.
+        /// </summary>
+        /// <param name="javaScriptObject">An instance of the Javascript object.</param>
+        /// <param name="nativeType">The type this method will try to create an instance of using the Javascript object.</param>
+        /// <returns>An instance of the native type.</returns>
+        public object Bind(object javaScriptObject, Type nativeType)
+        {
+            // if the intended destination is an enumeration, we can try and get the corresponding member upfront.
+            // internally this will throw a TypeBindingException if it runs into issues. See the documentation for more information.
+            if (nativeType.IsEnum)
+            {
+                return nativeType.CreateEnumMember(javaScriptObject);
+            }
+
+            // if the source object is null and is not an enum, then there isn't anything left to do.
+            if (javaScriptObject == null)
+            {
+                return null;
+            }
+            // get the underlying type for the incoming object 
+            var javaScriptType = javaScriptObject.GetType();
+
+            // if the object can be directly assigned to the destination type, then return and let the runtime handle the rest.
+            if (nativeType.IsAssignableFrom(javaScriptType))
+            {
+                return javaScriptObject;
+            }
+
+            // custom Type converters should be registered in the constructor before calling this
+            var typeConverter = TypeDescriptor.GetConverter(javaScriptType);
+            // If the object can be converted to the target (=> double to int, string to Guid), go for it.
+            if (typeConverter.CanConvertTo(nativeType))
+            {
+                return typeConverter.ConvertTo(javaScriptObject, nativeType);
+            }
+            // collections have to be unwound 
+            if (nativeType.IsCollection() || nativeType.IsArray() || nativeType.IsEnumerable())
+            {
+                return BindCollection(nativeType, javaScriptType, javaScriptObject);
+            }
+            return BindObject(nativeType, javaScriptType, javaScriptObject);
+        }
+
+
+        /// <summary>
+        /// Binds a Javascript collection to a .NET collection
+        /// </summary>
+        /// <param name="nativeType">The native collection type.</param>
+        /// <param name="javaScriptType">The underlying type for the Javascript object.</param>
+        /// <param name="javaScriptObject">The Javascript object that will be unwound to the native collection type.</param>
+        /// <returns>
+        /// A .NET collection which should have all the same value as the <paramref name="javaScriptObject"/>
+        /// </returns>
+        protected virtual object BindCollection(Type nativeType, Type javaScriptType, object javaScriptObject)
+        {
+            // if the Javascript object isn't a collection throw, we shouldn't have ended up here.
+            if (!(javaScriptObject is ICollection javaScriptCollection))
+            {
+                throw new TypeBindingException(javaScriptObject.GetType(), nativeType, BindingFailureCode.SourceNotAssignable);
+            }
+
+            Type genericType;
+
+            // check if the native type is a generic
+            if (nativeType.GetTypeInfo().IsGenericType)
+            {
+                // get the generic backing type of the native type
+                genericType = nativeType.GetGenericArguments().FirstOrDefault();
+            }
+            else
+            {
+                // otherwise it's a collection, and we get the backing type for that.
+                var enumerable = nativeType.GetInterfaces().Where(i => i.GetTypeInfo().IsGenericType).FirstOrDefault(i => i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+                genericType = enumerable?.GetGenericArguments()?.FirstOrDefault();
+            }
+
+            // if we don't have a generic type then just use object
+            if (genericType == null)
+            {
+                genericType = typeof(object);
+            }
+
+            var modelType = typeof(List<>).MakeGenericType(genericType);
+            var model = (IList)Activator.CreateInstance(modelType);
+
+            // loop over the collection and assign the items to their corresponding types
+            foreach (var javaScriptItem in javaScriptCollection)
+            {
+                // if the value is null then we'll add null to the collection,
+                if (javaScriptItem == null)
+                {
+                    // for value types like int we'll create the default value and assign that as we cannot assign null
+                    model.Add(genericType.IsValueType ? Activator.CreateInstance(genericType) : null);
+                }
+                else
+                {
+                    var valueType = javaScriptItem.GetType();
+                    // if the collection item is a list or dictionary then we'll attempt to bind it
+                    if (typeof(IDictionary<string, object>).IsAssignableFrom(valueType) || typeof(IList<object>).IsAssignableFrom(valueType))
+                    {
+                        var subModel = Bind(javaScriptItem, genericType);
+                        model.Add(subModel);
+                    }
+                    else
+                    {
+                        model.Add(javaScriptItem);
+                    }
+                }
+            }
+            // if the native type is actually an array and not a list, then convert the mode above to an array
+            if (nativeType.IsArray())
+            {
+                var genericToArrayMethod = ToArrayMethodInfo.MakeGenericMethod(genericType);
+                return genericToArrayMethod.Invoke(null, new object[] { model });
+            }
+            // otherwise return the model
+            return model;
+        }
+
+        /// <summary>
+        /// Bind a Javascript object to a corresponding .NET type
+        /// </summary>
+        /// <param name="nativeType">The native type to bind against.</param>
+        /// <param name="javaScriptType">The native type inferred from the Javascript object.</param>
+        /// <param name="javaScriptObject">The Javascript object that will be bound.</param>
+        /// <returns>
+        /// An instance of the .NET type which should have all the same values as the <paramref name="javaScriptObject"/>
+        /// </returns>
+        protected virtual object BindObject(Type nativeType, Type javaScriptType, object javaScriptObject)
+        {
+            // create an instance of our native type. 
+            // use nonPublic: true to signal we want public and non-public default constructors to activate
+            var model = Activator.CreateInstance(nativeType, true);
+
+            // If the object type is a dictionary then attempt to bind all the members of the Javascript object to their C# counterpart 
+            if (typeof(IDictionary<string, object>).IsAssignableFrom(javaScriptType))
+            {
+                // all of the public and assignable Properties from the native Type
+                var nativeMembers = BindingMemberInfo.CollectEncapsulatedProperties(nativeType).ToList();
+                // loop over the Javascript object
+                foreach (var javaScriptMember in (IDictionary<string, object>)javaScriptObject)
+                {
+                    // now for every Javascript member we try to find it's corresponding .NET member on the native Type 
+                    foreach (var nativeMember in nativeMembers)
+                    {
+                        // make sure the native members name is an EXACT match to what would have been bound to the window
+                        if (javaScriptMember.Key.Equals(nativeMember.ConvertNameToCamelCase()))
+                        {
+                            // bind the Javascript members value to to the native Type 
+                            var nativeValue = Bind(javaScriptMember.Value, nativeMember.Type);
+                            // and then set it on the instance of the native type we created
+                            nativeMember.SetValue(model, nativeValue);
+                        }
+                    }
+                    // if we failed to find a member on the .NET type whose name is equal to the Javascript member, throw.
+                    // most likely the end-user is not using proper conventions on one side.
+                    throw new TypeBindingException(javaScriptType, nativeType, BindingFailureCode.MemberNotFound, javaScriptMember.Key);
+                }
+            }
+            return model;
+        }
+
+    }
+}

--- a/CefSharp/ModelBinding/TypeSafeInterceptor.cs
+++ b/CefSharp/ModelBinding/TypeSafeInterceptor.cs
@@ -117,6 +117,8 @@ namespace CefSharp.ModelBinding
             // serialize the Guid to a Javascript safe object (string)
             if (value is Guid guid)
                 return SerializeGuid(guid);
+            if (value is Version version)
+                return SerializeVersion(version);
             // serialize the dictionary 
             if (value is IDictionary dict)
                 return SerializeDictionary(dict);
@@ -197,6 +199,15 @@ namespace CefSharp.ModelBinding
                 javaScriptObject[property.ConvertNameToCamelCase()] = SerializeObject(property.GetValue(value));
             }
             return javaScriptObject;
+        }
+        /// <summary>
+        /// Javascript does not natively support the <see cref="Version"/> class so it is serialized to a string here
+        /// </summary>
+        /// <param name="version">the instance of Version to be serialized</param>
+        /// <returns>a string representation of the <paramref name="version"/> instance</returns>
+        private static string SerializeVersion(Version version)
+        {
+            return version.ToString();
         }
 
         /// <summary>

--- a/CefSharp/ModelBinding/TypeSafeInterceptor.cs
+++ b/CefSharp/ModelBinding/TypeSafeInterceptor.cs
@@ -126,7 +126,7 @@ namespace CefSharp.ModelBinding
             if (value is ICollection collection)
                 return SerializeCollection(collection);
             // serialize tuples so they are usable
-            if (resultType.IsTupleType() || resultType.IsValueTupleType())
+            if (resultType.IsValueTupleType())
                 return SerializeTuple(value);
             // no conversion necessary other than a cast 
             if (resultType.IsEnum)
@@ -229,12 +229,7 @@ namespace CefSharp.ModelBinding
         private static List<object> SerializeTuple(object tuple)
         {
             // ValueTuples are structs, so we get it objects fields
-            if (tuple.GetType().IsValueTupleType())
-            {
-                return tuple.GetType().GetFields().Select(field => SerializeObject(field.GetValue(tuple))).ToList();
-            }
-            // Tuples are classes so we get the properties
-            return tuple.GetType().GetProperties().Select(property => SerializeObject(property.GetValue(tuple))).ToList();
+            return tuple.GetType().GetFields().Select(field => SerializeObject(field.GetValue(tuple))).ToList();
         }
 
         /// <summary>

--- a/CefSharp/ModelBinding/TypeSafeInterceptor.cs
+++ b/CefSharp/ModelBinding/TypeSafeInterceptor.cs
@@ -113,15 +113,16 @@ namespace CefSharp.ModelBinding
             var resultType = value.GetType();
             // check if the incoming value needs special care
             // this would be a lot cleaner with C# 8.0 pattern matching
-            switch (value)
-            {
-                case Guid guid:
-                    return SerializeGuid(guid);
-                case IDictionary dict:
-                    return SerializeDictionary(dict);
-                case ICollection collection:
-                    return SerializeCollection(collection);
-            }
+
+            // serialize the Guid to a Javascript safe object (string)
+            if (value is Guid guid)
+                return SerializeGuid(guid);
+            // serialize the dictionary 
+            if (value is IDictionary dict)
+                return SerializeDictionary(dict);
+            // serialize the list
+            if (value is ICollection collection)
+                return SerializeCollection(collection);
             // serialize tuples so they are usable
             if (resultType.IsTupleType() || resultType.IsValueTupleType())
                 return SerializeTuple(value);

--- a/CefSharp/ModelBinding/TypeSafeInterceptor.cs
+++ b/CefSharp/ModelBinding/TypeSafeInterceptor.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace CefSharp.ModelBinding
+{
+    /// <summary>
+    /// When using this interceptor .NET methods can continue to use .NET only types like <see cref="Guid"/> and <see cref="Tuple"/> both as parameters and return values.<br/>
+    /// Asynchronous <see cref="Task{TResult}"/> are also supported and can be bound to the window to allow support for promises without <see cref="CefSharpSettings.ConcurrentTaskExecution"/><br/>
+    /// The Javascript side will get back values it can use without forcing boilerplate on users.
+    /// </summary>
+    public class TypeSafeInterceptor : IMethodInterceptor
+    {
+        public bool IsAsynchronous => true;
+
+        /// <summary>
+        /// Interception starts when we detect Javascript has attempted to invoke a .NET method.
+        /// Now we evaluate the method and return what we deem to be the correct result for Javascript.
+        /// </summary>
+        /// <param name="method">the .NET method that will be invoked</param>
+        /// <param name="parameters">all of the input parameters</param>
+        /// <param name="methodName">the name of the method</param>
+        /// <returns>The serialized return value of the executed method</returns>
+        public async Task<object> InterceptAsync(Func<object[], object> method, object[] parameters, string methodName)
+        {
+            // execute the method using the provided parameters
+            var returnValue = method(parameters);
+            // there is no return value, so return immediately. 
+            if (returnValue == null)
+            {
+                return null;
+            }
+            // serialize the method's return value
+            return await Intercept(returnValue).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Not used.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="parameters"></param>
+        /// <param name="methodName"></param>
+        /// <returns></returns>
+        public object Intercept(Func<object[], object> method, object[] parameters, string methodName)
+        {
+            throw new NotImplementedException("To use the TypeSafeInterceptor please set IsAsynchronous to true");
+        }
+
+        /// <summary>
+        /// Performs dynamic analysis on a given input value and determines the best serialization to apply.
+        /// </summary>
+        /// <param name="value">the value the analyze</param>
+        /// <returns>the serialized value</returns>
+        public static async Task<object> Intercept(object value)
+        {
+            var returnType = value.GetType();
+            // the .NET method didn't return an asynchronous Task so we can just serialize and return.
+            if (!returnType.IsGenericType || returnType.GetGenericTypeDefinition() != typeof(Task<>))
+            {
+                return SerializeObject(value);
+            }
+            // our anonymous method is an asynchronous Task. Run it and await results.
+            var result = await ConvertTask(value as Task).ConfigureAwait(false);
+            if (result == null)
+            {
+                return null;
+            }
+            // try to serialize the Task result. If the result of the Task was another Task this will catch it.
+            return SerializeObject(result);
+        }
+
+        /// <summary>
+        /// Converts an Object into a runnable <see cref="Task"/>.
+        /// </summary>
+        /// <param name="task">the task that will be executed via reflection.</param>
+        /// <returns>the <paramref name="task"/> results if any.</returns>
+        private static async Task<object> ConvertTask(Task task)
+        {
+            // run the task
+            await task.ConfigureAwait(false);
+            var voidTaskType = typeof(Task<>).MakeGenericType(Type.GetType("System.Threading.Tasks.VoidTaskResult"));
+            // if the task is a void, we can just return.
+            if (voidTaskType.IsInstanceOfType(task))
+            {
+                return null;
+            }
+            // now use reflection to get the results 
+            var property = task.GetType().GetProperty("Result", BindingFlags.Public | BindingFlags.Instance);
+            // if there are none we return
+            if (property == null)
+            {
+                return null;
+            }
+            // grab the actual current return value from memory
+            return property.GetValue(task);
+        }
+
+        /// <summary>
+        /// Serializes a .NET object into the type-safe Javascript object.
+        /// </summary>
+        /// <param name="value">the .NET value that needs to be converted.</param>
+        /// <returns>A Javascript ready object.</returns>
+        /// <remarks>
+        /// It's dictionaries all the way down
+        /// </remarks>
+        private static object SerializeObject(object value)
+        {
+            if (value == null)
+                return null;
+            var resultType = value.GetType();
+            // check if the incoming value needs special care
+            // this would be a lot cleaner with C# 8.0 pattern matching
+            switch (value)
+            {
+                case Guid guid:
+                    return SerializeGuid(guid);
+                case IDictionary dict:
+                    return SerializeDictionary(dict);
+                case ICollection collection:
+                    return SerializeCollection(collection);
+            }
+            // serialize tuples so they are usable
+            if (resultType.IsTupleType() || resultType.IsValueTupleType())
+                return SerializeTuple(value);
+            // no conversion necessary other than a cast 
+            if (resultType.IsEnum)
+                return (int)value;
+            // all primitive types should be fine as is
+            if (value.IsNumber())
+                return value;
+            // a string doesn't require special conversion.
+            if (value is string)
+                return value;
+            // nor does a boolean
+            if (value is bool)
+                return value;
+
+
+            var typeName = resultType.FullName;
+            // no type name, no pass.
+            if (string.IsNullOrWhiteSpace(typeName))
+            {
+                throw new TypeBindingException(resultType, null, BindingFailureCode.SourceNotAssignable);
+            }
+            // something has gone horribly wrong, no System types should be on returning objects.
+            if (typeName.StartsWith("System."))
+            {
+                // throw and say it louder for the people in the back
+                switch (typeName)
+                {
+                    case "System.Object":
+                        throw new TypeBindingException(resultType, null, BindingFailureCode.UnsupportedJavascriptType, resultType.FullName, "Returning results must have a valid type to be serialized.");
+                    case "System.Threading.Tasks.Task":
+                    case "System.Threading.Tasks.VoidTaskResult":
+                        throw new TypeBindingException(resultType, null, BindingFailureCode.UnsupportedJavascriptType, resultType.FullName, "Serialized child objects cannot have a TypeDefinition which inherits Task.");
+                    case "System.Void":
+                        throw new TypeBindingException(resultType, null, BindingFailureCode.UnsupportedJavascriptType, resultType.FullName, "Void is not a type that can be serialized.");
+                    default:
+                        throw new TypeBindingException(resultType, null, BindingFailureCode.UnsupportedJavascriptType, resultType.FullName, "System types cannot be serialized.");
+                }
+            }
+
+            if (resultType.IsCustomStruct())
+            {
+                throw new TypeBindingException(resultType,
+                    null, BindingFailureCode.UnsupportedJavascriptType,
+                    resultType.FullName, "Structs are not supported as immutable fields cannot be guaranteed to stay unchanged if this structure is marshaled back to .NET.");
+            }
+            // if the underlying value isn't a .NET class or interface, return the value as it is.
+            if (!resultType.IsClass && !resultType.IsInterface)
+                return value;
+
+            var javaScriptObject = new Dictionary<string, object>();
+            // I Write Sins Not Tragedies
+            // for .NET classes being returned to Javascript, don't allow them to have fields.
+            // this avoids leaking data and exposing the backing fields for public properties. It also forces bound objects to practice good hygiene 
+            var fields = value.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public);
+            if (fields.Length > 0)
+            {
+                throw new TypeBindingException(resultType,
+                    null, BindingFailureCode.UnsupportedJavascriptType,
+                    resultType.FullName, "Cannot be serialized because it has public fields. " +
+                    "To avoid data leakage, please make the fields private and create a property that uses the underlying field.");
+            }
+
+            // gather up all the valid properties on a class
+            // this does not return properties in a particular order
+            var properties = value.GetType().GetValidProperties();
+            foreach (var property in properties)
+            {
+                // convert the model property name to camelCase to respect Javascript conventions
+                // then grab the current value of the property and serialize the result of that as well.
+                javaScriptObject[property.ConvertNameToCamelCase()] = SerializeObject(property.GetValue(value));
+            }
+            return javaScriptObject;
+        }
+
+        /// <summary>
+        /// Javascript does not support <see cref="Guid"/> structures so serialize it into a string.
+        /// </summary>
+        /// <param name="guid">a GUID</param>
+        /// <returns>the string representation of a GUID</returns>
+        private static string SerializeGuid(Guid guid)
+        {
+            return guid.ToString("N");
+        }
+
+        /// <summary>
+        /// A tuple is a data structure that has a specific number and sequence of elements.
+        /// Because tuples are not actually serializable in C#, we convert them to an array of serialized objects.
+        /// </summary>
+        /// <param name="tuple">Can be a Tuple or ValueTuple</param>
+        /// <returns></returns>
+        private static List<object> SerializeTuple(object tuple)
+        {
+            // ValueTuples are structs, so we get it objects fields
+            if (tuple.GetType().IsValueTupleType())
+            {
+                return tuple.GetType().GetFields().Select(field => SerializeObject(field.GetValue(tuple))).ToList();
+            }
+            // Tuples are classes so we get the properties
+            return tuple.GetType().GetProperties().Select(property => SerializeObject(property.GetValue(tuple))).ToList();
+        }
+
+        /// <summary>
+        /// Iterates through a collection, serializes the items, and returns the collection.
+        /// </summary>
+        /// <param name="collection">The collection that contains .NET types that need to be serialized.</param>
+        /// <returns>The newly formed Javascript collection</returns>
+        private static List<object> SerializeCollection(IEnumerable collection)
+        {
+            return (from object entry in collection select SerializeObject(entry)).ToList();
+        }
+
+        /// <summary>
+        /// Iterate through a dictionary and form a new one with the originals serialized values.
+        /// </summary>
+        /// <param name="dict">The dictionary that contains .NET types that need to be serialized.</param>
+        /// <returns>The newly formed Javascript ready dictionary.</returns>
+        private static Dictionary<string, object> SerializeDictionary(IEnumerable dict)
+        {
+            var ret = new Dictionary<string, object>();
+            foreach (DictionaryEntry entry in dict)
+            {
+                var key = entry.Key.ToString();
+                if (entry.Key.GetType().IsEnum)
+                    key = ((int)entry.Key).ToString();
+
+                ret[key] = SerializeObject(entry.Value);
+            }
+
+            return ret;
+        }
+    }
+}


### PR DESCRIPTION
**Fixes:** 
#3137 #3129 #2231 and probably a whole host of people who have been surprised to find out that `BindingOptions.CamelCaseJavascriptNames` is a one way operation. 

**Summary:** 
When `CefSharpSettings.TypeSafeMarshaling` is set to true CefSharp will use strict type-safe analysis for sending and receiving data.

- Javascript objects can be assigned to their corresponding .NET type, even if it is a Guid or Tuple.
- Nulls for non-nullable types and other undefine behavior raise detailed exceptions to developers so they can fix their code.
- .NET types like Guid and Tuple are valid return types for .NET methods returning to Javascript.
- Added support for asynchronous Task.
- Security has been introduced to prevent immutable types from being marshaled.
- .NET code can keep it's .NET coding conventions and Javascript and TypeScript code can keep theirs. 

For extra "safety" I'll open a separate pull request for a TypeScript code generator.

**Changes:** 

Because our build of CefSharp targets .NET 4.7.2 we have the luxury of some modern .NET features. For this change I had to implement things like a crude Tuple and ValueTuple (which isn't even supported in 4.5.2, and is no longer supported by Microsoft) detection, but it seems to work fine.

Other than that, we applied only the code that could be introduced without making breaking changes. This pull request has backwards combability for people who built their code around the default binder, but when they enable the new setting their code will probably break. 

Which probably isn't entirely a bad thing because using this code in production, we've eliminated almost all issues you would expect to get from sending complex objects from a typed language, to an untyped language, and back again.  
 
**How Has This Been Tested?**  

- Used in production at https://rainway.com/ for quite some time.

**Screenshots (if appropriate):**
![](https://i.imgur.com/lnsZJcH.png)
**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
