### PR TITLE
Net Core - Use msbuild directly for restore

### DIFF
--- a/build.netcore.ps1
+++ b/build.netcore.ps1
@@ -170,7 +170,7 @@ function Compile
     # Restore packages
     . $nuget restore CefSharp.Core\packages.config -PackagesDirectory packages
     . $nuget restore CefSharp.BrowserSubprocess.Core\packages.config  -PackagesDirectory packages
-    &dotnet msbuild /t:restore CefSharp3.netcore.sln
+    &msbuild /t:restore CefSharp3.netcore.sln
     
     Write-Diagnostic "Compile Packages"
     


### PR DESCRIPTION
**Part of:** #3197

**Summary:**
   - Use msbuild directly for restore. When using `dotnet msbuild` the tests somehow get stuck.
    Before the switch to `build.netcore.ps1` msbuild was also used directly: https://github.com/cefsharp/CefSharp/commit/74012ffe0ce04d092d33a8e42fc818825b2c8905#diff-180360612c6b8c4ed830919bbb4dd459L32

**Changes:**
   - Use msbuild directly for restore in `build.netcore.ps1`
      
**How Has This Been Tested?**  
https://ci.appveyor.com/project/campersau/cefsharp/builds/34716073/job/51gt2da87f0uqi1g

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
