### PR TITLE
Net Core - AppVeyor run tests and build x86/x64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,17 +30,17 @@ for:
         nuget restore CefSharp.Core\packages.config -PackagesDirectory packages &
         nuget restore CefSharp.BrowserSubprocess.Core\packages.config  -PackagesDirectory packages &
         msbuild /t:restore CefSharp3.netcore.sln
-    build:
-      project: CefSharp3.netcore.sln
+    build_script:
+      msbuild /t:build CefSharp3.netcore.sln /p:Platform=x86 &
+      msbuild /t:build CefSharp3.netcore.sln /p:Platform=x64
     after_build:
         nuget pack nuget\PackageReference\CefSharp.Common.NETCore.nuspec -NoPackageAnalysis -Version %APPVEYOR_BUILD_VERSION% -OutputDirectory nuget\PackageReference -Properties "RedistVersion=$RedistVersion;" &
         nuget pack nuget\PackageReference\CefSharp.OffScreen.NETCore.nuspec -NoPackageAnalysis -Version %APPVEYOR_BUILD_VERSION% -OutputDirectory nuget\PackageReference &
         nuget pack nuget\PackageReference\CefSharp.Wpf.NETCore.nuspec -NoPackageAnalysis -Version %APPVEYOR_BUILD_VERSION% -OutputDirectory nuget\PackageReference &
         nuget pack nuget\PackageReference\CefSharp.WinForms.NETCore.nuspec -NoPackageAnalysis -Version %APPVEYOR_BUILD_VERSION% -OutputDirectory nuget\PackageReference
-    test:
+    test_script:
         # Test our Release x64 build
-        assemblies:
-            - CefSharp.Test\bin.netcore\x64\Release\netcoreapp3.1\CefSharp.Test.dll  
+        dotnet test CefSharp.Test\bin.netcore\x64\Release\netcoreapp3.1\CefSharp.Test.dll
 
 artifacts:
   - path: NuGet\**\*.nupkg


### PR DESCRIPTION
**Part of**: #3197

**Summary:**
   - run netcore tests on appveyor
  - build x86 and x64 so `CefSharp.Common.NETCore` gets packaged

**Changes:**
   - adjusted appveyor.yml to run netcore tests and build x86/x64 so all nuget packages can be generated
      
**How Has This Been Tested?**  
https://ci.appveyor.com/project/campersau/cefsharp/builds/34657294

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
