### PR TITLE
Fix Task Deadlock During Interception

### DIFF
--- a/CefSharp.Example/ModelBinding/MethodInterceptorLogger.cs
+++ b/CefSharp.Example/ModelBinding/MethodInterceptorLogger.cs
@@ -4,17 +4,25 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using CefSharp.ModelBinding;
 
 namespace CefSharp.Example.ModelBinding
 {
     public class MethodInterceptorLogger : IMethodInterceptor
     {
+        public bool IsAsync => false;
+
         object IMethodInterceptor.Intercept(Func<object[], object> method, object[] parameters, string methodName)
         {
-            object result = method(parameters);
+            var result = method(parameters);
             Debug.WriteLine("Called " + methodName);
             return result;
+        }
+
+        public Task<object> InterceptAsync(Func<object[], object> method, object[] parameters, string methodName)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/CefSharp/Internals/Wcf/BrowserProcessService.cs
+++ b/CefSharp/Internals/Wcf/BrowserProcessService.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System.ServiceModel;
+using System.Threading.Tasks;
 
 namespace CefSharp.Internals.Wcf
 {
@@ -22,12 +23,8 @@ namespace CefSharp.Internals.Wcf
 
         public BrowserProcessResponse CallMethod(long objectId, string name, object[] parameters)
         {
-            object result;
-            string exception;
-
-            var success = javascriptObjectRepository.TryCallMethod(objectId, name, parameters, out result, out exception);
-
-            return new BrowserProcessResponse { Success = success, Result = result, Message = exception };
+            var value = javascriptObjectRepository.TryCallMethod(objectId, name, parameters).GetResultSafely();
+            return new BrowserProcessResponse { Success = value.Item1, Result = value.Item2, Message = value.Item3 };
         }
 
         public BrowserProcessResponse GetProperty(long objectId, string name)

--- a/CefSharp/ModelBinding/IMethodInterceptor.cs
+++ b/CefSharp/ModelBinding/IMethodInterceptor.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Threading.Tasks;
 
 namespace CefSharp.ModelBinding
 {
@@ -12,6 +13,11 @@ namespace CefSharp.ModelBinding
     /// </summary>
     public interface IMethodInterceptor
     {
+        /// <summary>
+        /// Indicates that the method interceptor needs to be ran asynchronously. 
+        /// </summary>
+        bool IsAsync { get; }
+
         /// <summary>
         /// Called before the method is invokved. You are now responsible for evaluating
         /// the function and returning the result.
@@ -29,6 +35,25 @@ namespace CefSharp.ModelBinding
         ///   return result;
         ///  }
         /// </example>
+        /// 
         object Intercept(Func<object[], object> method, object[] parameters, string methodName);
+        /// <summary>
+        /// Called before the method is invokved. You are now responsible for evaluating
+        /// the function and returning the result asynchronously.
+        /// </summary>
+        /// <param name="method">A Func that represents the method to be called</param>
+        /// <param name="parameters">paramaters to be passed to <paramref name="method"/></param>
+        /// <param name="methodName">Name of the method to be called</param>
+        /// <returns>The method result</returns>
+        /// <example>
+        /// 
+        /// Task{object} IMethodInterceptor.Intercept(Func&lt;object[], object&gt; method, object[] parameters, string methodName)
+        /// {
+        ///   object result = method(parameters);
+        ///   Debug.WriteLine("Called " + methodName);
+        ///   return result;
+        ///  }
+        /// </example>
+        Task<object> InterceptAsync(Func<object[], object> method, object[] parameters, string methodName);
     }
 }


### PR DESCRIPTION
**Summary:**
Currently custom interceptors are forced to call `.Result` as there is no async overload. In some scenarios this can lead to a deadlock as the task attempts to schedule it's continuation onto a thread that is being blocked by the call to Result. You can also trigger a deadlock by returning a Task directly without awaiting as CefSharp then calls `.Result` internally leading to the same issue mentioned prior.


**Changes:**
I have modified the method intercept call to allow for overloading with async. This now allows the entire execution to use async / await properly. A single call to `.Result` is made safely only in BrowserProcessService; by this time the results should be fully resolved so there is no risk of a deadlock.

It also disallows Task from being returned without first awaiting them. This removes the need for CefSharp to try and haphazardly resolve task itself. 

      
**How Has This Been Tested?**  
In our production app [Rainway](https://rainway.com/).

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
