### PR TITLE
Move platform dependent files to respective directories.

### DIFF
--- a/CefSharp3.sln
+++ b/CefSharp3.sln
@@ -42,15 +42,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CefSharp.WinForms.Example",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{A23AA466-1903-44F2-946D-25AD0500D56B}"
 	ProjectSection(SolutionItems) = preProject
+		NuGet\CefSharp.Common.app.config.x64.transform = NuGet\CefSharp.Common.app.config.x64.transform
+		NuGet\CefSharp.Common.app.config.x86.transform = NuGet\CefSharp.Common.app.config.x86.transform
 		NuGet\CefSharp.Common.nuspec = NuGet\CefSharp.Common.nuspec
 		NuGet\CefSharp.Common.props = NuGet\CefSharp.Common.props
 		NuGet\CefSharp.Common.targets = NuGet\CefSharp.Common.targets
+		NuGet\CefSharp.OffScreen.app.config.x64.transform = NuGet\CefSharp.OffScreen.app.config.x64.transform
+		NuGet\CefSharp.OffScreen.app.config.x86.transform = NuGet\CefSharp.OffScreen.app.config.x86.transform
 		NuGet\CefSharp.OffScreen.nuspec = NuGet\CefSharp.OffScreen.nuspec
 		NuGet\CefSharp.OffScreen.props = NuGet\CefSharp.OffScreen.props
+		NuGet\CefSharp.OffScreen.targets = NuGet\CefSharp.OffScreen.targets
+		NuGet\CefSharp.WinForms.app.config.x64.transform = NuGet\CefSharp.WinForms.app.config.x64.transform
+		NuGet\CefSharp.WinForms.app.config.x86.transform = NuGet\CefSharp.WinForms.app.config.x86.transform
 		NuGet\CefSharp.WinForms.nuspec = NuGet\CefSharp.WinForms.nuspec
 		NuGet\CefSharp.WinForms.props = NuGet\CefSharp.WinForms.props
+		NuGet\CefSharp.WinForms.targets = NuGet\CefSharp.WinForms.targets
+		NuGet\CefSharp.Wpf.app.config.x64.transform = NuGet\CefSharp.Wpf.app.config.x64.transform
+		NuGet\CefSharp.Wpf.app.config.x86.transform = NuGet\CefSharp.Wpf.app.config.x86.transform
 		NuGet\CefSharp.Wpf.nuspec = NuGet\CefSharp.Wpf.nuspec
 		NuGet\CefSharp.Wpf.props = NuGet\CefSharp.Wpf.props
+		NuGet\CefSharp.Wpf.targets = NuGet\CefSharp.Wpf.targets
 		NuGet\Readme.txt = NuGet\Readme.txt
 	EndProjectSection
 EndProject

--- a/NuGet/CefSharp.Common.app.config.x64.transform
+++ b/NuGet/CefSharp.Common.app.config.x64.transform
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.Core if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.Core if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
+                <assemblyIdentity name="CefSharp.Core" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x64/CefSharp.Core.dll"/>
+            </dependentAssembly>
+
+            <!-- Remove the dependentAssembly section for CefSharp if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')">
+                <assemblyIdentity name="CefSharp" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x64/CefSharp.dll"/>
+            </dependentAssembly>
+
+            <!-- Remove the dependentAssembly section for CefSharp.BrowserSubprocess.Core if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.BrowserSubprocess.Core if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
+                <assemblyIdentity name="CefSharp.BrowserSubprocess.Core" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x64/CefSharp.BrowserSubprocess.Core.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.Common.app.config.x64.transform
+++ b/NuGet/CefSharp.Common.app.config.x64.transform
@@ -10,31 +10,43 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.Core if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.Core if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
                 <assemblyIdentity name="CefSharp.Core" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x64/CefSharp.Core.dll"/>
             </dependentAssembly>
 
-            <!-- Remove the dependentAssembly section for CefSharp if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')"/>
+            <!-- Add or update the codeBase information for CefSharp.Core. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
+                <!-- Add the codebase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase version="83.4.3.0" href="x64/CefSharp.Core.dll" xdt:Transform="Replace"/>
+            </dependentAssembly>
 
             <!-- Add the dependentAssembly section for CefSharp if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')">
                 <assemblyIdentity name="CefSharp" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x64/CefSharp.dll"/>
             </dependentAssembly>
 
-            <!-- Remove the dependentAssembly section for CefSharp.BrowserSubprocess.Core if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')"/>
+            <!-- Add or update the codeBase information for CefSharp. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x64/CefSharp.dll"/>
+            </dependentAssembly>
 
             <!-- Add the dependentAssembly section for CefSharp.BrowserSubprocess.Core if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
                 <assemblyIdentity name="CefSharp.BrowserSubprocess.Core" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x64/CefSharp.BrowserSubprocess.Core.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.BrowserSubprocess.Core -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x64/CefSharp.BrowserSubprocess.Core.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.Common.app.config.x64.transform
+++ b/NuGet/CefSharp.Common.app.config.x64.transform
@@ -11,12 +11,12 @@
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <!-- Add the dependentAssembly section for CefSharp.Core if missing. -->
-            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
-                <assemblyIdentity name="CefSharp.Core" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
+                <assemblyIdentity name="CefSharp.Core" processorArchitecture="amd64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
             </dependentAssembly>
 
             <!-- Add or update the codeBase information for CefSharp.Core. -->
-            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
                 <!-- Add the codebase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->
@@ -24,12 +24,12 @@
             </dependentAssembly>
 
             <!-- Add the dependentAssembly section for CefSharp if missing. -->
-            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')">
-                <assemblyIdentity name="CefSharp" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp')">
+                <assemblyIdentity name="CefSharp" processorArchitecture="amd64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
             </dependentAssembly>
 
             <!-- Add or update the codeBase information for CefSharp. -->
-            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp')">
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp')">
                 <!-- Add the codeBase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->
@@ -37,12 +37,12 @@
             </dependentAssembly>
 
             <!-- Add the dependentAssembly section for CefSharp.BrowserSubprocess.Core if missing. -->
-            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
-                <assemblyIdentity name="CefSharp.BrowserSubprocess.Core" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
+                <assemblyIdentity name="CefSharp.BrowserSubprocess.Core" processorArchitecture="amd64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
             </dependentAssembly>
 
             <!-- Add or update the codeBase information for CefSharp.BrowserSubprocess.Core -->
-            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
                 <!-- Add the codeBase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->

--- a/NuGet/CefSharp.Common.app.config.x86.transform
+++ b/NuGet/CefSharp.Common.app.config.x86.transform
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.Core if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Core')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.Core if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
+                <assemblyIdentity name="CefSharp.Core" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x86/CefSharp.Core.dll"/>
+            </dependentAssembly>
+
+            <!-- Remove the dependentAssembly section for CefSharp if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp')">
+                <assemblyIdentity name="CefSharp" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x86/CefSharp.dll"/>
+            </dependentAssembly>
+
+            <!-- Remove the dependentAssembly section for CefSharp.BrowserSubprocess.Core if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.BrowserSubprocess.Core if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
+                <assemblyIdentity name="CefSharp.BrowserSubprocess.Core" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x86/CefSharp.BrowserSubprocess.Core.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.Common.app.config.x86.transform
+++ b/NuGet/CefSharp.Common.app.config.x86.transform
@@ -10,31 +10,43 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.Core if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Core')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.Core if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
                 <assemblyIdentity name="CefSharp.Core" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x86/CefSharp.Core.dll"/>
             </dependentAssembly>
 
-            <!-- Remove the dependentAssembly section for CefSharp if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp')"/>
+            <!-- Add or update the codeBase information for CefSharp.Core. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Core')">
+                <!-- Add the codebase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase version="83.4.3.0" href="x86/CefSharp.Core.dll" xdt:Transform="Replace"/>
+            </dependentAssembly>
 
             <!-- Add the dependentAssembly section for CefSharp if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp')">
                 <assemblyIdentity name="CefSharp" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x86/CefSharp.dll"/>
             </dependentAssembly>
 
-            <!-- Remove the dependentAssembly section for CefSharp.BrowserSubprocess.Core if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')"/>
+            <!-- Add or update the codeBase information for CefSharp. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x86/CefSharp.dll"/>
+            </dependentAssembly>
 
             <!-- Add the dependentAssembly section for CefSharp.BrowserSubprocess.Core if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
                 <assemblyIdentity name="CefSharp.BrowserSubprocess.Core" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x86/CefSharp.BrowserSubprocess.Core.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.BrowserSubprocess.Core -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.BrowserSubprocess.Core')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x86/CefSharp.BrowserSubprocess.Core.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.Common.nuspec
+++ b/NuGet/CefSharp.Common.nuspec
@@ -49,6 +49,8 @@
 
     <file src="CefSharp.Common.props" target="build" />
     <file src="CefSharp.Common.targets" target="build" />
+    <file src="CefSharp.Common.app.config.x86.transform" target="build\app.config.x86.transform" />
+    <file src="CefSharp.Common.app.config.x64.transform" target="build\app.config.x64.transform" />
   
     <file src="..\CefSharp\**\*.cs" target="src\CefSharp" />
     <file src="..\CefSharp.Core\**\*.h" target="src\CefSharp.Core" />

--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -9,36 +9,44 @@
     correct ordering .props imports, which we require as this depends on the cef.redist packages
     exporting an ItemGroup
    -->
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
-    <None Include="@(CefRedist32)">
-      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-    <None Include="@(CefSharpCommonBinaries32)">
-      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+      <ItemGroup>
+        <None Include="@(CefRedist32)">
+          <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+        <None Include="@(CefSharpCommonBinaries32)">
+          <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>
+    </When>
+  </Choose>
 
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
-    <None Include="@(CefRedist64)">
-      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-    <None Include="@(CefSharpCommonBinaries64)">
-      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+      <ItemGroup>
+        <None Include="@(CefRedist64)">
+          <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+        <None Include="@(CefSharpCommonBinaries64)">
+          <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>
+    </When>
+  </Choose>
+  
   <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
   <Target Name="CefSharpCommon_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">
     <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x86.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>

--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -39,4 +39,11 @@
     </None>
   </ItemGroup>
 
+  <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
+  <Target Name="CefSharpCommon_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x86.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
+  <Target Name="CefSharpCommon_TransformX64Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x64.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
 </Project>

--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -1,77 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="PlatformCheck" BeforeTargets="ResolveAssemblyReferences" Condition="(('$(Platform)' != 'x86') AND ('$(Platform)' != 'x64') AND ('$(Platform)' != 'Win32') AND '$(CefSharpAnyCpuSupport)' != 'true')">
-    <Error Text="$(MSBuildThisFileName) is unable to proceeed as your current Platform is '$(Platform)'. To target AnyCPU please read https://github.com/cefsharp/CefSharp/issues/1714. Alternatively change your Platform to x86 or x64 and the relevant files will be copied automatically. For details on changing your projects Platform see https://docs.microsoft.com/en-gb/visualstudio/ide/how-to-configure-projects-to-target-platforms?view=vs-2017" HelpKeyword="CefSharpSolutionPlatformCheck" />
-  </Target>
-
   <Target Name="FrameworkVersionCheck" BeforeTargets="ResolveAssemblyReferences" Condition="(('$(TargetFrameworkVersion)' == 'v4.5.1') OR ('$(TargetFrameworkVersion)' == 'v4.5') OR ('$(TargetFrameworkVersion)' == 'v4.0'))">
     <Error Text="CefSharp requires .Net 4.5.2 or higher" />
   </Target>
-
-  <PropertyGroup>
-    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">.</CefSharpTargetDir>
-  </PropertyGroup>
 
   <!--
     These item groups should be in the .props file, unfortunately Nuget 2.8.x doesn't gurantee the
     correct ordering .props imports, which we require as this depends on the cef.redist packages
     exporting an ItemGroup
    -->
-
-  <ItemGroup Condition="('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
     <None Include="@(CefRedist32)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PublishState>Include</PublishState>
       <Visible>false</Visible>
     </None>
     <None Include="@(CefSharpCommonBinaries32)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PublishState>Include</PublishState>
       <Visible>false</Visible>
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Platform)' == 'x64'">
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
     <None Include="@(CefRedist64)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PublishState>Include</PublishState>
       <Visible>false</Visible>
     </None>
     <None Include="@(CefSharpCommonBinaries64)">
-      <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PublishState>Include</PublishState>
       <Visible>false</Visible>
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Platform)' == 'AnyCPU'">
-    <None Include="@(CefRedist32)">
-      <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-    <None Include="@(CefRedist64)">
-      <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-    <None Include="@(CefSharpCommonBinaries32)">
-      <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-    <None Include="@(CefSharpCommonBinaries64)">
-      <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
 </Project>

--- a/NuGet/CefSharp.OffScreen.app.config.x64.transform
+++ b/NuGet/CefSharp.OffScreen.app.config.x64.transform
@@ -10,13 +10,17 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.OffScreen if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.OffScreen if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
                 <assemblyIdentity name="CefSharp.OffScreen" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x64/CefSharp.OffScreen.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.OffScreen. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x64/CefSharp.OffScreen.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.OffScreen.app.config.x64.transform
+++ b/NuGet/CefSharp.OffScreen.app.config.x64.transform
@@ -11,12 +11,12 @@
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <!-- Add the dependentAssembly section for CefSharp.OffScreen if missing. -->
-            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
-                <assemblyIdentity name="CefSharp.OffScreen" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
+                <assemblyIdentity name="CefSharp.OffScreen" processorArchitecture="amd64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
             </dependentAssembly>
 
             <!-- Add or update the codeBase information for CefSharp.OffScreen. -->
-            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
                 <!-- Add the codeBase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->

--- a/NuGet/CefSharp.OffScreen.app.config.x64.transform
+++ b/NuGet/CefSharp.OffScreen.app.config.x64.transform
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.OffScreen if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.OffScreen if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
+                <assemblyIdentity name="CefSharp.OffScreen" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x64/CefSharp.OffScreen.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.OffScreen.app.config.x86.transform
+++ b/NuGet/CefSharp.OffScreen.app.config.x86.transform
@@ -10,13 +10,17 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.OffScreen if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.OffScreen if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
                 <assemblyIdentity name="CefSharp.OffScreen" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x86/CefSharp.OffScreen.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.OffScreen. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x86/CefSharp.OffScreen.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.OffScreen.app.config.x86.transform
+++ b/NuGet/CefSharp.OffScreen.app.config.x86.transform
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.OffScreen if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.OffScreen if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.OffScreen')">
+                <assemblyIdentity name="CefSharp.OffScreen" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x86/CefSharp.OffScreen.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.OffScreen.nuspec
+++ b/NuGet/CefSharp.OffScreen.nuspec
@@ -39,6 +39,8 @@
 
     <file src="CefSharp.OffScreen.props" target="build" />
     <file src="CefSharp.OffScreen.targets" target="build" />
+    <file src="CefSharp.OffScreen.app.config.x64.transform" target="build\app.config.x64.transform" />
+    <file src="CefSharp.OffScreen.app.config.x86.transform" target="build\app.config.x86.transform" />
 
     <file src="Readme.txt" target="" />
 

--- a/NuGet/CefSharp.OffScreen.targets
+++ b/NuGet/CefSharp.OffScreen.targets
@@ -7,23 +7,31 @@
    -->
 
   <!-- Copy platform specific libraries to the platform specific folders. -->
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
-    <None Include="@(CefSharpOffScreenBinaries32)">
-      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+      <ItemGroup>
+        <None Include="@(CefSharpOffScreenBinaries32)">
+          <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>      
+    </When>
+  </Choose>
 
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
-    <None Include="@(CefSharpOffScreenBinaries64)">
-      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+      <ItemGroup>
+        <None Include="@(CefSharpOffScreenBinaries64)">
+          <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
   <Target Name="CefSharpOffScreen_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">

--- a/NuGet/CefSharp.OffScreen.targets
+++ b/NuGet/CefSharp.OffScreen.targets
@@ -1,53 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">.</CefSharpTargetDir>
-  </PropertyGroup>
-
   <!--
     These item groups should be in the .props file, unfortunately Nuget 2.8.x doesn't gurantee the
     correct ordering .props imports, which we require as this depends on the cef.redist packages
     exporting an ItemGroup
    -->
 
-  <!-- Copying all files here included those at are added As References so you can specify CefSharpTargetDir -->
-  <Choose>
-    <When Condition="'$(Platform)' == 'AnyCPU'">
-      <ItemGroup>
-        <None Include="@(CefSharpOffScreenBinaries32)">
-          <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-        <None Include="@(CefSharpOffScreenBinaries64)">
-          <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'x64'">
-      <ItemGroup>
-        <None Include="@(CefSharpOffScreenBinaries64)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <!-- x86, and Win32 -->
-    <Otherwise>
-      <ItemGroup>
-        <None Include="@(CefSharpOffScreenBinaries32)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <!-- Copy platform specific libraries to the platform specific folders. -->
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+    <None Include="@(CefSharpOffScreenBinaries32)">
+      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PublishState>Include</PublishState>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+    <None Include="@(CefSharpOffScreenBinaries64)">
+      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PublishState>Include</PublishState>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
 </Project>

--- a/NuGet/CefSharp.OffScreen.targets
+++ b/NuGet/CefSharp.OffScreen.targets
@@ -24,4 +24,12 @@
       <Visible>false</Visible>
     </None>
   </ItemGroup>
+
+  <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
+  <Target Name="CefSharpOffScreen_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x86.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
+  <Target Name="CefSharpOffScreen_TransformX64Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x64.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
 </Project>

--- a/NuGet/CefSharp.WinForms.app.config.x64.transform
+++ b/NuGet/CefSharp.WinForms.app.config.x64.transform
@@ -11,12 +11,12 @@
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <!-- Add the dependentAssembly section for CefSharp.WinForms if missing. -->
-            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
-                <assemblyIdentity name="CefSharp.WinForms" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
+                <assemblyIdentity name="CefSharp.WinForms" processorArchitecture="amd64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
             </dependentAssembly>
 
             <!-- Add or update the codeBase information for CefSharp.WinForms. -->
-            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
                 <!-- Add the codeBase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->

--- a/NuGet/CefSharp.WinForms.app.config.x64.transform
+++ b/NuGet/CefSharp.WinForms.app.config.x64.transform
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.WinForms if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.WinForms if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
+                <assemblyIdentity name="CefSharp.WinForms" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x64/CefSharp.WinForms.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.WinForms.app.config.x64.transform
+++ b/NuGet/CefSharp.WinForms.app.config.x64.transform
@@ -10,13 +10,17 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.WinForms if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.WinForms if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
                 <assemblyIdentity name="CefSharp.WinForms" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x64/CefSharp.WinForms.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.WinForms. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x64/CefSharp.WinForms.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.WinForms.app.config.x86.transform
+++ b/NuGet/CefSharp.WinForms.app.config.x86.transform
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.WinForms if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.WinForms if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
+                <assemblyIdentity name="CefSharp.WinForms" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x86/CefSharp.WinForms.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.WinForms.app.config.x86.transform
+++ b/NuGet/CefSharp.WinForms.app.config.x86.transform
@@ -10,13 +10,17 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.WinForms if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.WinForms if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
                 <assemblyIdentity name="CefSharp.WinForms" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x86/CefSharp.WinForms.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.WinForms. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.WinForms')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x86/CefSharp.WinForms.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.WinForms.nuspec
+++ b/NuGet/CefSharp.WinForms.nuspec
@@ -39,6 +39,8 @@
 
     <file src="CefSharp.WinForms.props" target="build" />
     <file src="CefSharp.WinForms.targets" target="build" />
+    <file src="CefSharp.WinForms.app.config.x64.transform" target="build/app.config.x64.transform" />
+    <file src="CefSharp.WinForms.app.config.x86.transform" target="build/app.config.x86.transform" />
 
     <file src="Readme.txt" target="" />
 

--- a/NuGet/CefSharp.WinForms.targets
+++ b/NuGet/CefSharp.WinForms.targets
@@ -24,4 +24,12 @@
 		  <Visible>false</Visible>
     </None>
   </ItemGroup>
+
+  <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
+  <Target Name="CefSharpWinForms_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x86.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
+  <Target Name="CefSharpWinForms_TransformX64Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x64.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
 </Project>

--- a/NuGet/CefSharp.WinForms.targets
+++ b/NuGet/CefSharp.WinForms.targets
@@ -1,53 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">.</CefSharpTargetDir>
-  </PropertyGroup>
-
   <!--
     These item groups should be in the .props file, unfortunately Nuget 2.8.x doesn't gurantee the
     correct ordering .props imports, which we require as this depends on the cef.redist packages
     exporting an ItemGroup
    -->
 
-  <!-- Copying all files here included those at are added As References so you can specify CefSharpTargetDir -->
-  <Choose>
-    <When Condition="'$(Platform)' == 'AnyCPU'">
-      <ItemGroup>
-        <None Include="@(CefSharpWinFormsBinaries32)">
-          <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-        <None Include="@(CefSharpWinFormsBinaries64)">
-          <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'x64'">
-      <ItemGroup>
-        <None Include="@(CefSharpWinFormsBinaries64)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <!-- x86, and Win32 -->
-    <Otherwise>
-      <ItemGroup>
-        <None Include="@(CefSharpWinFormsBinaries32)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <!-- Copy platform specific libraries to the platform specific folders. -->
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+    <None Include="@(CefSharpWinFormsBinaries32)">
+      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PublishState>Include</PublishState>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+    <None Include="@(CefSharpWinFormsBinaries64)">
+      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <PublishState>Include</PublishState>
+		  <Visible>false</Visible>
+    </None>
+  </ItemGroup>
 </Project>

--- a/NuGet/CefSharp.WinForms.targets
+++ b/NuGet/CefSharp.WinForms.targets
@@ -7,23 +7,31 @@
    -->
 
   <!-- Copy platform specific libraries to the platform specific folders. -->
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
-    <None Include="@(CefSharpWinFormsBinaries32)">
-      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+      <ItemGroup>
+        <None Include="@(CefSharpWinFormsBinaries32)">
+          <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>
+    </When>
+  </Choose>
 
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
-    <None Include="@(CefSharpWinFormsBinaries64)">
-      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		  <PublishState>Include</PublishState>
-		  <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+      <ItemGroup>
+        <None Include="@(CefSharpWinFormsBinaries64)">
+          <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		      <PublishState>Include</PublishState>
+		      <Visible>false</Visible>
+        </None>
+      </ItemGroup>      
+    </When>
+  </Choose>
 
   <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
   <Target Name="CefSharpWinForms_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">

--- a/NuGet/CefSharp.Wpf.app.config.x64.transform
+++ b/NuGet/CefSharp.Wpf.app.config.x64.transform
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.Wpf if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.Wpf if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
+                <assemblyIdentity name="CefSharp.Wpf" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x64/CefSharp.Wpf.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.Wpf.app.config.x64.transform
+++ b/NuGet/CefSharp.Wpf.app.config.x64.transform
@@ -10,13 +10,17 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.Wpf if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.Wpf if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
                 <assemblyIdentity name="CefSharp.Wpf" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x64/CefSharp.Wpf.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.Wpf. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x64/CefSharp.Wpf.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.Wpf.app.config.x64.transform
+++ b/NuGet/CefSharp.Wpf.app.config.x64.transform
@@ -11,12 +11,12 @@
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <!-- Add the dependentAssembly section for CefSharp.Wpf if missing. -->
-            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
-                <assemblyIdentity name="CefSharp.Wpf" processorArchitecture="x64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
+                <assemblyIdentity name="CefSharp.Wpf" processorArchitecture="amd64" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
             </dependentAssembly>
 
             <!-- Add or update the codeBase information for CefSharp.Wpf. -->
-            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='amd64' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
                 <!-- Add the codeBase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->

--- a/NuGet/CefSharp.Wpf.app.config.x86.transform
+++ b/NuGet/CefSharp.Wpf.app.config.x86.transform
@@ -10,13 +10,17 @@
 
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove the dependentAssembly section for CefSharp.Wpf if present. -->
-            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')"/>
-
             <!-- Add the dependentAssembly section for CefSharp.Wpf if missing. -->
             <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
                 <assemblyIdentity name="CefSharp.Wpf" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
-                <codeBase version="83.4.2.0" href="x86/CefSharp.Wpf.dll"/>
+            </dependentAssembly>
+
+            <!-- Add or update the codeBase information for CefSharp.Wpf. -->
+            <dependentAssembly xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
+                <!-- Add the codeBase section if missing. -->
+                <codeBase xdt:Transform="InsertIfMissing"/>
+                <!-- Ensure the codeBase version and href are set to the correct values. -->
+                <codeBase xdt:Transform="Replace" version="83.4.3.0" href="x86/CefSharp.Wpf.dll"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.Wpf.app.config.x86.transform
+++ b/NuGet/CefSharp.Wpf.app.config.x86.transform
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1">
+    <!-- Add the runtime section if missing. -->
+    <runtime xdt:Transform="InsertIfMissing"/>
+
+    <runtime>
+        <!-- Add the assemblyBinding section if missing. -->
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" xdt:Transform="InsertIfMissing"/>
+    </runtime>
+
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Remove the dependentAssembly section for CefSharp.Wpf if present. -->
+            <dependentAssembly xdt:Transform="Remove" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')"/>
+
+            <!-- Add the dependentAssembly section for CefSharp.Wpf if missing. -->
+            <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@processorArchitecture='x86' and asmv1:assemblyIdentity/@name='CefSharp.Wpf')">
+                <assemblyIdentity name="CefSharp.Wpf" processorArchitecture="x86" publicKeyToken="40c4b6fc221f4138" culture="neutral"/>
+                <codeBase version="83.4.2.0" href="x86/CefSharp.Wpf.dll"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/NuGet/CefSharp.Wpf.nuspec
+++ b/NuGet/CefSharp.Wpf.nuspec
@@ -39,6 +39,8 @@
 
     <file src="CefSharp.Wpf.props" target="build" />
     <file src="CefSharp.Wpf.targets" target="build" />
+    <file src="CefSharp.Wpf.app.config.x64.transform" target="build\app.config.x64.transform" />
+    <file src="CefSharp.Wpf.app.config.x86.transform" target="build\app.config.x86.transform" />
 
     <file src="Readme.txt" target="" />
 

--- a/NuGet/CefSharp.Wpf.targets
+++ b/NuGet/CefSharp.Wpf.targets
@@ -7,23 +7,31 @@
    -->
 
   <!-- Copy platform specific libraries to the platform specific folders. -->
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
-    <None Include="@(CefSharpWpfBinaries32)">
-      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+      <ItemGroup>
+        <None Include="@(CefSharpWpfBinaries32)">
+          <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>
+    </When>
+  </Choose>
 
-  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
-    <None Include="@(CefSharpWpfBinaries64)">
-      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PublishState>Include</PublishState>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <Choose>
+    <When Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+      <ItemGroup>
+        <None Include="@(CefSharpWpfBinaries64)">
+          <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <PublishState>Include</PublishState>
+          <Visible>false</Visible>
+        </None>
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
   <Target Name="CefSharpWpf_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">

--- a/NuGet/CefSharp.Wpf.targets
+++ b/NuGet/CefSharp.Wpf.targets
@@ -24,4 +24,12 @@
       <Visible>false</Visible>
     </None>
   </ItemGroup>
+
+  <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
+  <Target Name="CefSharpWpf_TransformX86Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x86.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
+  <Target Name="CefSharpWpf_TransformX64Config" Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')" AfterTargets="_CopyAppConfigFile">
+    <TransformXml Source="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Transform="$(MSBuildThisFileDirectory)app.config.x64.transform" Destination="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')"/>
+  </Target>
 </Project>

--- a/NuGet/CefSharp.Wpf.targets
+++ b/NuGet/CefSharp.Wpf.targets
@@ -1,53 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <CefSharpTargetDir Condition=" '$(CefSharpTargetDir)' == '' ">.</CefSharpTargetDir>
-  </PropertyGroup>
-
   <!--
     These item groups should be in the .props file, unfortunately Nuget 2.8.x doesn't gurantee the
     correct ordering .props imports, which we require as this depends on the cef.redist packages
     exporting an ItemGroup
    -->
 
-  <!-- Copying all files here included those at are added As References so you can specify CefSharpTargetDir -->
-  <Choose>
-    <When Condition="'$(Platform)' == 'AnyCPU'">
-      <ItemGroup>
-        <None Include="@(CefSharpWpfBinaries32)">
-          <Link>$(CefSharpTargetDir)\x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-        <None Include="@(CefSharpWpfBinaries64)">
-          <Link>$(CefSharpTargetDir)\x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'x64'">
-      <ItemGroup>
-        <None Include="@(CefSharpWpfBinaries64)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <!-- x86, and Win32 -->
-    <Otherwise>
-      <ItemGroup>
-        <None Include="@(CefSharpWpfBinaries32)">
-          <Link>$(CefSharpTargetDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <PublishState>Include</PublishState>
-          <Visible>false</Visible>
-        </None>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <!-- Copy platform specific libraries to the platform specific folders. -->
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x86') OR ('$(Platform)' == 'Win32')">
+    <None Include="@(CefSharpWpfBinaries32)">
+      <Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PublishState>Include</PublishState>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="('$(Platform)' == 'AnyCPU') OR ('$(Platform)' == 'x64')">
+    <None Include="@(CefSharpWpfBinaries64)">
+      <Link>x64\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PublishState>Include</PublishState>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -381,6 +381,18 @@ function WriteVersionToManifest($manifest)
     [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
 }
 
+function WriteVersionToTransform($transform)
+{
+    $Filename = Join-Path $WorkingDir $transform
+    $Regex = 'codeBase version="(.*?)"';
+
+    $TransformData = Get-Content -Encoding UTF8 $Filename
+    $NewString = $TransformData -replace $Regex, "codeBase version=""$AssemblyVersion.0"""
+
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($Filename, $NewString, $Utf8NoBomEncoding)
+}
+
 function WriteVersionToResourceFile($resourceFile)
 {
     $Filename = Join-Path $WorkingDir $resourceFile
@@ -444,6 +456,15 @@ WriteVersionToManifest "CefSharp.Wpf.Example\app.manifest"
 
 WriteVersionToResourceFile "CefSharp.BrowserSubprocess.Core\Resource.rc"
 WriteVersionToResourceFile "CefSharp.Core\Resource.rc"
+
+WriteVersionToTransform "NuGet\CefSharp.Common.app.config.x64.transform"
+WriteVersionToTransform "NuGet\CefSharp.Common.app.config.x86.transform"
+WriteVersionToTransform "NuGet\CefSharp.OffScreen.app.config.x64.transform"
+WriteVersionToTransform "nuget\CefSharp.OffScreen.app.config.x86.transform"
+WriteVersionToTransform "NuGet\CefSharp.WinForms.app.config.x64.transform"
+WriteVersionToTransform "NuGet\CefSharp.WinForms.app.config.x86.transform"
+WriteVersionToTransform "NuGet\CefSharp.Wpf.app.config.x64.transform"
+WriteVersionToTransform "NuGet\CefSharp.Wpf.app.config.x86.transform"
 
 switch -Exact ($Target)
 {


### PR DESCRIPTION
This pull request simplifies AnyCPU builds and permits side by side installation of the CefSharp
libraries by moving the CefSharp libraries to the platform dependent folders. With this change,
CefSharpTargetDir is no longer used to indicate where to put platform dependent files, and no
project changes are needed for AnyCPU builds.

**Fixes:** #3161 

**Summary:**
   - This change moves the CefSharp platform dependent libraries to their respective folders.
   - XML transforms are used to add `<dependentAssembly>` sections to the app.config during build.

**Changes:**
   - Adds targets to NuGet packages that are executed during build.
   - Simplifies NuGet .targets files for all platforms.
      
**How Has This Been Tested?**  
   - Tested updated NuGet packages using a local folder.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
