### PR TITLE
WinForms Example - Use Uri.EscapeDataString instead of WebUtility.Htm…

### DIFF
--- a/CefSharp.WinForms.Example/BrowserTabUserControl.cs
+++ b/CefSharp.WinForms.Example/BrowserTabUserControl.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -387,7 +386,7 @@ namespace CefSharp.WinForms.Example
             }
             else
             {
-                var searchUrl = "https://www.google.com/search?q=" + WebUtility.HtmlEncode(url);
+                var searchUrl = "https://www.google.com/search?q=" + Uri.EscapeDataString(url);
 
                 Browser.Load(searchUrl);
             }


### PR DESCRIPTION
…lEncode for escaping query string value

**Fixes:** See https://github.com/cefsharp/CefSharp/commit/253849549be3e35912a39a5c28263a2d5f7bd76b#r40262204

**Summary:** WinForms Example - Use Uri.EscapeDataString instead of WebUtility.HtmlEncode for escaping query string value

**Changes:** [specify the structures changed] 
   - replaced `WebUtility.HtmlEncode` with `Uri.EscapeDataString`
      
**How Has This Been Tested?**  
I have run the example and tested a few strings.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
