### PR TITLE
Core - Re-Add IAudioHandler

### DIFF
--- a/CefSharp.Core/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core/Internals/ClientAdapter.cpp
@@ -992,6 +992,79 @@ namespace CefSharp
             }
         }
 
+        bool ClientAdapter::GetAudioParameters(CefRefPtr<CefBrowser> browser, CefAudioParameters & params)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler == nullptr)
+            {
+                return false;
+            }
+
+            auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+            auto parameters = new AudioParameters((CefSharp::Enums::ChannelLayout)params.channel_layout, params.sample_rate, params.frames_per_buffer);
+
+            auto result = handler->GetAudioParameters(_browserControl, browserWrapper, *parameters);
+
+            if (result)
+            {
+                params.channel_layout = (cef_channel_layout_t)parameters->ChannelLayout;
+                params.sample_rate = parameters->SampleRate;
+                params.frames_per_buffer = parameters->FramesPerBuffer;
+            }
+
+            return result;
+        }
+
+        void ClientAdapter::OnAudioStreamStarted(CefRefPtr<CefBrowser> browser, const CefAudioParameters& params, int channels)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+                AudioParameters parameters((CefSharp::Enums::ChannelLayout)params.channel_layout, params.sample_rate, params.frames_per_buffer);
+
+                handler->OnAudioStreamStarted(_browserControl, browserWrapper, parameters, channels);
+            }
+        }
+
+        void ClientAdapter::OnAudioStreamPacket(CefRefPtr<CefBrowser> browser, const float** data, int frames, int64 pts)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnAudioStreamPacket(_browserControl, browserWrapper, IntPtr((void *)data), frames, pts);
+            }
+        }
+
+        void ClientAdapter::OnAudioStreamStopped(CefRefPtr<CefBrowser> browser)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnAudioStreamStopped(_browserControl, browserWrapper);
+            }
+        }
+
+        void ClientAdapter::OnAudioStreamError(CefRefPtr<CefBrowser> browser, const CefString& message)
+        {
+            auto handler = _browserControl->AudioHandler;
+
+            if (handler != nullptr)
+            {
+                auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
+
+                handler->OnAudioStreamError(_browserControl, browserWrapper, StringUtils::ToClr(message));
+            }
+        }
+
         bool ClientAdapter::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefProcessId source_process, CefRefPtr<CefProcessMessage> message)
         {
             auto handled = false;

--- a/CefSharp.Core/Internals/ClientAdapter.h
+++ b/CefSharp.Core/Internals/ClientAdapter.h
@@ -32,7 +32,8 @@ namespace CefSharp
             public CefDialogHandler,
             public CefDragHandler,
             public CefDownloadHandler,
-            public CefFindHandler
+            public CefFindHandler,
+            public CefAudioHandler
         {
         private:
             gcroot<IWebBrowserInternal^> _browserControl;
@@ -94,6 +95,7 @@ namespace CefSharp
             virtual DECL CefRefPtr<CefDialogHandler> GetDialogHandler() OVERRIDE { return this; }
             virtual DECL CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE { return this; }
             virtual DECL CefRefPtr<CefFindHandler> GetFindHandler() OVERRIDE { return this; }
+            virtual DECL CefRefPtr<CefAudioHandler> GetAudioHandler() OVERRIDE { return this; }
             virtual DECL bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefProcessId source_process, CefRefPtr<CefProcessMessage> message) OVERRIDE;
 
 
@@ -184,6 +186,13 @@ namespace CefSharp
 
             //CefFindHandler
             virtual DECL void OnFindResult(CefRefPtr<CefBrowser> browser, int identifier, int count, const CefRect& selectionRect, int activeMatchOrdinal, bool finalUpdate) OVERRIDE;
+
+            //CefAudioHandler
+            virtual DECL bool GetAudioParameters(CefRefPtr<CefBrowser> browser, CefAudioParameters & params) OVERRIDE;
+            virtual DECL void OnAudioStreamStarted(CefRefPtr<CefBrowser> browser, const CefAudioParameters& params, int channels) OVERRIDE;
+            virtual DECL void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser, const float** data, int frames, int64 pts) OVERRIDE;
+            virtual DECL void OnAudioStreamStopped(CefRefPtr<CefBrowser> browser) OVERRIDE;
+            virtual DECL void OnAudioStreamError(CefRefPtr<CefBrowser> browser, const CefString& message) OVERRIDE;
 
             IMPLEMENT_REFCOUNTING(ClientAdapter);
         };

--- a/CefSharp.Example/CefSharp.Example.csproj
+++ b/CefSharp.Example/CefSharp.Example.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Callback\RunFileDialogCallback.cs" />
     <Compile Include="DevTools\DevToolsExtensions.cs" />
     <Compile Include="DevTools\TaskMethodDevToolsMessageObserver.cs" />
+    <Compile Include="Handlers\AudioHandler.cs" />
     <Compile Include="Handlers\ExampleResourceRequestHandler.cs" />
     <Compile Include="Handlers\ExtensionHandler.cs" />
     <Compile Include="JavascriptBinding\AsyncBoundObject.cs" />

--- a/CefSharp.Example/Handlers/AudioHandler.cs
+++ b/CefSharp.Example/Handlers/AudioHandler.cs
@@ -1,0 +1,47 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using CefSharp.Enums;
+using CefSharp.Structs;
+
+namespace CefSharp.Example.Handlers
+{
+    public class AudioHandler : IAudioHandler
+    {
+        private ChannelLayout channelLayout;
+        private int channelCount;
+        private int sampleRate;
+
+        bool IAudioHandler.GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref AudioParameters parameters)
+        {
+            //Cancel Capture
+            return false;
+        }
+
+        void IAudioHandler.OnAudioStreamError(IWebBrowser chromiumWebBrowser, IBrowser browser, string errorMessage)
+        {
+
+        }
+
+        void IAudioHandler.OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, IntPtr data, int noOfFrames, long pts)
+        {
+            //NOTE: data is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s)
+            //Based on and the channelLayout value passed to IAudioHandler.OnAudioStreamStarted
+            //you can calculate the size of the data array in bytes.
+        }
+
+        void IAudioHandler.OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, AudioParameters parameters, int channels)
+        {
+            this.channelLayout = parameters.ChannelLayout;
+            this.sampleRate = parameters.SampleRate;
+            this.channelCount = channels;
+        }
+
+        void IAudioHandler.OnAudioStreamStopped(IWebBrowser chromiumWebBrowser, IBrowser browser)
+        {
+
+        }
+    }
+}

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -186,13 +186,15 @@ namespace CefSharp.OffScreen
         /// </summary>
         /// <value>The find handler.</value>
         public IFindHandler FindHandler { get; set; }
-
+        /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        public IAudioHandler AudioHandler { get; set; }
         /// <summary>
         /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
         /// </summary>
         /// <value>The accessibility handler.</value>
         public IAccessibilityHandler AccessibilityHandler { get; set; }
-
         /// <summary>
         /// Event handler that will get called when the resource load for a navigation fails or is canceled.
         /// It's important to note this event is fired on a CEF UI thread, which by default is not the same as your application UI

--- a/CefSharp.WinForms.Example/BrowserTabUserControl.cs
+++ b/CefSharp.WinForms.Example/BrowserTabUserControl.cs
@@ -39,6 +39,8 @@ namespace CefSharp.WinForms.Example
             browser.RequestHandler = new WinFormsRequestHandler(openNewTab);
             browser.JsDialogHandler = new JsDialogHandler();
             browser.DownloadHandler = new DownloadHandler();
+            browser.AudioHandler = new AudioHandler();
+
             if (multiThreadedMessageLoopEnabled)
             {
                 browser.KeyboardHandler = new KeyboardHandler();

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -268,6 +268,11 @@ namespace CefSharp.WinForms
         [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden), DefaultValue(null)]
         public IFindHandler FindHandler { get; set; }
         /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden), DefaultValue(null)]
+        public IAudioHandler AudioHandler { get; set; }
+        /// <summary>
         /// The <see cref="IFocusHandler" /> for this ChromiumWebBrowser.
         /// </summary>
         /// <value>The focus handler.</value>

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -91,6 +91,7 @@ namespace CefSharp.Wpf.Example.Views
             downloadHandler.OnBeforeDownloadFired += OnBeforeDownloadFired;
             downloadHandler.OnDownloadUpdatedFired += OnDownloadUpdatedFired;
             browser.DownloadHandler = downloadHandler;
+            browser.AudioHandler = new AudioHandler();
 
             //Read an embedded bitmap into a memory stream then register it as a resource you can then load custom://cefsharp/images/beach.jpg
             var beachImageStream = new MemoryStream();

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -290,7 +290,10 @@ namespace CefSharp.Wpf
         /// </summary>
         /// <value>The find handler.</value>
         public IFindHandler FindHandler { get; set; }
-
+        /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        public IAudioHandler AudioHandler { get; set; }
         /// <summary>
         /// Implement <see cref="IAccessibilityHandler" /> to handle events related to accessibility.
         /// </summary>

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -128,6 +128,7 @@
     <Compile Include="ResourceRequestHandlerFactory.cs" />
     <Compile Include="ResourceRequestHandlerFactoryItem.cs" />
     <Compile Include="Enums\AlphaType.cs" />
+    <Compile Include="Enums\ChannelLayout.cs" />
     <Compile Include="Enums\PointerType.cs" />
     <Compile Include="Enums\TextInputMode.cs" />
     <Compile Include="Enums\TouchEventType.cs" />
@@ -146,6 +147,7 @@
     <Compile Include="Handler\ICookieAccessFilter.cs" />
     <Compile Include="Handler\IResourceRequestHandler.cs" />
     <Compile Include="IApp.cs" />
+    <Compile Include="Handler\IAudioHandler.cs" />
     <Compile Include="IExtension.cs" />
     <Compile Include="Internals\IMethodRunnerQueue.cs" />
     <Compile Include="Internals\ConcurrentMethodRunnerQueue.cs" />
@@ -163,6 +165,7 @@
     <Compile Include="RenderProcess\V8Exception.cs" />
     <Compile Include="RequestContextExtensions.cs" />
     <Compile Include="ResponseFilter\StreamResponseFilter.cs" />
+    <Compile Include="Structs\AudioParamaters.cs" />
     <Compile Include="Structs\TouchEvent.cs" />
     <Compile Include="V8Extension.cs" />
     <Compile Include="CefLibraryHandle.cs" />

--- a/CefSharp/Enums/ChannelLayout.cs
+++ b/CefSharp/Enums/ChannelLayout.cs
@@ -1,0 +1,187 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.Enums
+{
+    /// <summary>
+    /// Enumerates the various representations of the ordering of audio channels.
+    /// Logged to UMA, so never reuse a value, always add new/greater ones!
+    /// See media\base\channel_layout.h
+    /// </summary>
+    public enum ChannelLayout
+    {
+        /// <summary>
+        /// None
+        /// </summary>
+        LayoutNone = 0,
+
+        /// <summary>
+        /// Unsupported
+        /// </summary>
+        LayoutUnsupported = 1,
+
+        /// <summary>
+        /// Front C
+        /// </summary>
+        LayoutMono = 2,
+
+        /// <summary>
+        /// Front L, Front R
+        /// </summary>
+        LayoutStereo = 3,
+
+        /// <summary>
+        /// Front L, Front R, Back C
+        /// </summary>
+        Layout2_1 = 4,
+
+        /// <summary>
+        /// Front L, Front R, Front C
+        /// </summary>
+        LayoutSurround = 5,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Back C
+        /// </summary>
+        Layout4_0 = 6,
+
+        /// <summary>
+        /// Front L, Front R, Side L, Side R
+        /// </summary>
+        Layout2_2 = 7,
+
+        /// <summary>
+        /// Front L, Front R, Back L, Back R
+        /// </summary>
+        LayoutQuad = 8,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R
+        /// </summary>
+        Layout5_0 = 9,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Side L, Side R
+        /// </summary>
+        Layout5_1 = 10,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Back L, Back R
+        /// </summary>
+        Layout5_0Back = 11,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Back L, Back R
+        /// </summary>
+        Layout5_1Back = 12,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R, Back L, Back R
+        /// </summary>
+        Layout7_0 = 13,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Side L, Side R, Back L, Back R
+        /// </summary>
+        Layout7_1 = 14,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Side L, Side R, Front LofC, Front RofC
+        /// </summary>
+        Layout7_1Wide = 15,
+
+        /// <summary>
+        /// Stereo L, Stereo R
+        /// </summary>
+        LayoutStereoDownMix = 16,
+
+        /// <summary>
+        /// Stereo L, Stereo R, LFE
+        /// </summary>
+        Layout2Point1 = 17,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, LFE
+        /// </summary>
+        Layout3_1 = 18,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, Rear C, LFE
+        /// </summary>
+        Layout4_1 = 19,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, Side L, Side R, Back C
+        /// </summary>
+        Layout6_0 = 20,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Side L, Side R, Front LofC, Front RofC
+        /// </summary>
+        Layout6_0Front = 21,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, Rear L, Rear R, Rear C
+        /// </summary>
+        LayoutHexagonal = 22,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, LFE, Side L, Side R, Rear Center
+        /// </summary>
+        Layout6_1 = 23,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Front C, LFE, Back L, Back R, Rear Center
+        /// </summary>
+        Layout6_1Back = 24,
+
+        /// <summary>
+        /// Stereo L, Stereo R, Side L, Side R, Front LofC, Front RofC, LFE
+        /// </summary>
+        Layout6_1Front = 25,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R, Front LofC, Front RofC
+        /// </summary>
+        Layout7_0Front = 26,
+
+        /// <summary>
+        /// Front L, Front R, Front C, LFE, Back L, Back R, Front LofC, Front RofC
+        /// </summary>
+        Layout7_1WideBack = 27,
+
+        /// <summary>
+        /// Front L, Front R, Front C, Side L, Side R, Rear L, Back R, Back C.
+        /// </summary>
+        LayoutOctagonal = 28,
+
+        /// <summary>
+        /// Channels are not explicitly mapped to speakers.
+        /// </summary>
+        LayoutDiscrete = 29,
+
+        /// <summary>
+        /// Front L, Front R, Front C. Front C contains the keyboard mic audio. This
+        /// layout is only intended for input for WebRTC. The Front C channel
+        /// is stripped away in the WebRTC audio input pipeline and never seen outside
+        /// of that.
+        /// </summary>
+        LayoutStereoKeyboardAndMic = 30,
+
+        /// <summary>
+        /// Front L, Front R, Side L, Side R, LFE
+        /// </summary>
+        Layout4_1QuadSize = 31,
+
+        /// <summary>
+        /// Actual channel layout is specified in the bitstream and the actual channel
+        /// count is unknown at Chromium media pipeline level (useful for audio
+        /// pass-through mode).
+        /// </summary>
+        LayoutBitstream = 32,
+
+        // Max value, must always equal the largest entry ever logged.
+        LayoutMax = LayoutBitstream
+    }
+}

--- a/CefSharp/Handler/IAudioHandler.cs
+++ b/CefSharp/Handler/IAudioHandler.cs
@@ -1,0 +1,73 @@
+// Copyright © 2019 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using CefSharp.Structs;
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Implement this interface to handle audio events
+    /// All methods will be called on the CEF UI thread
+    /// </summary>
+    public interface IAudioHandler
+    {
+        /// <summary>
+        /// Called on the CEF UI thread to allow configuration of audio stream parameters.
+        /// Audio stream paramaters can optionally be configured by modifying <paramref name="parameters"/>
+        /// </summary>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="parameters">audio stream parameters can optionally be configured here, they are
+        /// pre-filled with some sensible defaults.</param>
+        /// <returns>Return true to proceed with audio stream capture, or false to cancel it</returns>
+        bool GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref AudioParameters parameters);
+
+        /// <summary>
+        /// Called on a browser audio capture thread when the browser starts streaming audio.
+        /// OnAudioSteamStopped will always be called after OnAudioStreamStarted; both methods may be called multiple
+        /// times for the same browser.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="parameters">contains the audio parameters like sample rate and channel layout.
+        /// Changing the param values will have no effect here.</param>
+        /// <param name="channels">is the number of channels</param>
+        void OnAudioStreamStarted(IWebBrowser chromiumWebBrowser,
+            IBrowser browser,
+            AudioParameters parameters,
+            int channels);
+
+        /// <summary>
+        /// Called on the audio stream thread when a PCM packet is received for the stream.
+        /// Based on and the <see cref="AudioParameters.ChannelLayout"/> value passed to <see cref="OnAudioStreamStarted"/>
+        /// you can calculate the size of the <paramref name="data"/> array in bytes.
+        /// </summary>
+        /// <param name="chromiumWebBrowser"></param>
+        /// <param name="data">is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s).</param>
+        /// <param name="noOfFrames">is the number of frames in the PCM packet</param>
+        /// <param name="pts">is the presentation timestamp (in milliseconds since the Unix Epoch)
+        /// and represents the time at which the decompressed packet should be presented to the user</param>
+        void OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, IntPtr data, int noOfFrames, long pts);
+
+        /// <summary>
+        /// Called on the CEF UI thread when the stream has stopped. OnAudioSteamStopped will always be called after <see cref="OnAudioStreamStarted"/>;
+        /// both methods may be called multiple times for the same stream.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        void OnAudioStreamStopped(IWebBrowser chromiumWebBrowser, IBrowser browser);
+
+        /// <summary>
+        /// Called on the CEF UI thread or audio stream thread when an error occurred. During the
+        /// stream creation phase this callback will be called on the UI thread while
+        /// in the capturing phase it will be called on the audio stream thread. The
+        /// stream will be stopped immediately.
+        /// </summary>
+        /// <param name="chromiumWebBrowser">the ChromiumWebBrowser control</param>
+        /// <param name="browser">the browser object</param>
+        /// <param name="errorMessage">error message</param>
+        void OnAudioStreamError(IWebBrowser chromiumWebBrowser, IBrowser browser, string errorMessage);
+    }
+}

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -174,6 +174,11 @@ namespace CefSharp
         IFindHandler FindHandler { get; set; }
 
         /// <summary>
+        /// Implement <see cref="IAudioHandler" /> to handle audio events.
+        /// </summary>
+        IAudioHandler AudioHandler { get; set; }
+
+        /// <summary>
         /// A flag that indicates whether the WebBrowser is initialized (true) or not (false).
         /// </summary>
         /// <value><c>true</c> if this instance is browser initialized; otherwise, <c>false</c>.</value>

--- a/CefSharp/Internals/InternalWebBrowserExtensions.cs
+++ b/CefSharp/Internals/InternalWebBrowserExtensions.cs
@@ -8,6 +8,7 @@ namespace CefSharp.Internals
     {
         internal static void SetHandlersToNullExceptLifeSpan(this IWebBrowserInternal browser)
         {
+            browser.AudioHandler = null;
             browser.DialogHandler = null;
             browser.FindHandler = null;
             browser.RequestHandler = null;

--- a/CefSharp/Structs/AudioParamaters.cs
+++ b/CefSharp/Structs/AudioParamaters.cs
@@ -1,0 +1,42 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using CefSharp.Enums;
+
+namespace CefSharp.Structs
+{
+    /// <summary>
+    /// Structure representing the audio parameters for setting up the audio handler.
+    /// </summary>
+    public struct AudioParameters
+    {
+        /// <summary>
+        /// Layout of the audio channels
+        /// </summary>
+        public ChannelLayout ChannelLayout { get; set; }
+
+        /// <summary>
+        /// Sample rate
+        /// </summary>
+        public int SampleRate { get; set; }
+
+        /// <summary>
+        /// Number of frames per buffer
+        /// </summary>
+        public int FramesPerBuffer { get; set; }
+
+        /// <summary>
+        /// Init with default values
+        /// </summary>
+        /// <param name="channelLayout">channel layout</param>
+        /// <param name="sampleRate">sample rate</param>
+        /// <param name="framesPerBuffer">frames per buffer</param>
+        public AudioParameters(ChannelLayout channelLayout, int sampleRate, int framesPerBuffer)
+        {
+            ChannelLayout = channelLayout;
+            SampleRate = sampleRate;
+            FramesPerBuffer = framesPerBuffer;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #3152

**Summary:** 
Re-Add `AudioHandler` implementation which was removed (was removed `upstream`).

**Changes:** [specify the structures changed] 
 - Add `IAudioHandler` interface
 - Add `browser.AudioHandler` property 
      
**How Has This Been Tested?**  
This has had minimal testing, the basic wrapper appears to be working correctly, modifying `AudioParameters` is reflected as expected.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
