### PR TITLE
Fixed issue #3270 (Core - Improve IPopupFeatures mapping and xml doc)

### DIFF
--- a/CefSharp.Core/PopupFeatures.h
+++ b/CefSharp.Core/PopupFeatures.h
@@ -38,44 +38,24 @@ namespace CefSharp
             this->!PopupFeatures();
         }
 
-        virtual property int X
+        virtual property System::Nullable<int> X
         {
-            int get() { return _popupFeatures->x; }
+            System::Nullable<int> get() { return _popupFeatures->xSet ? _popupFeatures->x : Nullable<int>(); }
         }
 
-        virtual property int XSet
+        virtual property System::Nullable<int> Y
         {
-            int get() { return _popupFeatures->xSet; }
+            System::Nullable<int> get() { return _popupFeatures->ySet ? _popupFeatures->y : Nullable<int>(); }
         }
 
-        virtual property int Y
+        virtual property System::Nullable<int> Width
         {
-            int get() { return _popupFeatures->y; }
+            System::Nullable<int> get() { return _popupFeatures->widthSet ? _popupFeatures->width : Nullable<int>(); }
         }
 
-        virtual property int YSet
+        virtual property System::Nullable<int> Height
         {
-            int get() { return _popupFeatures->ySet; }
-        }
-
-        virtual property int Width
-        {
-            int get() { return _popupFeatures->width; }
-        }
-
-        virtual property int WidthSet
-        {
-            int get() { return _popupFeatures->width; }
-        }
-
-        virtual property int Height
-        {
-            int get() { return _popupFeatures->height; }
-        }
-
-        virtual property int HeightSet
-        {
-            int get() { return _popupFeatures->heightSet; }
+            System::Nullable<int> get() { return _popupFeatures->heightSet ? _popupFeatures->height : Nullable<int>(); }
         }
 
         virtual property bool MenuBarVisible
@@ -98,10 +78,29 @@ namespace CefSharp
             bool get() { return _popupFeatures->scrollbarsVisible == 1; }
         }
 
-        /*property List<String^>^ AdditionalFeatures
+        /*virtual property bool LocationBarVisible
+        {
+            bool get() { return _popupFeatures->locationBarVisible == 1; }
+        }
+
+        virtual property bool Resizable
+        {
+            bool get() { return _popupFeatures->resizable == 1; }
+        }
+
+        virtual property bool FullScreen
+        {
+            bool get() { return _popupFeatures->fullscreen == 1; }
+        }
+
+        virtual property bool Dialog
+        {
+            bool get() { return _popupFeatures->dialog == 1; }
+        }
+
+        virtual property List<String^>^ AdditionalFeatures
         {
             List<String^>^ get() { return StringUtils::ToClr(_popupFeatures->additionalFeatures); }
-            void set(List<String^>^ value) { _popupFeatures->dialog = value; }
         }*/
     };
 }

--- a/CefSharp/IPopupFeatures.cs
+++ b/CefSharp/IPopupFeatures.cs
@@ -2,6 +2,8 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System.Collections.Generic;
+
 namespace CefSharp
 {
     /// <summary>
@@ -15,56 +17,28 @@ namespace CefSharp
         /// <value>
         /// The x coordinate.
         /// </value>
-        int X { get; }
-        /// <summary>
-        /// Gets the set.
-        /// </summary>
-        /// <value>
-        /// The x coordinate set.
-        /// </value>
-        int XSet { get; }
+        int? X { get; }
         /// <summary>
         /// Gets the y coordinate.
         /// </summary>
         /// <value>
         /// The y coordinate.
         /// </value>
-        int Y { get; }
-        /// <summary>
-        /// Gets the set.
-        /// </summary>
-        /// <value>
-        /// The y coordinate set.
-        /// </value>
-        int YSet { get; }
+        int? Y { get; }
         /// <summary>
         /// Gets the width.
         /// </summary>
         /// <value>
         /// The width.
         /// </value>
-        int Width { get; }
-        /// <summary>
-        /// Gets the set the width belongs to.
-        /// </summary>
-        /// <value>
-        /// The width set.
-        /// </value>
-        int WidthSet { get; }
+        int? Width { get; }
         /// <summary>
         /// Gets the height.
         /// </summary>
         /// <value>
         /// The height.
         /// </value>
-        int Height { get; }
-        /// <summary>
-        /// Gets the set the height belongs to.
-        /// </summary>
-        /// <value>
-        /// The height set.
-        /// </value>
-        int HeightSet { get; }
+        int? Height { get; }
         /// <summary>
         /// Gets a value indicating whether the menu bar is visible.
         /// </summary>
@@ -93,5 +67,25 @@ namespace CefSharp
         /// True if scrollbars visible, false if not.
         /// </value>
         bool ScrollbarsVisible { get; }
+        ///// <summary> These were apparently removed?
+        ///// Gets a value indicating whether the location bar is visible.
+        ///// </summary>
+        ///// <value>
+        ///// True if location bar visible, false if not.
+        ///// </value>
+        //bool LocationBarVisible { get; }
+        ///// <summary>
+        ///// Gets a value indicating whether or not the window should be resizable.
+        ///// </summary>
+        ///// <value>
+        ///// True if resizable, false if not.
+        ///// </value>
+        //bool Resizable { get; }
+        //bool FullScreen { get; }
+        //bool Dialog { get; }
+        ///// <summary>
+        ///// A list of any additional requested features
+        ///// </summary>
+        //List<string> AdditionalFeatures { get; }
     }
 }


### PR DESCRIPTION
Now using nullable ints for optional values in IPopupFeatures

**Fixes:**   #3270  

**Summary:**
   - Now using nullable ints for optional values in IPopupFeatures

**Changes:**
   - Changed X, Y, Width, and Height to return nullable values
      - Also removed the corresponding *Set properties (XSet, YSet, WidthSet, HeightSet) since those are now covered by the nullable ints
      
**How Has This Been Tested?**  
There were no existing tests for this particular class, so I used `ExperimentalLifespanHandler` in CefSharp.Wpf.Example with a breakpoint at line 39 (the start of `OnBeforePopup`. I put it in `BrowserTabViewModel` in the same project after line 200. I then navigated to https://www.w3schools.com/html/html_links.asp and clicked "Try it Yourself" and made sure that sane values were returned from the `popupFeatures` instance. Nothing crashed, so I think we should be good.

**Screenshots (if appropriate):**

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
