### PR TITLE
Enhancement - Simplify Setting of RequestContext Proxy

### DIFF
--- a/CefSharp.Core.RefAssembly/CefSharp.Core.cs
+++ b/CefSharp.Core.RefAssembly/CefSharp.Core.cs
@@ -253,6 +253,7 @@ namespace CefSharp
         public virtual void ClearHttpAuthCredentials(CefSharp.ICompletionCallback callback) { }
         public virtual bool ClearSchemeHandlerFactories() { throw null; }
         public virtual void CloseAllConnections(CefSharp.ICompletionCallback callback) { }
+        public static CefSharp.RequestContextBuilder Configure() { throw null; }
         public static CefSharp.IRequestContext CreateContext(CefSharp.IRequestContext other, CefSharp.IRequestContextHandler requestContextHandler) { throw null; }
         public virtual bool DidLoadExtension(string extensionId) { throw null; }
         public void Dispose() { }
@@ -272,6 +273,19 @@ namespace CefSharp
         public virtual bool RegisterSchemeHandlerFactory(string schemeName, string domainName, CefSharp.ISchemeHandlerFactory factory) { throw null; }
         public virtual System.Threading.Tasks.Task<CefSharp.ResolveCallbackResult> ResolveHostAsync(System.Uri origin) { throw null; }
         public virtual bool SetPreference(string name, object value, out string error) { throw null; }
+    }
+    public partial class RequestContextBuilder
+    {
+        public RequestContextBuilder() { }
+        public CefSharp.IRequestContext Create() { throw null; }
+        public CefSharp.RequestContextBuilder OnInitialize(System.Action<CefSharp.IRequestContext> action) { throw null; }
+        public CefSharp.RequestContextBuilder PersistUserPreferences() { throw null; }
+        public CefSharp.RequestContextBuilder WithCachePath(string cachePath) { throw null; }
+        public CefSharp.RequestContextBuilder WithPreference(string name, object value) { throw null; }
+        public CefSharp.RequestContextBuilder WithProxyServer(string host) { throw null; }
+        public CefSharp.RequestContextBuilder WithProxyServer(string host, int? port) { throw null; }
+        public CefSharp.RequestContextBuilder WithProxyServer(string scheme, string host, int? port) { throw null; }
+        public CefSharp.RequestContextBuilder WithSharedSettings(CefSharp.IRequestContext other) { throw null; }
     }
     public partial class RequestContextSettings : System.IDisposable
     {

--- a/CefSharp.Core/Cef.h
+++ b/CefSharp.Core/Cef.h
@@ -238,8 +238,7 @@ namespace CefSharp
             FileThreadTaskFactory = gcnew TaskFactory(gcnew CefTaskScheduler(TID_FILE));
 
             //Allows us to execute Tasks on the CEF UI thread in CefSharp.dll
-            CefThread::UiThreadTaskFactory = UIThreadTaskFactory;
-            CefThread::CurrentOnUiThreadDelegate = gcnew Func<bool>(&CurrentOnUiThread); ;
+            CefThread::Initialize(UIThreadTaskFactory, gcnew Func<bool>(&CurrentOnUiThread));
 
             //To allow FolderSchemeHandlerFactory to access GetMimeType we pass in a Func
             CefSharp::SchemeHandler::FolderSchemeHandlerFactory::GetMimeTypeDelegate = gcnew Func<String^, String^>(&GetMimeType);
@@ -497,8 +496,8 @@ namespace CefSharp
                     UIThreadTaskFactory = nullptr;
                     IOThreadTaskFactory = nullptr;
                     FileThreadTaskFactory = nullptr;
-                    CefThread::UiThreadTaskFactory = nullptr;
-                    CefThread::CurrentOnUiThreadDelegate = nullptr;
+
+                    CefThread::Shutdown();
 
                     for each(IDisposable^ diposable in Enumerable::ToList(_disposables))
                     {

--- a/CefSharp.Core/CefSharp.Core.netcore.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.netcore.vcxproj
@@ -245,6 +245,7 @@
     <ClCompile Include="Request.cpp" />
     <ClCompile Include="RequestContext.cpp" />
     <ClCompile Include="Internals\CefResourceHandlerAdapter.cpp" />
+    <ClCompile Include="RequestContextBuilder.cpp" />
     <ClCompile Include="Stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -302,6 +303,7 @@
     <ClInclude Include="PostData.h" />
     <ClInclude Include="PostDataElement.h" />
     <ClInclude Include="Request.h" />
+    <ClInclude Include="RequestContextBuilder.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="UrlRequest.h" />
     <ClInclude Include="WindowInfo.h" />

--- a/CefSharp.Core/CefSharp.Core.netcore.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.netcore.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="Internals\CefResourceHandlerAdapter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="RequestContextBuilder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vcclr_local.h">
@@ -326,6 +329,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Internals\CefRegistrationWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="RequestContextBuilder.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CefSharp.Core/CefSharp.Core.vcxproj
+++ b/CefSharp.Core/CefSharp.Core.vcxproj
@@ -250,6 +250,7 @@
     <ClCompile Include="Request.cpp" />
     <ClCompile Include="RequestContext.cpp" />
     <ClCompile Include="Internals\CefResourceHandlerAdapter.cpp" />
+    <ClCompile Include="RequestContextBuilder.cpp" />
     <ClCompile Include="Stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -307,6 +308,7 @@
     <ClInclude Include="PostData.h" />
     <ClInclude Include="PostDataElement.h" />
     <ClInclude Include="Request.h" />
+    <ClInclude Include="RequestContextBuilder.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="UrlRequest.h" />
     <ClInclude Include="WindowInfo.h" />

--- a/CefSharp.Core/CefSharp.Core.vcxproj.filters
+++ b/CefSharp.Core/CefSharp.Core.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="Internals\CefResourceHandlerAdapter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="RequestContextBuilder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vcclr_local.h">
@@ -326,6 +329,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Internals\CefRegistrationWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="RequestContextBuilder.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CefSharp.Core/RequestContext.h
+++ b/CefSharp.Core/RequestContext.h
@@ -11,6 +11,7 @@
 #include "include\cef_request_context.h"
 
 #include "RequestContextSettings.h"
+#include "RequestContextBuilder.h"
 #include "Internals\CefRequestContextHandlerAdapter.h"
 #include "Internals\CefWrapper.h"
 
@@ -112,7 +113,7 @@ namespace CefSharp
         /// </summary>
         /// <param name="other">shares storage with this RequestContext</param>
         /// <param name="requestContextHandler">optional requestContext handler</param>
-        /// <returns>Returns a nre RequestContext</returns>
+        /// <returns>Returns a new RequestContext</returns>
         static IRequestContext^ CreateContext(IRequestContext^ other, IRequestContextHandler^ requestContextHandler)
         {
             auto otherRequestContext = static_cast<RequestContext^>(other);
@@ -120,6 +121,18 @@ namespace CefSharp
 
             auto newContext = CefRequestContext::CreateContext(otherRequestContext, handler);
             return gcnew RequestContext(newContext);
+        }
+
+        /// <summary>
+        /// Creates a new RequestContextBuilder which can be used to fluently set
+        /// preferences
+        /// </summary>
+        /// <returns>Returns a new RequestContextBuilder</returns>
+        static RequestContextBuilder^ Configure()
+        {
+            auto builder = gcnew RequestContextBuilder();
+
+            return builder;
         }
 
         /// <summary>

--- a/CefSharp.Core/RequestContextBuilder.cpp
+++ b/CefSharp.Core/RequestContextBuilder.cpp
@@ -1,0 +1,111 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#include "Stdafx.h"
+#include "RequestContextBuilder.h"
+#include "RequestContext.h"
+
+namespace CefSharp
+{
+    IRequestContext^ RequestContextBuilder::Create()
+    {
+        if (_otherContext != nullptr)
+        {
+            return gcnew RequestContext(_otherContext, _handler);
+        }
+
+        if(_settings != nullptr)
+        {
+            return gcnew RequestContext(_settings, _handler);
+        }
+
+        return gcnew RequestContext(_handler);
+    }
+
+    RequestContextBuilder^ RequestContextBuilder::WithPreference(String^ name, Object^ value)
+    {
+        if (_handler == nullptr)
+        {
+            _handler = gcnew RequestContextHandler();
+        }
+
+        _handler->SetPreferenceOnContextInitialized(name, value);
+
+        return this;
+    }
+
+    RequestContextBuilder^ RequestContextBuilder::WithProxyServer(String^ host)
+    {
+        if (_handler == nullptr)
+        {
+            _handler = gcnew RequestContextHandler();
+        }
+
+        _handler->SetProxyOnContextInitialized(host, Nullable<int>());
+
+        return this;
+    }
+
+    RequestContextBuilder^ RequestContextBuilder::WithProxyServer(String^ host, Nullable<int> port)
+    {
+        if (_handler == nullptr)
+        {
+            _handler = gcnew RequestContextHandler();
+        }
+
+        _handler->SetProxyOnContextInitialized(host, port);
+
+        return this;
+    }
+
+    RequestContextBuilder^ RequestContextBuilder::WithProxyServer(String^ scheme, String^ host, Nullable<int> port)
+    {
+        if (_handler == nullptr)
+        {
+            _handler = gcnew RequestContextHandler();
+        }
+
+        _handler->SetProxyOnContextInitialized(scheme, host, port);
+
+        return this;
+    }
+
+    RequestContextBuilder^ RequestContextBuilder::PersistUserPreferences()
+    {
+        ThrowExceptionIfContextAlreadySet();
+
+        if (_settings == nullptr)
+        {
+            _settings = gcnew RequestContextSettings();
+        }
+
+        _settings->PersistUserPreferences = true;
+
+        return this;
+    }
+
+
+    RequestContextBuilder^ RequestContextBuilder::WithCachePath(String^ cachePath)
+    {
+        ThrowExceptionIfContextAlreadySet();
+
+        if (_settings == nullptr)
+        {
+            _settings = gcnew RequestContextSettings();
+        }
+
+        _settings->CachePath = cachePath;
+
+        return this;
+    }
+
+    RequestContextBuilder^ RequestContextBuilder::WithSharedSettings(IRequestContext^ other)
+    {
+        ThrowExceptionIfCustomSettingSpecified();
+
+        _otherContext = other;
+
+        return this;
+    }
+}

--- a/CefSharp.Core/RequestContextBuilder.cpp
+++ b/CefSharp.Core/RequestContextBuilder.cpp
@@ -23,6 +23,18 @@ namespace CefSharp
         return gcnew RequestContext(_handler);
     }
 
+    RequestContextBuilder^ RequestContextBuilder::OnInitialize(Action<IRequestContext^>^ action)
+    {
+        if (_handler == nullptr)
+        {
+            _handler = gcnew RequestContextHandler();
+        }
+
+        _handler->OnInitialize(action);
+
+        return this;
+    }
+
     RequestContextBuilder^ RequestContextBuilder::WithPreference(String^ name, Object^ value)
     {
         if (_handler == nullptr)
@@ -85,7 +97,6 @@ namespace CefSharp
         return this;
     }
 
-
     RequestContextBuilder^ RequestContextBuilder::WithCachePath(String^ cachePath)
     {
         ThrowExceptionIfContextAlreadySet();
@@ -102,6 +113,11 @@ namespace CefSharp
 
     RequestContextBuilder^ RequestContextBuilder::WithSharedSettings(IRequestContext^ other)
     {
+        if (other == nullptr)
+        {
+            throw gcnew ArgumentNullException("other");
+        }
+
         ThrowExceptionIfCustomSettingSpecified();
 
         _otherContext = other;

--- a/CefSharp.Core/RequestContextBuilder.h
+++ b/CefSharp.Core/RequestContextBuilder.h
@@ -1,0 +1,126 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "RequestContextSettings.h"
+
+using namespace CefSharp::Handler;
+
+namespace CefSharp
+{
+    /// <summary>
+    /// Fluent style builder for creating IRequestContext instances.
+    /// </summary>
+    public ref class RequestContextBuilder
+    {
+    private:
+        RequestContextSettings^ _settings;
+        IRequestContext^ _otherContext;
+        RequestContextHandler^ _handler;
+
+        void ThrowExceptionIfContextAlreadySet()
+        {
+            if (_otherContext != nullptr)
+            {
+                throw gcnew Exception("A call to WithSharedSettings has already been made, it is no possible to provide custom settings.");
+            }
+        }
+
+        void ThrowExceptionIfCustomSettingSpecified()
+        {
+            if (_settings != nullptr)
+            {
+                throw gcnew Exception("A call to WithCachePath/PersistUserPreferences has already been made, it's not possible to share settings with another RequestContext.");
+            }
+        }
+
+    public:
+        /// <summary>
+        /// Create the actual RequestContext instance
+        /// <param name="other">shares storage with this RequestContext</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        IRequestContext^ Create();
+
+        /// <summary>
+        /// Set the value associated with preference name when the RequestContext
+        /// is initialzied. If value is null the preference will be restored to its
+        /// default value. If setting the preference fails no error is throw, you
+        /// must check the CEF Log file.
+        /// Preferences set via the command-line usually cannot be modified.
+        /// </summary>
+        /// <param name="name">preference key</param>
+        /// <param name="value">preference value</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithPreference(String^ name, Object^ value);
+
+        /// <summary>
+        /// Set the Proxy server when the RequestContext is initialzied.
+        /// If value is null the preference will be restored to its
+        /// default value. If setting the preference fails no error is throw, you
+        /// must check the CEF Log file.
+        /// Proxy set via the command-line cannot be modified.
+        /// </summary>
+        /// <param name="host">proxy host</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithProxyServer(String^ host);
+
+        /// <summary>
+        /// Set the Proxy server when the RequestContext is initialzied.
+        /// If value is null the preference will be restored to its
+        /// default value. If setting the preference fails no error is throw, you
+        /// must check the CEF Log file.
+        /// Proxy set via the command-line cannot be modified.
+        /// </summary>
+        /// <param name="host">proxy host</param>
+        /// <param name="port">proxy port (optional)</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithProxyServer(String^ host, Nullable<int> port);
+
+        /// <summary>
+        /// Set the Proxy server when the RequestContext is initialzied.
+        /// If value is null the preference will be restored to its
+        /// default value. If setting the preference fails no error is throw, you
+        /// must check the CEF Log file.
+        /// Proxy set via the command-line cannot be modified.
+        /// </summary>
+        /// <param name="scheme">proxy scheme</param>
+        /// <param name="host">proxy host</param>
+        /// <param name="port">proxy port (optional)</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithProxyServer(String^ scheme, String^ host, Nullable<int> port);
+
+        /// <summary>
+        /// Sets the Cache Path
+        /// </summary>
+        /// <param name="cachePath">
+        /// The location where cache data for this request context will be stored on
+        /// disk. If this value is non-empty then it must be an absolute path that is
+        /// either equal to or a child directory of CefSettings.RootCachePath.
+        /// If the value is empty then browsers will be created in "incognito mode"
+        /// where in-memory caches are used for storage and no data is persisted to disk.
+        /// HTML5 databases such as localStorage will only persist across sessions if a
+        /// cache path is specified. To share the global browser cache and related
+        /// configuration set this value to match the CefSettings.CachePath value.
+        /// </param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithCachePath(String^ cachePath);
+
+        /// <summary>
+        /// Invoke this method tp persist user preferences as a JSON file in the cache path directory.
+        /// Can be set globally using the CefSettings.PersistUserPreferences value.
+        /// This value will be ignored if CachePath is empty or if it matches the CefSettings.CachePath value.
+        /// </summary>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ PersistUserPreferences();
+
+        /// <summary>
+        /// Shares storage with other RequestContext
+        /// </summary>
+        /// <param name="other">shares storage with this RequestContext</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithSharedSettings(IRequestContext^ other);
+    };
+}
+

--- a/CefSharp.Core/RequestContextBuilder.h
+++ b/CefSharp.Core/RequestContextBuilder.h
@@ -44,6 +44,37 @@ namespace CefSharp
         IRequestContext^ Create();
 
         /// <summary>
+        /// Action is called in IRequestContextHandler.OnRequestContextInitialized
+        /// </summary>
+        /// <param name="action">called when the context has been initialized.</param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ OnInitialize(Action<IRequestContext^>^ action);
+
+        /// <summary>
+        /// Sets the Cache Path
+        /// </summary>
+        /// <param name="cachePath">
+        /// The location where cache data for this request context will be stored on
+        /// disk. If this value is non-empty then it must be an absolute path that is
+        /// either equal to or a child directory of CefSettings.RootCachePath.
+        /// If the value is empty then browsers will be created in "incognito mode"
+        /// where in-memory caches are used for storage and no data is persisted to disk.
+        /// HTML5 databases such as localStorage will only persist across sessions if a
+        /// cache path is specified. To share the global browser cache and related
+        /// configuration set this value to match the CefSettings.CachePath value.
+        /// </param>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ WithCachePath(String^ cachePath);
+
+        /// <summary>
+        /// Invoke this method tp persist user preferences as a JSON file in the cache path directory.
+        /// Can be set globally using the CefSettings.PersistUserPreferences value.
+        /// This value will be ignored if CachePath is empty or if it matches the CefSettings.CachePath value.
+        /// </summary>
+        /// <returns>Returns RequestContextBuilder instance</returns>
+        RequestContextBuilder^ PersistUserPreferences();
+
+        /// <summary>
         /// Set the value associated with preference name when the RequestContext
         /// is initialzied. If value is null the preference will be restored to its
         /// default value. If setting the preference fails no error is throw, you
@@ -90,30 +121,6 @@ namespace CefSharp
         /// <param name="port">proxy port (optional)</param>
         /// <returns>Returns RequestContextBuilder instance</returns>
         RequestContextBuilder^ WithProxyServer(String^ scheme, String^ host, Nullable<int> port);
-
-        /// <summary>
-        /// Sets the Cache Path
-        /// </summary>
-        /// <param name="cachePath">
-        /// The location where cache data for this request context will be stored on
-        /// disk. If this value is non-empty then it must be an absolute path that is
-        /// either equal to or a child directory of CefSettings.RootCachePath.
-        /// If the value is empty then browsers will be created in "incognito mode"
-        /// where in-memory caches are used for storage and no data is persisted to disk.
-        /// HTML5 databases such as localStorage will only persist across sessions if a
-        /// cache path is specified. To share the global browser cache and related
-        /// configuration set this value to match the CefSettings.CachePath value.
-        /// </param>
-        /// <returns>Returns RequestContextBuilder instance</returns>
-        RequestContextBuilder^ WithCachePath(String^ cachePath);
-
-        /// <summary>
-        /// Invoke this method tp persist user preferences as a JSON file in the cache path directory.
-        /// Can be set globally using the CefSettings.PersistUserPreferences value.
-        /// This value will be ignored if CachePath is empty or if it matches the CefSettings.CachePath value.
-        /// </summary>
-        /// <returns>Returns RequestContextBuilder instance</returns>
-        RequestContextBuilder^ PersistUserPreferences();
 
         /// <summary>
         /// Shares storage with other RequestContext

--- a/CefSharp.Example/Handlers/RequestContextHandler.cs
+++ b/CefSharp.Example/Handlers/RequestContextHandler.cs
@@ -28,14 +28,8 @@ namespace CefSharp.Example.Handlers
             //string errorMessage;
             //var success = requestContext.SetPreference("webkit.webprefs.minimum_font_size", 24, out errorMessage);
 
-            //You can set the proxy with code similar to the code below
-            //var v = new Dictionary<string, object>
-            //{
-            //    ["mode"] = "fixed_servers",
-            //    ["server"] = "scheme://host:port"
-            //};
             //string errorMessage;
-            //bool success = requestContext.SetPreference("proxy", v, out errorMessage);
+            //bool success = requestContext.SetProxy("http://localhost:8080", out errorMessage); 
         }
     }
 }

--- a/CefSharp.Example/Handlers/RequestContextHandler.cs
+++ b/CefSharp.Example/Handlers/RequestContextHandler.cs
@@ -4,14 +4,14 @@
 
 namespace CefSharp.Example.Handlers
 {
-    public class RequestContextHandler : IRequestContextHandler
+    public class RequestContextHandler : CefSharp.Handler.RequestContextHandler
     {
-        IResourceRequestHandler IRequestContextHandler.GetResourceRequestHandler(IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
+        protected override IResourceRequestHandler GetResourceRequestHandler(IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
         {
-            return null;
+            return new ExampleResourceRequestHandler();
         }
 
-        bool IRequestContextHandler.OnBeforePluginLoad(string mimeType, string url, bool isMainFrame, string topOriginUrl, WebPluginInfo pluginInfo, ref PluginPolicy pluginPolicy)
+        protected override bool OnBeforePluginLoad(string mimeType, string url, bool isMainFrame, string topOriginUrl, WebPluginInfo pluginInfo, ref PluginPolicy pluginPolicy)
         {
             //pluginPolicy = PluginPolicy.Disable;
             //return true;
@@ -19,7 +19,7 @@ namespace CefSharp.Example.Handlers
             return false;
         }
 
-        void IRequestContextHandler.OnRequestContextInitialized(IRequestContext requestContext)
+        protected override void OnRequestContextInitialized(IRequestContext requestContext)
         {
             //You can set preferences here on your newly initialized request context.
             //Note, there is called on the CEF UI Thread, so you can directly call SetPreference

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -170,6 +170,7 @@
     <Compile Include="CefSharpFixtureCollection.cs" />
     <Compile Include="PostMessage\IntegrationTestFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SkipIfRunOnAppVeyorFact.cs" />
     <Compile Include="WebBrowserTestExtensions.cs" />
     <Compile Include="WinForms\WinFormsBrowserBasicFacts.cs" />
     <Compile Include="Wpf\WpfBrowserBasicFacts.cs" />

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -66,10 +66,19 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.5.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable.BouncyCastle.1.8.5.2\lib\net40\BouncyCastle.Crypto.dll</HintPath>
+    </Reference>
+    <Reference Include="BrotliSharpLib, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3f4e2a1cd615fcb7, processorArchitecture=MSIL">
+      <HintPath>..\packages\BrotliSharpLib.0.3.3\lib\net451\BrotliSharpLib.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>
     </Reference>
@@ -92,13 +101,29 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -106,6 +131,9 @@
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
+    <Reference Include="Titanium.Web.Proxy, Version=3.1.1301.0, Culture=neutral, PublicKeyToken=8e41e1f1c790d7cf, processorArchitecture=MSIL">
+      <HintPath>..\packages\Titanium.Web.Proxy.3.1.1301\lib\net461\Titanium.Web.Proxy.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Framework\LegacyCamelCaseJavascriptNameConverterFacts.cs" />
     <Compile Include="Framework\MimeTypeMappingFacts.cs" />
     <Compile Include="Framework\PathCheckFacts.cs" />
+    <Compile Include="Framework\RequestContextBuilderFacts.cs" />
     <Compile Include="Framework\RequestContextExtensionFacts.cs" />
     <Compile Include="Framework\TestMemberInfo.cs" />
     <Compile Include="JavascriptBinding\IntegrationTestFacts.cs" />

--- a/CefSharp.Test/CefSharp.Test.netcore.csproj
+++ b/CefSharp.Test/CefSharp.Test.netcore.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
+	<PackageReference Include="Titanium.Web.Proxy" version="3.1.1301" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CefSharp.Test/CefSharpFixture.cs
+++ b/CefSharp.Test/CefSharpFixture.cs
@@ -4,10 +4,13 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using CefSharp.Example;
 using CefSharp.OffScreen;
 using Nito.AsyncEx;
+using Titanium.Web.Proxy;
+using Titanium.Web.Proxy.Models;
 using Xunit;
 
 namespace CefSharp.Test
@@ -15,6 +18,7 @@ namespace CefSharp.Test
     public class CefSharpFixture : IAsyncLifetime, IDisposable
     {
         private readonly AsyncContextThread contextThread;
+        private ProxyServer proxyServer;
 
         public CefSharpFixture()
         {
@@ -57,6 +61,8 @@ namespace CefSharp.Test
             {
                 Cef.Shutdown();
             }
+
+            StopProxyServer();
         }
 
         public Task InitializeAsync()
@@ -72,6 +78,27 @@ namespace CefSharp.Test
         public void Dispose()
         {
             contextThread.Dispose();
+        }
+
+        public void StartProxyServerIfRequired()
+        {
+            if (proxyServer == null)
+            {
+                proxyServer = new ProxyServer(userTrustRootCertificate: false);
+
+                var explicitEndPoint = new ExplicitProxyEndPoint(IPAddress.Loopback, 8080, false);
+
+                // An explicit endpoint is where the client knows about the existence of a proxy
+                // So client sends request in a proxy friendly manner
+                proxyServer.AddEndPoint(explicitEndPoint);
+                proxyServer.Start();
+            }
+        }
+
+        public void StopProxyServer()
+        {
+            proxyServer?.Stop();
+            proxyServer = null;
         }
     }
 }

--- a/CefSharp.Test/CefSharpFixture.cs
+++ b/CefSharp.Test/CefSharpFixture.cs
@@ -4,13 +4,10 @@
 
 using System;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
 using CefSharp.Example;
 using CefSharp.OffScreen;
 using Nito.AsyncEx;
-using Titanium.Web.Proxy;
-using Titanium.Web.Proxy.Models;
 using Xunit;
 
 namespace CefSharp.Test
@@ -18,7 +15,6 @@ namespace CefSharp.Test
     public class CefSharpFixture : IAsyncLifetime, IDisposable
     {
         private readonly AsyncContextThread contextThread;
-        private ProxyServer proxyServer;
 
         public CefSharpFixture()
         {
@@ -27,15 +23,6 @@ namespace CefSharp.Test
 
         private void CefInitialize()
         {
-            proxyServer = new ProxyServer(userTrustRootCertificate:false);
-
-            var explicitEndPoint = new ExplicitProxyEndPoint(IPAddress.Loopback, 8080, false);
-
-            // An explicit endpoint is where the client knows about the existence of a proxy
-            // So client sends request in a proxy friendly manner
-            proxyServer.AddEndPoint(explicitEndPoint);
-            proxyServer.Start();
-
             if (!Cef.IsInitialized)
             {
                 var isDefault = AppDomain.CurrentDomain.IsDefaultAppDomain();
@@ -66,8 +53,6 @@ namespace CefSharp.Test
 
         private void CefShutdown()
         {
-            proxyServer.Stop();
-
             if (Cef.IsInitialized)
             {
                 Cef.Shutdown();

--- a/CefSharp.Test/Framework/RequestContextBuilderFacts.cs
+++ b/CefSharp.Test/Framework/RequestContextBuilderFacts.cs
@@ -1,0 +1,63 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CefSharp.Test.Framework
+{
+    //NOTE: All Test classes must be part of this collection as it manages the Cef Initialize/Shutdown lifecycle
+    [Collection(CefSharpFixtureCollection.Key)]
+    public class RequestContextBuilderFacts
+    {
+        private CefSharpFixture fixture;
+        private ITestOutputHelper output;
+
+        public RequestContextBuilderFacts(ITestOutputHelper output, CefSharpFixture fixture)
+        {
+            this.fixture = fixture;
+            this.output = output;
+        }
+
+        [Fact]
+        public void ThrowExceptionWithSharedSettingsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var requestContext = RequestContext
+                    .Configure()
+                    .WithSharedSettings(null);
+            });
+        }
+
+        [Fact]
+        public void ThrowExceptionIfContextAlreadySpecified()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                var requestContext = new RequestContext();
+
+                RequestContext
+                    .Configure()
+                    .WithSharedSettings(requestContext)
+                    .WithCachePath("shouldThrowException");
+            });
+        }
+
+        [Fact]
+        public void ThrowExceptionIfCachePathAlreadySpecified()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                var requestContext = new RequestContext();
+
+                RequestContext
+                    .Configure()
+                    .WithCachePath("c:\\temp")
+                    .WithSharedSettings(requestContext);
+            });
+        }
+    }
+}

--- a/CefSharp.Test/Framework/RequestContextExtensionFacts.cs
+++ b/CefSharp.Test/Framework/RequestContextExtensionFacts.cs
@@ -4,10 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using Moq;
-using Titanium.Web.Proxy;
-using Titanium.Web.Proxy.Models;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,7 +15,6 @@ namespace CefSharp.Test.Framework
         private const string ProxyPreferenceKey = "proxy";
 
         private readonly ITestOutputHelper output;
-        private ProxyServer proxyServer;
 
         private delegate void SetPreferenceDelegate(string name, object value, out string errorMessage);
 
@@ -27,21 +23,18 @@ namespace CefSharp.Test.Framework
             this.output = output;
         }
 
-        [Theory(Skip = "Starts/Stops a proxy server, will need to be run manually for now.")]
-        //[Theory]
+        [Theory]
         [InlineData("http", "localhost", 8080, "http://localhost:8080")]
         [InlineData("socks", "localhost", null, "socks://localhost")]
         [InlineData(null, "localhost", null, "http://localhost")]
         public void CanSetProxyWithSchemeHostAndPort(string scheme, string host, int? port, string expected)
         {
-            StartProxyServer();
-
             string preferenceName = "";
             object preferenceValue = null;
             var mockRequestContext = new Mock<IRequestContext>();
 
             mockRequestContext.Setup(x => x.CanSetPreference(ProxyPreferenceKey)).Returns(true);
-            
+
             mockRequestContext.Setup(x => x.SetPreference(ProxyPreferenceKey, It.IsAny<IDictionary<string, object>>(), out It.Ref<string>.IsAny))
                 .Callback(new SetPreferenceDelegate((string name, object value, out string errorMessage) =>
                 {
@@ -62,8 +55,6 @@ namespace CefSharp.Test.Framework
             Assert.Equal(2, dict.Count);
             Assert.Equal("fixed_servers", dict["mode"]);
             Assert.Equal(expected, dict["server"]);
-
-            StopProxyServer();
         }
 
         [Fact]
@@ -71,30 +62,13 @@ namespace CefSharp.Test.Framework
         {
             var mockRequestContext = new Mock<IRequestContext>();
 
-            mockRequestContext.Setup(x => x.SetPreference(ProxyPreferenceKey, It.IsAny<IDictionary<string, object>>(), out It.Ref<string>.IsAny)) .Returns(true);
+            mockRequestContext.Setup(x => x.SetPreference(ProxyPreferenceKey, It.IsAny<IDictionary<string, object>>(), out It.Ref<string>.IsAny)).Returns(true);
 
             Assert.Throws<ArgumentException>(() =>
             {
                 string msg;
                 mockRequestContext.Object.SetProxy("myscheme", "localhost", 0, out msg);
             });
-        }
-
-        private void StartProxyServer()
-        {
-            proxyServer = new ProxyServer(userTrustRootCertificate: false);
-
-            var explicitEndPoint = new ExplicitProxyEndPoint(IPAddress.Loopback, 8080, false);
-
-            // An explicit endpoint is where the client knows about the existence of a proxy
-            // So client sends request in a proxy friendly manner
-            proxyServer.AddEndPoint(explicitEndPoint);
-            proxyServer.Start();
-        }
-
-        private void StopProxyServer()
-        {
-            proxyServer.Stop();
         }
     }
 }

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -289,17 +289,17 @@ namespace CefSharp.Test.OffScreen
         [Fact]
         public async Task CanLoadGoogleUsingProxy()
         {
-            var requestContextHander = new RequestContextHandler()
-                .SetProxyOnContextInitialized("localhost", 8080);
+            var requestContextHandler = new RequestContextHandler()
+                .SetProxyOnContextInitialized("127.0.0.1", 8080);
 
-            var requestContext = new RequestContext(requestContextHander);
-            using (var browser = new ChromiumWebBrowser("www.google.com", requestContext: requestContext))
+            var requestContext = new RequestContext(requestContextHandler);
+            using (var browser = new ChromiumWebBrowser("http://cefsharp.github.io/", requestContext: requestContext))
             {
                 await browser.LoadPageAsync();
 
                 var mainFrame = browser.GetMainFrame();
                 Assert.True(mainFrame.IsValid);
-                Assert.Contains("www.google", mainFrame.Url);
+                Assert.Contains("cefsharp.github.io", mainFrame.Url);
 
                 output.WriteLine("Url {0}", mainFrame.Url);
             }

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CefSharp.Example;
+using CefSharp.Example.Handlers;
 using CefSharp.Internals;
 using CefSharp.OffScreen;
 using Xunit;
@@ -282,6 +283,25 @@ namespace CefSharp.Test.OffScreen
                 await browser.LoadPageAsync(firstUrl);
 
                 Assert.True(browser.CanExecuteJavascriptInMainFrame);
+            }
+        }
+
+        [Fact]
+        public async Task CanLoadGoogleUsingProxy()
+        {
+            var requestContextHander = new RequestContextHandler()
+                .SetProxyOnContextInitialized("localhost", 8080);
+
+            var requestContext = new RequestContext(requestContextHander);
+            using (var browser = new ChromiumWebBrowser("www.google.com", requestContext: requestContext))
+            {
+                await browser.LoadPageAsync();
+
+                var mainFrame = browser.GetMainFrame();
+                Assert.True(mainFrame.IsValid);
+                Assert.Contains("www.google", mainFrame.Url);
+
+                output.WriteLine("Url {0}", mainFrame.Url);
             }
         }
     }

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -286,9 +286,11 @@ namespace CefSharp.Test.OffScreen
             }
         }
 
-        [Fact]
-        public async Task CanLoadGoogleUsingProxy()
+        [SkipIfRunOnAppVeyorFact]
+        public async Task CanLoadHttpWebsiteUsingProxy()
         {
+            fixture.StartProxyServerIfRequired();
+
             var requestContextHandler = new RequestContextHandler()
                 .SetProxyOnContextInitialized("127.0.0.1", 8080);
 

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -291,10 +291,11 @@ namespace CefSharp.Test.OffScreen
         {
             fixture.StartProxyServerIfRequired();
 
-            var requestContextHandler = new RequestContextHandler()
-                .SetProxyOnContextInitialized("127.0.0.1", 8080);
-
-            var requestContext = new RequestContext(requestContextHandler);
+            var requestContext = RequestContext
+                .Configure()
+                .WithProxyServer("127.0.0.1", 8080)
+                .Create();
+                
             using (var browser = new ChromiumWebBrowser("http://cefsharp.github.io/", requestContext: requestContext))
             {
                 await browser.LoadPageAsync();

--- a/CefSharp.Test/SkipIfRunOnAppVeyorFact.cs
+++ b/CefSharp.Test/SkipIfRunOnAppVeyorFact.cs
@@ -1,0 +1,20 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using Xunit;
+
+namespace CefSharp.Test
+{
+    public class SkipIfRunOnAppVeyorFact : FactAttribute
+    {
+        public SkipIfRunOnAppVeyorFact()
+        {
+            if(Environment.GetEnvironmentVariable("APPVEYOR") == "True")
+            {
+                Skip = "Running on Appveyor - Test Skipped";
+            }
+        }
+    }
+}

--- a/CefSharp.Test/app.config
+++ b/CefSharp.Test/app.config
@@ -26,6 +26,10 @@
         <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/CefSharp.Test/packages.config
+++ b/CefSharp.Test/packages.config
@@ -1,17 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BrotliSharpLib" version="0.3.3" targetFramework="net462" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net462" />
   <package id="cef.redist.x64" version="85.3.12" targetFramework="net462" />
   <package id="cef.redist.x86" version="85.3.12" targetFramework="net462" />
+  <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net462" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />
   <package id="Nito.AsyncEx.Context" version="5.0.0" targetFramework="net462" />
   <package id="Nito.AsyncEx.Coordination" version="5.0.0" targetFramework="net462" />
   <package id="Nito.AsyncEx.Tasks" version="5.0.0" targetFramework="net462" />
   <package id="Nito.Collections.Deque" version="1.0.4" targetFramework="net462" />
   <package id="Nito.Disposables" version="2.0.0" targetFramework="net462" />
+  <package id="Portable.BouncyCastle" version="1.8.5.2" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net462" />
+  <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net462" />
+  <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net462" />
+  <package id="Titanium.Web.Proxy" version="3.1.1301" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
   <package id="xunit.assert" version="2.4.1" targetFramework="net462" />
   <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net462" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -591,6 +591,7 @@
     <Compile Include="DevTools\WebAuthn\WebAuthn.cs" />
     <Compile Include="Enums\CompositionUnderlineStyle.cs" />
     <Compile Include="Enums\SchemeOptions.cs" />
+    <Compile Include="Handler\RequestContextHandler.cs" />
     <Compile Include="Internals\CefThread.cs" />
     <Compile Include="Internals\FreezableBase.cs" />
     <Compile Include="Internals\IBrowserRefCounter.cs" />

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -614,6 +614,7 @@
     <Compile Include="JavascriptBinding\CamelCaseJavascriptNameConverter.cs" />
     <Compile Include="JavascriptBinding\IJavascriptNameConverter.cs" />
     <Compile Include="JavascriptBinding\LegacyCamelCaseJavascriptNameConverter.cs" />
+    <Compile Include="Preferences\SetPreferenceResponse.cs" />
     <Compile Include="ResourceRequestHandlerFactory.cs" />
     <Compile Include="ResourceRequestHandlerFactoryItem.cs" />
     <Compile Include="Enums\AlphaType.cs" />

--- a/CefSharp/Handler/RequestContextHandler.cs
+++ b/CefSharp/Handler/RequestContextHandler.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System;
 using System.Collections.Generic;
 
 namespace CefSharp.Handler
@@ -15,6 +16,22 @@ namespace CefSharp.Handler
     {
         private readonly IList<KeyValuePair<string, object>> preferences = new List<KeyValuePair<string, object>>();
         private bool requestContextInitialized = false;
+        private Action<IRequestContext> onContextInitialziedAction;
+
+        /// <summary>
+        /// The <see cref="Action{IRequestContext}"/> is executed when the RequestContext has been initialized, after the
+        /// preferences/proxy preferences have been set, before OnRequestContextInitialized.
+        /// </summary>
+        /// <param name="onContextInitialziedAction">action to perform on context initialize</param>
+        /// <returns>A <see cref="RequestContextHandler"/> instance allowing you to chain multiple AddPreference calls together </returns>
+        /// <remarks>Only a single action reference is maintained, multiple calls will result in the
+        /// previous action reference being overriden.</remarks>
+        public RequestContextHandler OnInitialize(Action<IRequestContext> onContextInitialziedAction)
+        {
+            this.onContextInitialziedAction = onContextInitialziedAction;
+
+            return this;
+        }
 
         /// <summary>
         /// Sets the preferences when the <see cref="IRequestContextHandler.OnRequestContextInitialized(IRequestContext)"/>
@@ -126,6 +143,8 @@ namespace CefSharp.Handler
                     //TODO: Do something if there's an error
                 }
             }
+
+            onContextInitialziedAction?.Invoke(requestContext);
 
             OnRequestContextInitialized(requestContext);
         }

--- a/CefSharp/Handler/RequestContextHandler.cs
+++ b/CefSharp/Handler/RequestContextHandler.cs
@@ -1,0 +1,144 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Collections.Generic;
+
+namespace CefSharp.Handler
+{
+    /// <summary>
+    /// Implement this interface to provide handler implementations. The handler
+    /// instance will not be released until all objects related to the context have
+    /// been destroyed. Implement this interface to cancel loading of specific plugins
+    /// </summary>
+    public class RequestContextHandler : IRequestContextHandler
+    {
+        private readonly IList<KeyValuePair<string, object>> preferences = new List<KeyValuePair<string, object>>();
+        private bool requestContextInitialized = false;
+
+        /// <summary>
+        /// Sets the preferences when the <see cref="IRequestContextHandler.OnRequestContextInitialized(IRequestContext)"/>
+        /// method is called. If <paramref name="value"/> is null the  preference will be restored
+        /// to its default value. Preferences set via the command-line usually cannot be modified.
+        /// </summary>
+        /// <param name="name">preference name</param>
+        /// <param name="value">preference value</param>
+        /// <returns>A <see cref="RequestContextHandler"/> instance allowing you to chain multiple AddPreference calls together </returns>
+        public RequestContextHandler SetPreferenceOnContextInitialized(string name, object value)
+        {
+            if (requestContextInitialized)
+            {
+                throw new System.Exception("RequestContext has already been initialized, ");
+            }
+
+            preferences.Add(new KeyValuePair<string, object>(name, value));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the proxy preferences when the <see cref="IRequestContextHandler.OnRequestContextInitialized(IRequestContext)"/>
+        /// method is called. Proxy set via the command-line usually cannot be modified.
+        /// </summary>
+        /// <param name="host">proxy host</param>
+        /// <param name="port">proxy port</param>
+        /// <returns>A <see cref="RequestContextHandler"/> instance allowing you to chain multiple AddPreference calls together </returns>
+        public RequestContextHandler SetProxyOnContextInitialized(string host, int? port = null)
+        {
+            return SetProxyOnContextInitialized(null, host, port);
+        }
+
+        /// <summary>
+        /// Sets the proxy preferences when the <see cref="IRequestContextHandler.OnRequestContextInitialized(IRequestContext)"/>
+        /// method is called. Proxy set via the command-line usually cannot be modified.
+        /// </summary>
+        /// <param name="scheme">is the protocol of the proxy server, and is one of: 'http', 'socks', 'socks4', 'socks5'. Also note that 'socks' is equivalent to 'socks5'.</param>
+        /// <param name="host">proxy host</param>
+        /// <param name="port">proxy port</param>
+        /// <returns>A <see cref="RequestContextHandler"/> instance allowing you to chain multiple AddPreference calls together </returns>
+        public RequestContextHandler SetProxyOnContextInitialized(string scheme, string host, int? port)
+        {
+            if (requestContextInitialized)
+            {
+                throw new System.Exception("RequestContext has already been initialized, ");
+            }
+
+            var value = RequestContextExtensions.GetProxyDictionary(scheme, host, port);
+
+            preferences.Add(new KeyValuePair<string, object>("proxy", value));
+
+            return this;
+        }
+
+        IResourceRequestHandler IRequestContextHandler.GetResourceRequestHandler(IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
+        {
+            return GetResourceRequestHandler(browser, frame, request, isNavigation, isDownload, requestInitiator, ref disableDefaultHandling);
+        }
+
+        /// <summary>
+        /// Called on the CEF IO thread before a resource request is initiated.
+        /// This method will not be called if the client associated with <paramref name="browser"/> returns a non-NULL value
+        /// from <see cref="IRequestHandler.GetResourceRequestHandler"/> for the same request (identified by <see cref="IRequest.Identifier"/>).
+        /// </summary>
+        /// <param name="browser">represent the source browser of the request, and may be null for requests originating from service workers.</param>
+        /// <param name="frame">represent the source frame of the request, and may be null for requests originating from service workers.</param>
+        /// <param name="request">represents the request contents and cannot be modified in this callback</param>
+        /// <param name="isNavigation">will be true if the resource request is a navigation</param>
+        /// <param name="isDownload">will be true if the resource request is a download</param>
+        /// <param name="requestInitiator">is the origin (scheme + domain) of the page that initiated the request</param>
+        /// <param name="disableDefaultHandling">Set to true to disable default handling of the request, in which case it will need to be handled via <see cref="IResourceRequestHandler.GetResourceHandler(IWebBrowser, IBrowser, IFrame, IRequest)"/> or it will be canceled</param>
+        /// <returns>To allow the resource load to proceed with default handling return null. To specify a handler for the resource return a <see cref="IResourceRequestHandler"/> object.</returns>
+        protected virtual IResourceRequestHandler GetResourceRequestHandler(IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
+        {
+            return null;
+        }
+
+        bool IRequestContextHandler.OnBeforePluginLoad(string mimeType, string url, bool isMainFrame, string topOriginUrl, WebPluginInfo pluginInfo, ref PluginPolicy pluginPolicy)
+        {
+            return OnBeforePluginLoad(mimeType, url, isMainFrame, topOriginUrl, pluginInfo, ref pluginPolicy);
+        }
+
+        /// <summary>
+        /// Called on the CEF IO thread before a plugin instance is loaded.
+        /// The default plugin policy can be set at runtime using the `--plugin-policy=[allow|detect|block]` command-line flag.
+        /// </summary>
+        /// <param name="mimeType">is the mime type of the plugin that will be loaded</param>
+        /// <param name="url">is the content URL that the plugin will load and may be empty</param>
+        /// <param name="isMainFrame">will be true if the plugin is being loaded in the main (top-level) frame</param>
+        /// <param name="topOriginUrl">is the URL for the top-level frame that contains the plugin</param>
+        /// <param name="pluginInfo">includes additional information about the plugin that will be loaded</param>
+        /// <param name="pluginPolicy">Modify and return true to change the policy.</param>
+        /// <returns>Return false to use the recommended policy. Modify and return true to change the policy.</returns>
+        protected virtual bool OnBeforePluginLoad(string mimeType, string url, bool isMainFrame, string topOriginUrl, WebPluginInfo pluginInfo, ref PluginPolicy pluginPolicy)
+        {
+            return false;
+        }
+
+        void IRequestContextHandler.OnRequestContextInitialized(IRequestContext requestContext)
+        {
+            requestContextInitialized = true;
+            string errorMessage;
+
+            foreach (var pref in preferences)
+            {
+                if (!requestContext.SetPreference(pref.Key, pref.Value, out errorMessage))
+                {
+                    //TODO: Do something if there's an error
+                }
+            }
+
+            OnRequestContextInitialized(requestContext);
+        }
+
+        /// <summary>
+        /// Called immediately after the request context has been initialized.
+        /// It's important to note this event is fired on a CEF UI thread, which by default is not the same as your application UI
+        /// thread.
+        /// </summary>
+        /// <param name="requestContext">the request context</param>
+        protected virtual void OnRequestContextInitialized(IRequestContext requestContext)
+        {
+
+        }
+    }
+}

--- a/CefSharp/Internals/CefThread.cs
+++ b/CefSharp/Internals/CefThread.cs
@@ -15,13 +15,24 @@ namespace CefSharp.Internals
     /// </summary>
     public static class CefThread
     {
+        private static readonly object LockObj = new object();
+
         /// <summary>
         /// TaskFactory will be null before Cef.Initialize is called
         /// and null after Cef.Shutdown is called.
         /// </summary>
-        public static TaskFactory UiThreadTaskFactory { get; set; }
+        public static TaskFactory UiThreadTaskFactory { get; private set; }
 
-        public static Func<bool> CurrentOnUiThreadDelegate { get; set; }
+        /// <summary>
+        /// Event fired after Cef.Initialze has been called, we can now start
+        /// posting Tasks to the CEF UI Thread.
+        /// </summary>
+        public static event EventHandler Initialized;
+
+        /// <summary>
+        /// Delegate used to wrap the native call to CefCurrentlyOn(CefThreadId::TID_UI).
+        /// </summary>
+        public static Func<bool> CurrentOnUiThreadDelegate { get; private set; }
 
         /// <summary>
         /// true if we have a reference to the UiThreadTaskFactory
@@ -38,29 +49,108 @@ namespace CefSharp.Internals
             }
         }
 
+        /// <summary>
+        /// Currently on the CEF UI Thread
+        /// </summary>
         public static bool CurrentlyOnUiThread
         {
             get
             {
-                if (CurrentOnUiThreadDelegate == null)
+                var d = CurrentOnUiThreadDelegate;
+                if (d == null)
                 {
                     return false;
                 }
 
-                return CurrentOnUiThreadDelegate();
+                return d();
             }
         }
 
+        /// <summary>
+        /// returns true if Cef.Shutdown been called, otherwise false.
+        /// </summary>
+        public static bool HasShutdown { get; private set; }
+
+        /// <summary>
+        /// Execute the provided function on the CEF UI Thread
+        /// </summary>
+        /// <typeparam name="TResult">result</typeparam>
+        /// <param name="function">function</param>
+        /// <returns>Task{Result}</returns>
         public static Task<TResult> ExecuteOnUiThread<TResult>(Func<TResult> function)
         {
-            var taskFactory = UiThreadTaskFactory;
-
-            if (taskFactory == null)
+            lock (LockObj)
             {
-                throw new Exception("CefThread.UiThreadTaskFactory is null, ");
-            }
+                if (HasShutdown)
+                {
+                    throw new Exception("Cef.Shutdown has already been called, it's no longer possible to execute on the CEF UI Thread. Check CefThread.HasShutdown to guard against this execption");
+                }
 
-            return taskFactory.StartNew(function);
+                var taskFactory = UiThreadTaskFactory;
+
+                if (taskFactory == null)
+                {
+                    //We don't have a task factory yet, so we'll queue for execution.
+                    return QueueForExcutionWhenUiThreadCreated(function);
+                }
+
+                return taskFactory.StartNew(function);
+            }
+        }
+
+        /// <summary>
+        /// Wait for CEF to Initialize, continuation happens on
+        /// the CEF UI Thraed.
+        /// </summary>
+        /// <returns>Task that can be awaited</returns>
+        private static Task<T> QueueForExcutionWhenUiThreadCreated<T>(Func<T> func)
+        {
+            var tcs = new TaskCompletionSource<T>();
+
+            EventHandler handler = null;
+
+            handler = (s, args) =>
+            {
+                Initialized -= handler;
+
+                var result = func();
+
+                tcs.SetResult(result);
+            };
+
+            Initialized += handler;
+
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Called when the CEF UI Thread is a
+        /// </summary>
+        public static void Initialize(TaskFactory uiThreadTaskFactory, Func<bool> currentOnUiThreadDelegate)
+        {
+            lock (LockObj)
+            {
+                Initialized?.Invoke(null, EventArgs.Empty);
+
+                UiThreadTaskFactory = uiThreadTaskFactory;
+                CurrentOnUiThreadDelegate = currentOnUiThreadDelegate;
+            }
+        }
+
+        /// <summary>
+        /// !!WARNING!! DO NOT CALL THIS YOURSELF, THIS WILL BE CALLED INTERNALLY.
+        /// Called when Cef.Shutdown is called to cleanup our references
+        /// and release any event handlers.
+        /// </summary>
+        public static void Shutdown()
+        {
+            lock (LockObj)
+            {
+                CurrentOnUiThreadDelegate = null;
+                Initialized = null;
+                UiThreadTaskFactory = null;
+                HasShutdown = true;
+            }
         }
     }
 }

--- a/CefSharp/Preferences/SetPreferenceResponse.cs
+++ b/CefSharp/Preferences/SetPreferenceResponse.cs
@@ -1,0 +1,34 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+namespace CefSharp.Preferences
+{
+    /// <summary>
+    /// Response when <see cref="IRequestContext.SetPreference(string, object, out string)"/>
+    /// is called in an async fashion
+    /// </summary>
+    public class SetPreferenceResponse
+    {
+        /// <summary>
+        /// Success
+        /// </summary>
+        public bool Success { get; private set; }
+
+        /// <summary>
+        /// Error Message
+        /// </summary>
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="success">success</param>
+        /// <param name="errorMessage">error message</param>
+        public SetPreferenceResponse(bool success, string errorMessage)
+        {
+            Success = success;
+            ErrorMessage = errorMessage;
+        }
+    }
+}

--- a/CefSharp/RequestContextExtensions.cs
+++ b/CefSharp/RequestContextExtensions.cs
@@ -72,7 +72,12 @@ namespace CefSharp
         {
             var v = GetProxyDictionary(scheme, host, port);
 
-            return requestContext.SetPreference("proxy", v, out errorMessage);
+            if (requestContext.CanSetPreference("proxy"))
+            {
+                return requestContext.SetPreference("proxy", v, out errorMessage);
+            }
+
+            throw new Exception("Unable to set the proxy preference, it is read-only. If you specified the proxy settings with command line args it is not possible to change the proxy settings via this method.");
         }
 
         /// <summary>

--- a/CefSharp/RequestContextExtensions.cs
+++ b/CefSharp/RequestContextExtensions.cs
@@ -70,32 +70,7 @@ namespace CefSharp
         /// preference 'proxy' and mode of 'fixed_servers'</remarks>
         public static bool SetProxy(this IRequestContext requestContext, string scheme, string host, int? port, out string errorMessage)
         {
-            //Default to using http scheme if non provided
-            if (string.IsNullOrWhiteSpace(scheme))
-            {
-                scheme = "http";
-            }
-
-            if (!ProxySchemes.Contains(scheme.ToLower()))
-            {
-                throw new ArgumentException("Invalid Scheme, see https://bitbucket.org/chromiumembedded/cef/wiki/GeneralUsage.md#markdown-header-proxy-resolution for a list of valid schemes.", "scheme");
-            }
-
-            if (string.IsNullOrWhiteSpace(host))
-            {
-                throw new ArgumentException("Cannot be null or empty", "host");
-            }
-
-            if (port.HasValue && (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort))
-            {
-                throw new ArgumentOutOfRangeException("port", port, "Invalid TCP Port");
-            }
-
-            var v = new Dictionary<string, object>
-            {
-                ["mode"] = "fixed_servers",
-                ["server"] = scheme + "://" + host + (port.HasValue ? (":" + port) : "")
-            };
+            var v = GetProxyDictionary(scheme, host, port);
 
             return requestContext.SetPreference("proxy", v, out errorMessage);
         }
@@ -131,6 +106,45 @@ namespace CefSharp
         public static bool SetProxy(this IRequestContext requestContext, string host, out string errorMessage)
         {
             return requestContext.SetProxy(null, host, null, out errorMessage);
+        }
+
+        /// <summary>
+        /// Creates a Dictionary that can be used with <see cref="IRequestContext.SetPreference(string, object, out string)"/>
+        /// </summary>
+        /// <param name="scheme">is the protocol of the proxy server, and is one of: 'http', 'socks', 'socks4', 'socks5'. Also note that 'socks' is equivalent to 'socks5'.</param>
+        /// <param name="host">proxy host</param>
+        /// <param name="port">proxy port</param>
+        /// <returns></returns>
+        public static IDictionary<string, object> GetProxyDictionary(string scheme, string host, int? port)
+        {
+            //Default to using http scheme if non provided
+            if (string.IsNullOrWhiteSpace(scheme))
+            {
+                scheme = "http";
+            }
+
+            if (!ProxySchemes.Contains(scheme.ToLower()))
+            {
+                throw new ArgumentException("Invalid Scheme, see https://bitbucket.org/chromiumembedded/cef/wiki/GeneralUsage.md#markdown-header-proxy-resolution for a list of valid schemes.", "scheme");
+            }
+
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                throw new ArgumentException("Cannot be null or empty", "host");
+            }
+
+            if (port.HasValue && (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort))
+            {
+                throw new ArgumentOutOfRangeException("port", port, "Invalid TCP Port");
+            }
+
+            var dict = new Dictionary<string, object>
+            {
+                ["mode"] = "fixed_servers",
+                ["server"] = scheme + "://" + host + (port.HasValue ? (":" + port) : "")
+            };
+
+            return dict;
         }
 
         /// <summary>


### PR DESCRIPTION
**Fixes:** 

Issue #3235 


**Summary:**
Simplifies the setting of proxy preference

**Changes:** 
- Add new `RequestContextHandler` default implementation
- Add new extension methods
- Add Fluent API for setting the proxy server

Example of new API looks like this:
```c#
var requestContext = RequestContext
	.Configure()
	.WithProxyServer("127.0.0.1", 8080)
	.Create();

using (var browser = new ChromiumWebBrowser("http://cefsharp.github.io/", requestContext: requestContext))
{
	await browser.LoadPageAsync();

	var mainFrame = browser.GetMainFrame();
	Assert.True(mainFrame.IsValid);
	Assert.Contains("cefsharp.github.io", mainFrame.Url);

	output.WriteLine("Url {0}", mainFrame.Url);
}
```
      
**How Has This Been Tested?**  
Basic Unit test (only runs locally) spawns a proxy server and makes a simple page load request.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
