### PR TITLE
Use EventArgs.Empty in DelegateCommand

### DIFF
--- a/CefSharp.Wpf/DelegateCommand.cs
+++ b/CefSharp.Wpf/DelegateCommand.cs
@@ -66,7 +66,7 @@ namespace CefSharp.Wpf
         {
             if (CanExecuteChanged != null)
             {
-                CanExecuteChanged(this, new EventArgs());
+                CanExecuteChanged(this, EventArgs.Empty);
             }
         }
     }


### PR DESCRIPTION
**Summary:** `new EventArgs` can be replaced with `EventArgs.Empty` to avoid an object allocation.

**Changes:**
   - replaced `new EventArgs()` with `EventArgs.Empty`
      
**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
