### PR TITLE
.NET Core - Allow non-portable RuntimeIdentifiers

### DIFF
--- a/NuGet/PackageReference/CefSharp.Common.NETCore.targets
+++ b/NuGet/PackageReference/CefSharp.Common.NETCore.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Choose>
-    <When Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+    <When Condition="$(RuntimeIdentifier.StartsWith('win')) and $(RuntimeIdentifier.Contains('-x64'))">
       <ItemGroup>
         <Content Include="@(CefRuntimeWin64Locales)">
 		  <Link>locales\%(RecursiveDir)%(FileName)%(Extension)</Link>
@@ -17,7 +17,7 @@
 		</Content>
       </ItemGroup>
     </When>
-	<When Condition="'$(RuntimeIdentifier)' == 'win-x86'">
+	<When Condition="$(RuntimeIdentifier.StartsWith('win')) and $(RuntimeIdentifier.Contains('-x86'))">
       <ItemGroup>
         <Content Include="@(CefRuntimeWin32Locales)">
 		  <Link>locales\%(RecursiveDir)%(FileName)%(Extension)</Link>
@@ -62,7 +62,7 @@
 		  <Visible>false</Visible>
 		</Content>
 		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\lib\netcoreapp3.1\Ijwhost.dll">
-		  <Link>runtimes\win-x64\native\%(RecursiveDir)%(FileName)%(Extension)</Link>
+		  <Link>runtimes\win-x86\native\%(RecursiveDir)%(FileName)%(Extension)</Link>
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		  <PublishState>Included</PublishState>
 		  <Visible>false</Visible>


### PR DESCRIPTION
**Issue:** cefsharp/CefSharp#3197


**Summary:**
   - Adjust the `RuntimeIdentifier` check in `CefSharp.Common.NETCore.targets` to make it work with non-portable RIDs like `win7-x64` or `win10-x86`.

**Changes:** 
- Changed the comparison of the `RuntimeIdentifier` to not check for exact RIDs like `win-x64`, but check that the string starts with `win` and that it contains the architecture like `-x64`.
- Note: I used `.Contains('-x64')` rather than `.EndsWith('-x64')` as there seem to be some RIDs that have [another suffix](https://github.com/dotnet/runtime/blob/f8e9156244606582c202c9f01be571baf523cccf/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json#L2974), like `win7-x64-aot`, which is described as `[additional qualifiers]` in [.NET Core RID catalog](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog).  However I don't know exactly when/how such RIDs would be used.
      
**How Has This Been Tested?**  
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, operating system, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Built the `CefSharp.Common.NETCore` NuGet package, referenced it in a app that uses `CefSharp.WinForms.NETCore`, and published it using runtime identifiers `win7-x64` and `win7-x86`.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
