### PR TITLE
Enhancement - Add EvaluateScriptAsPromiseAsync

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -175,6 +175,7 @@
     <ClInclude Include="BindObjectAsyncHandler.h" />
     <ClCompile Include="BrowserSubprocessExecutable.h" />
     <ClInclude Include="Cef.h" />
+    <ClInclude Include="JavascriptPromiseHandler.h" />
     <ClInclude Include="SubProcessApp.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodCallback.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodHandler.h" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClInclude Include="Cef.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="JavascriptPromiseHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp">

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPromiseHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPromiseHandler.h
@@ -1,0 +1,85 @@
+// Copyright © 2020 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "include/cef_v8.h"
+#include "..\CefSharp.Core\Internals\Messaging\Messages.h"
+#include "..\CefSharp.Core\Internals\Serialization\Primitives.h"
+#include "Serialization\V8Serialization.h"
+
+using namespace System;
+using namespace CefSharp::Internals::Messaging;
+using namespace CefSharp::Internals::Serialization;
+
+namespace CefSharp
+{
+    const CefString kSendEvalScriptResponse = CefString("SendEvalScriptResponse");
+    const CefString kSendEvalScriptResponseCamelCase = CefString("sendEvalScriptResponse");
+
+    private class JavascriptPromiseHandler : public CefV8Handler
+    {
+    public:
+
+        virtual bool Execute(const CefString& name,
+            CefRefPtr<CefV8Value> object,
+            const CefV8ValueList& arguments,
+            CefRefPtr<CefV8Value>& retval,
+            CefString& exception)
+        {
+            if (arguments.size() < 2)
+            {
+                //TODO: Improve error message
+                exception = "Must specify a callback Id and then/catch.";
+
+                return true;
+            }
+
+            auto callbackId = arguments[0]->GetIntValue();
+
+            if (callbackId == 0)
+            {
+                exception = "Invalid callback Id";
+
+                return true;
+            }
+
+            auto success = arguments[1]->GetBoolValue();
+
+            auto response = CefProcessMessage::Create(kEvaluateJavascriptResponse);
+
+            auto responseArgList = response->GetArgumentList();
+            //Success
+            responseArgList->SetBool(0, success);
+            //Callback Id
+            SetInt64(responseArgList, 1, callbackId);
+            if (exception == "")
+            {
+                if (success)
+                {
+                    SerializeV8Object(arguments[2], responseArgList, 2, nullptr);
+                }
+                else
+                {
+                    auto reason = arguments[2];
+                    responseArgList->SetString(2, reason->GetStringValue());
+                }
+            }
+            else
+            {
+                responseArgList->SetString(2, exception);
+            }
+
+            auto context = CefV8Context::GetCurrentContext();
+
+            auto frame = context->GetFrame();
+
+            frame->SendProcessMessage(CefProcessId::PID_BROWSER, response);
+
+            return false;
+        }
+
+        IMPLEMENT_REFCOUNTING(JavascriptPromiseHandler);
+    };
+}

--- a/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.cpp
@@ -165,7 +165,7 @@ void Frame::ExecuteJavaScriptAsync(String^ code, String^ scriptUrl, int startLin
     _frame->ExecuteJavaScript(StringUtils::ToNative(code), StringUtils::ToNative(scriptUrl), startLine);
 }
 
-Task<JavascriptResponse^>^ Frame::EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout)
+Task<JavascriptResponse^>^ Frame::EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout, bool useImmediatelyInvokedFuncExpression)
 {
     throw gcnew NotImplementedException();
 }

--- a/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.h
+++ b/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.h
@@ -164,7 +164,7 @@ namespace CefSharp
             /*--cef(optional_param=script_url)--*/
             virtual void ExecuteJavaScriptAsync(String^ code, String^ scriptUrl, int startLine);
 
-            virtual Task<JavascriptResponse^>^ EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout);
+            virtual Task<JavascriptResponse^>^ EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout, bool useImmediatelyInvokedFuncExpression);
 
             ///
             // Returns true if this is the main (top-level) frame.

--- a/CefSharp.Core/Internals/CefFrameWrapper.cpp
+++ b/CefSharp.Core/Internals/CefFrameWrapper.cpp
@@ -225,7 +225,7 @@ void CefFrameWrapper::ExecuteJavaScriptAsync(String^ code, String^ scriptUrl, in
     _frame->ExecuteJavaScript(StringUtils::ToNative(code), StringUtils::ToNative(scriptUrl), startLine);
 }
 
-Task<JavascriptResponse^>^ CefFrameWrapper::EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout)
+Task<JavascriptResponse^>^ CefFrameWrapper::EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout, bool useImmediatelyInvokedFuncExpression)
 {
     ThrowIfDisposed();
     ThrowIfFrameInvalid();
@@ -245,6 +245,11 @@ Task<JavascriptResponse^>^ CefFrameWrapper::EvaluateScriptAsync(String^ script, 
 
     //create a new taskcompletionsource
     auto idAndComplectionSource = pendingTaskRepository->CreatePendingTask(timeout);
+
+    if (useImmediatelyInvokedFuncExpression)
+    {
+        script = "(function() { let cefSharpInternalCallbackId = " + idAndComplectionSource.Key + "; " + script + " })();";
+    }
 
     auto message = CefProcessMessage::Create(kEvaluateJavascriptRequest);
     auto argList = message->GetArgumentList();

--- a/CefSharp.Core/Internals/CefFrameWrapper.h
+++ b/CefSharp.Core/Internals/CefFrameWrapper.h
@@ -165,7 +165,7 @@ namespace CefSharp
             /*--cef(optional_param=script_url)--*/
             virtual void ExecuteJavaScriptAsync(String^ code, String^ scriptUrl, int startLine);
 
-            virtual Task<JavascriptResponse^>^ EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout);
+            virtual Task<JavascriptResponse^>^ EvaluateScriptAsync(String^ script, String^ scriptUrl, int startLine, Nullable<TimeSpan> timeout, bool useImmediatelyInvokedFuncExpression);
 
             ///
             // Returns true if this is the main (top-level) frame.

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -199,6 +199,34 @@ namespace CefSharp.Test.OffScreen
             }
         }
 
+        [Theory]
+        [InlineData("return 42;", true, "42")]
+        [InlineData("return new Promise(function(resolve, reject) { resolve(42); });", true, "42")]
+        [InlineData("return new Promise(function(resolve, reject) { reject('reject test'); });", false, "reject test")]
+        public async Task CanEvaluateScriptAsPromiseAsync(string script, bool success, string expected)
+        {
+            using (var browser = new ChromiumWebBrowser("http://www.google.com"))
+            {
+                await browser.LoadPageAsync();
+
+                var mainFrame = browser.GetMainFrame();
+                Assert.True(mainFrame.IsValid);
+
+                var javascriptResponse = await browser.EvaluateScriptAsPromiseAsync(script);
+
+                Assert.Equal(success, javascriptResponse.Success);
+
+                if (success)
+                {
+                    Assert.Equal(expected, javascriptResponse.Result.ToString());
+                }
+                else
+                {
+                    Assert.Equal(expected, javascriptResponse.Message);
+                }
+            }
+        }
+
         [Fact]
         public async Task CanMakeFrameUrlRequest()
         {

--- a/CefSharp/IFrame.cs
+++ b/CefSharp/IFrame.cs
@@ -124,8 +124,12 @@ namespace CefSharp
         /// <param name="scriptUrl">is the URL where the script in question can be found, if any.</param>
         /// <param name="startLine">is the base line number to use for error reporting.</param>
         /// <param name="timeout">The timeout after which the Javascript code execution should be aborted.</param>
+        /// <param name="useImmediatelyInvokedFuncExpression">When true the script is wrapped in a self executing function.
+        /// Make sure to use a return statement in your javascript. e.g. (function () { return 42; })();
+        /// When false don't include a return statement e.g. 42;
+        /// </param>
         /// <returns>A Task that can be awaited to perform the script execution</returns>
-        Task<JavascriptResponse> EvaluateScriptAsync(string script, string scriptUrl = "about:blank", int startLine = 1, TimeSpan? timeout = null);
+        Task<JavascriptResponse> EvaluateScriptAsync(string script, string scriptUrl = "about:blank", int startLine = 1, TimeSpan? timeout = null, bool useImmediatelyInvokedFuncExpression = false);
 
         /// <summary>
         /// Returns true if this is the main (top-level) frame.


### PR DESCRIPTION
**Summary:**
Use newly added `EvaluateScriptAsPromiseAsync` extension method (add `using CefSharp;`) to evaluate javascript that 
returns a promise. Uses `Promise.resolve` to return the script execution into a promise regardless, `EvaluateScriptAsPromiseAsync("return 53")` will be turned into a promise.

Differs from other `EvaluateScriptAsync` methods in that you **must** return a result.

```js
//This will return 42
await browser.EvaluateScriptAsPromiseAsync("return 42");
//This will return undefined
await browser.EvaluateScriptAsPromiseAsync("42");
```

**Changes:**
- Add useImmediatelyInvokedFuncExpression param to EvaluateScriptAsync which wraps the script in an IIFE
  with the cefSharpInternalCallbackId variable defined in scope to allow for deferred completion
- Wrap script in Immediately Invoked Function Expression and call promise.resolve to guarantee a promise.
- Return 'CefSharpDefEvalScriptRes' as the result of the js function to defer execution of the callback
- Call newly added cefSharp.sendEvalScriptResponse method in javascript when promise has been resolved/rejected

This is built up of a few parts and can technically be used by the new user to defer the response until they are ready.
Just return `'CefSharpDefEvalScriptRes'` and manually call cefSharp.sendEvalScriptResponse using the cefSharpInternalCallbackId
variable which is injected into the script execution (wrapped in an IIFE to limit scope)
      
**How Has This Been Tested?**  
Basic unit test has been added.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
