### PR TITLE
Issue #2053 - Add accessibility support in WPF

### DIFF
--- a/CefSharp.Wpf/CefSettings.cs
+++ b/CefSharp.Wpf/CefSettings.cs
@@ -25,6 +25,9 @@ namespace CefSharp.Wpf
             //Disable GPU Compositing
             //Issue https://github.com/cefsharp/CefSharp/issues/3114
             CefCommandLineArgs.Add("disable-gpu-compositing");
+
+            // Enables support for screen readers like Microsoft Narrator, NVDA and JAWS.
+            CefCommandLineArgs.Add("force-renderer-accessibility");
         }
     }
 }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2018,7 +2018,14 @@ namespace CefSharp.Wpf
         protected virtual IWindowInfo CreateOffscreenBrowserWindowInfo(IntPtr handle)
         {
             var windowInfo = new WindowInfo();
-            windowInfo.SetAsWindowless(handle);
+            if (handle == IntPtr.Zero)
+            {
+                windowInfo.SetAsWindowless(handle);
+            }
+            else
+            {
+                windowInfo.SetAsChild(handle);
+            }
             return windowInfo;
         }
 


### PR DESCRIPTION
**Fixes:** [issue-number] 
Fixes: #2053 

**Summary:** [summary of the change and which issue is fixed here]
   - It is now possible to run the CefSharp.Wpf.Example and use a screen reader such as [Microsoft Narrator](https://en.wikipedia.org/wiki/Microsoft_Narrator), [NVDA](https://www.nvaccess.org/about-nvda/) or [JAWS](https://www.freedomscientific.com/products/software/jaws/) to traverse and navigate the web content hierarchy.

**Changes:** [specify the structures changed] 
   - In `CreateOffscreenBrowserWindowInfo` in ChromiumWebBrowser.cs, it is necessary to use `SetAsChild` instead of `SetAsWindowless` in order for the UIAutomation/MSAA trees from CEF to be exposed.
   - In CefSettings.cs, the `force-renderer-accessibility` command line argument needs to be added in order for CEF to expose its UIAutomation/MSAA trees.
      
**How Has This Been Tested?**  
   - I have tested this by running the CefSharp.Wpf.Example app on a Windows 10 64-bit machine while using Microsoft Narrator, NVDA and JAWS (trial version) to navigate the web content.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [X] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
