### PR TITLE
WPF - Fix Chinese IME character Composition issue

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -245,7 +245,7 @@ namespace CefSharp.Wpf.Experimental
             if (ImeHandler.GetResult(hwnd, (uint)lParam, out text))
             {
                 owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);
-                if (languageCodeId == ImeNative.LANG_KOREAN)
+                if (languageCodeId == ImeNative.LANG_KOREAN || languageCodeId == ImeNative.LANG_CHINESE)
                 {
                     owner.GetBrowserHost().ImeSetComposition(text, new CompositionUnderline[0], new Range(int.MaxValue, int.MaxValue), new Range(0, 0));
                     owner.GetBrowserHost().ImeFinishComposingText(false);


### PR DESCRIPTION
**Issue:**

#1262

**Summary:** 
   - This pr is based on pull request [WPF - IME Fix Korean character emitting issue](https://github.com/cefsharp/CefSharp/pull/3054). I find out that only ImeNative.LANG_KOREAN is handled. So I add ImeNative.LANG_CHINESE in the if statement.

**Changes:**
   - CefSharp.Wpf.Experimental.WpfImeKeyboardHandler.cs is modified.
     from

     ` if (languageCodeId == ImeNative.LANG_KOREAN)
                {...}`

     to

     ` if (languageCodeId == ImeNative.LANG_KOREAN || languageCodeId == ImeNative.LANG_CHINESE)
                {...}`
      
**How Has This Been Tested?**  
 - I have tested Chinese IME on windows 10, version 2004, and it works well.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
