### PR TITLE
Fix typos in Cef documentation

### DIFF
--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -145,7 +145,7 @@ namespace CefSharp
         /// <summary>
         /// Initializes CefSharp with user-provided settings.
         /// It's important to note that Initialize and Shutdown <strong>MUST</strong> be called on your main
-        /// applicaiton thread (Typically the UI thead). If you call them on different
+        /// application thread (typically the UI thread). If you call them on different
         /// threads, your application will hang. See the documentation for Cef.Shutdown() for more details.
         /// </summary>
         /// <param name="cefSettings">CefSharp configuration settings.</param>
@@ -160,7 +160,7 @@ namespace CefSharp
         /// <summary>
         /// Initializes CefSharp with user-provided settings.
         /// It's important to note that Initialize/Shutdown <strong>MUST</strong> be called on your main
-        /// applicaiton thread (Typically the UI thead). If you call them on different
+        /// application thread (typically the UI thread). If you call them on different
         /// threads, your application will hang. See the documentation for Cef.Shutdown() for more details.
         /// </summary>
         /// <param name="cefSettings">CefSharp configuration settings.</param>
@@ -177,7 +177,7 @@ namespace CefSharp
         /// <summary>
         /// Initializes CefSharp with user-provided settings.
         /// It's important to note that Initialize/Shutdown <strong>MUST</strong> be called on your main
-        /// applicaiton thread (Typically the UI thead). If you call them on different
+        /// application thread (typically the UI thread). If you call them on different
         /// threads, your application will hang. See the documentation for Cef.Shutdown() for more details.
         /// </summary>
         /// <param name="cefSettings">CefSharp configuration settings.</param>


### PR DESCRIPTION
**Summary:**
   - I have fixed typos in `Cef.Initialize` method documentation

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code (if applicable)
- [ ] Commented my code
- [x] Changed the documentation (if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
