### PR TITLE
Example - Simplify BindObjectAsync tests with QUnit

### DIFF
--- a/CefSharp.Example/Properties/Resources.Designer.cs
+++ b/CefSharp.Example/Properties/Resources.Designer.cs
@@ -313,12 +313,12 @@ namespace CefSharp.Example.Properties {
         ///&lt;html&gt;
         ///&lt;head&gt;
         ///    &lt;title&gt;Binding Test&lt;/title&gt;
-        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.10.0.css&quot;&gt;
         ///&lt;/head&gt;
         ///&lt;body&gt;
         ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
         ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.10.0.js&quot;&gt;&lt;/script&gt;
         ///
         ///    &lt;!--&lt;script type=&quot;text/javascript&quot;&gt;
         ///    (async function() {
@@ -362,12 +362,12 @@ namespace CefSharp.Example.Properties {
         ///&lt;html&gt;
         ///&lt;head&gt;
         ///    &lt;title&gt;Binding Test (Net Core)&lt;/title&gt;
-        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.10.0.css&quot;&gt;
         ///&lt;/head&gt;
         ///&lt;body&gt;
         ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
         ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.10.0.js&quot;&gt;&lt;/script&gt;
         ///
         ///    &lt;!--&lt;script type=&quot;text/javascript&quot;&gt;
         ///    (async function() {
@@ -386,7 +386,7 @@ namespace CefSharp.Example.Properties {
         ///&lt;html&gt;
         ///&lt;head&gt;
         ///    &lt;title&gt;Binding Test Async Task&lt;/title&gt;
-        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.10.0.css&quot;&gt;
         ///&lt;/head&gt;
         ///&lt;body&gt;
         ///    &lt;div&gt;
@@ -396,7 +396,7 @@ namespace CefSharp.Example.Properties {
         ///
         ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
         ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.10.0.js&quot;&gt;&lt;/script&gt;
         ///
         ///     [rest of string was truncated]&quot;;.
         /// </summary>
@@ -405,18 +405,18 @@ namespace CefSharp.Example.Properties {
                 return ResourceManager.GetString("BindingTestsAsyncTask", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0 Transitional//EN&quot;&gt;
         ///&lt;html&gt;
         ///&lt;head&gt;
         ///    &lt;title&gt;Binding Test&lt;/title&gt;
-        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.10.0.css&quot;&gt;
         ///&lt;/head&gt;
         ///&lt;body&gt;
         ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
         ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.10.0.js&quot;&gt;&lt;/script&gt;
         ///
         ///    &lt;script type=&quot;text/javascript&quot;&gt;
         ///        (async () =&gt;
@@ -694,12 +694,12 @@ namespace CefSharp.Example.Properties {
         ///&lt;html&gt;
         ///    &lt;head&gt;
         ///        &lt;title&gt;Legacy Binding Test&lt;/title&gt;
-        ///        &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///        &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.10.0.css&quot;&gt;
         ///    &lt;/head&gt;
         ///    &lt;body&gt;
         ///        &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
         ///        &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///        &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///        &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.10.0.js&quot;&gt;&lt;/script&gt;
         ///
         ///        &lt;script type=&quot;text/javascript&quot;&gt;
         ///        (function()
@@ -760,12 +760,12 @@ namespace CefSharp.Example.Properties {
         ///&lt;head&gt;
         ///    &lt;meta charset=&quot;utf-8&quot; /&gt;
         ///    &lt;title&gt;Post Message Test&lt;/title&gt;
-        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.4.1.css&quot;&gt;
+        ///    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://code.jquery.com/qunit/qunit-2.10.0.css&quot;&gt;
         ///&lt;/head&gt;
         ///&lt;body&gt;
         ///    &lt;div id=&quot;qunit&quot;&gt;&lt;/div&gt;
         ///    &lt;div id=&quot;qunit-fixture&quot;&gt;&lt;/div&gt;
-        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.4.1.js&quot;&gt;&lt;/script&gt;
+        ///    &lt;script src=&quot;https://code.jquery.com/qunit/qunit-2.10.0.js&quot;&gt;&lt;/script&gt;
         ///
         ///    &lt;script type=&quot;text/javascript&quot;&gt;
         ///        let PostMessageIntTestCallback;

--- a/CefSharp.Example/Resources/BindingTest.html
+++ b/CefSharp.Example/Resources/BindingTest.html
@@ -2,12 +2,12 @@
 <html>
 <head>
     <title>Binding Test</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+    <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
 
     <!--<script type="text/javascript">
     (async function() {

--- a/CefSharp.Example/Resources/BindingTestAsync.js
+++ b/CefSharp.Example/Resources/BindingTestAsync.js
@@ -1,204 +1,100 @@
-(async () =>
+QUnit.module('BindObjectAsync', (hooks) =>
 {
-    // Verify that two objects are completely equal
-    function deepEqual(x, y)
-    {
-        if ((typeof x == "object" && x != null) && (typeof y == "object" && y != null))
-        {
-            for (var prop in x)
-            {
-                if (prop in y && (Object.keys(x).length === Object.keys(y).length))
-                {
-                    return deepEqual(x[prop], y[prop]);
-                }
-                else
-                {
-                    return false;
-                }
-            }
-        }
-        else
-        {
-            return x === y;
-        }
-    }
+    hooks.before(async () => {
+        await CefSharp.BindObjectAsync("boundAsync");
+    } );
 
-    await CefSharp.BindObjectAsync("boundAsync");
-
-    QUnit.test("BindObjectAsync Second call with boundAsync param", function (assert)
+    QUnit.test("BindObjectAsync Second call with boundAsync param", async (assert) =>
     {
-        let asyncCallback = assert.async();
-        CefSharp.BindObjectAsync("boundAsync").then(function (res)
-        {
-            assert.equal(res.Success, false, "Second call to BindObjectAsync with already bound objects as params returned false.");
-            asyncCallback();
-        });
+        const res = await CefSharp.BindObjectAsync("boundAsync");
+        assert.equal(res.Success, false, "Second call to BindObjectAsync with already bound objects as params returned false.");
     });
 
-    QUnit.test("Async call (Throw .Net Exception)", function (assert)
+    QUnit.test("Async call (Throw .Net Exception)", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.error().catch(function (e)
-        {
-            assert.ok(true, "Error: " + e);
-
-            asyncCallback();
-        });
+        assert.rejects(boundAsync.error());
     });
 
-    QUnit.test("Async call (Divide 16 / 2):", function (assert)
+    QUnit.test("Async call (Divide 16 / 2):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.div(16, 2).then(function (actualResult)
-        {
-            const expectedResult = 8
-
-            assert.equal(expectedResult, actualResult, "Divide 16 / 2 resulted in " + expectedResult);
-
-            asyncCallback();
-        });
+        const actualResult = await boundAsync.div(16, 2);
+        const expectedResult = 8
+        assert.equal(expectedResult, actualResult, "Divide 16 / 2");
     });
 
-    QUnit.test("Async call (Div with Blocking Task 16 / 2):", function (assert)
+    QUnit.test("Async call (Div with Blocking Task 16 / 2):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.divWithBlockingTaskCall(16, 2).then(function (actualResult)
-        {
-            const expectedResult = 8
-
-            assert.equal(expectedResult, actualResult, "Divide 16 / 2 resulted in " + expectedResult);
-
-            asyncCallback();
-        });
+        const actualResult = await boundAsync.divWithBlockingTaskCall(16, 2);
+        const expectedResult = 8
+        assert.equal(expectedResult, actualResult, "Divide 16 / 2");
     });
 
-    QUnit.test("Async call (Divide 16 /0)", function (assert)
+    QUnit.test("Async call (Divide 16 /0)", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.div(16, 0).then(function (res)
-        {
-            //Will always throw exception
-        },
-            function (e)
-            {
-                assert.ok(true, "Error: " + e + "(" + Date() + ")");
-
-                asyncCallback();
-            });
+        assert.rejects(boundAsync.div(16, 0));
     });
 
-    QUnit.test("Async call (UIntAddModel 3 + 2):", function (assert)
+    QUnit.test("Async call (UIntAddModel 3 + 2):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const actualResult = await boundAsync.uIntAddModel({ ParamA: 3, ParamB: 2 });
+        const expectedResult = 5
 
-        boundAsync.uIntAddModel({ ParamA: 3, ParamB: 2 }).then(function (actualResult)
-        {
-            const expectedResult = 5
-
-            assert.equal(expectedResult, actualResult, "Add 3 + 2 resulted in " + expectedResult);
-
-            asyncCallback();
-        });
+        assert.equal(expectedResult, actualResult, "Add 3 + 2 resulted in " + expectedResult);
     });
 
-    QUnit.test("Async call (UIntAdd 3 + 2):", function (assert)
+    QUnit.test("Async call (UIntAdd 3 + 2):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const actualResult = await boundAsync.uIntAdd(3, 2);
+        const expectedResult = 5
 
-        boundAsync.uIntAdd(3, 2).then(function (actualResult)
-        {
-            const expectedResult = 5
-
-            assert.equal(expectedResult, actualResult, "Add 3 + 2 resulted in " + expectedResult);
-
-            asyncCallback();
-        });
+        assert.equal(expectedResult, actualResult, "Add 3 + 2 resulted in " + expectedResult);
     });
 
-    QUnit.test("Async call (Hello):", function (assert)
+    QUnit.test("Async call (Hello):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.hello('CefSharp').then(function (res)
-        {
-            assert.equal(res, "Hello CefSharp")
-
-            asyncCallback();
-        });
+        const res = await boundAsync.hello('CefSharp');
+        assert.equal(res, "Hello CefSharp")
     });
 
-    QUnit.test("Async call (Long Running Task):", function (assert)
+    QUnit.test("Async call (Long Running Task):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.doSomething().then(function (res)
-        {
-            assert.ok(true, "Slept for 1000ms")
-
-            asyncCallback();
-        });
+        const res = await boundAsync.doSomething();
+        assert.ok(true, "Slept for 1000ms")
     });
 
-    QUnit.test("Async call (return Struct):", function (assert)
+    QUnit.test("Async call (return Struct):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        var res = await boundAsync.returnObject('CefSharp Struct Test');
+        assert.equal(res.Value, "CefSharp Struct Test", "Struct with a single field");
 
-        boundAsync.returnObject('CefSharp Struct Test').then(function (res)
-        {
-            assert.equal(res.Value, "CefSharp Struct Test", "Struct with a single field");
-
-            asyncCallback();
-        });
     });
 
-    QUnit.test("Async call (return Class):", function (assert)
+    QUnit.test("Async call (return Class):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
         //Returns a class
-        boundAsync.returnClass('CefSharp Class Test').then(function (res)
-        {
-            const expectedResult = 'CefSharp Class Test';
+        const res = await boundAsync.returnClass('CefSharp Class Test');
+        const expectedResult = 'CefSharp Class Test';
 
-            assert.equal(expectedResult, res.Value, "Class with a single property");
-
-            asyncCallback();
-        });
+        assert.equal(expectedResult, res.Value, "Class with a single property");
     });
 
-    QUnit.test("Async call (return Class as JsonString):", function (assert)
+    QUnit.test("Async call (return Class as JsonString):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
         const expectedResult = 'CefSharp Class Test';
 
         //Returns a class
-        boundAsync.returnClassAsJsonString(expectedResult).then(function (res)
-        {
-            assert.equal(expectedResult, res.Value, "Class with a single property");
-
-            asyncCallback();
-        });
+        const res = await boundAsync.returnClassAsJsonString(expectedResult);
+        assert.equal(expectedResult, res.Value, "Class with a single property");
     });
 
-    QUnit.test("Async call (returnStructArray):", function (assert)
+    QUnit.test("Async call (returnStructArray):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
-        boundAsync.returnStructArray('CefSharp').then(function (res)
-        {
-            assert.equal(res[0].Value, "CefSharpItem1", "Expected Result of CefSharpItem1");
-            assert.equal(res[1].Value, "CefSharpItem2", "Expected Result of CefSharpItem2");
-
-            asyncCallback();
-        });
+        const res = await boundAsync.returnStructArray('CefSharp');
+        assert.equal(res[0].Value, "CefSharpItem1", "Expected Result of CefSharpItem1");
+        assert.equal(res[1].Value, "CefSharpItem2", "Expected Result of CefSharpItem2");
     });
 
-    QUnit.test("Async call (returnClassesArray):", function (assert)
+    QUnit.test("Async call (returnClassesArray):", async (assert) =>
     {
         var asyncCallback = assert.async();
 
@@ -211,67 +107,48 @@
         });
     });
 
-    QUnit.test("Async call (echoArray):", function (assert)
+    QUnit.test("Async call (echoArray):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const res = await boundAsync.echoArray(["one", null, "three"]);
 
-        boundAsync.echoArray(["one", null, "three"]).then(function (res)
-        {
-            assert.equal(res.length, 3, "Expected result to be length 3");
-            assert.equal(res[0], "one", "Expected Result of 1st item");
-            assert.equal(res[1], null, "Expected Result of 2nd item");
-            assert.equal(res[2], "three", "Expected Result of 3rd item");
-
-            asyncCallback();
-        });
+        assert.equal(res.length, 3, "Expected result to be length 3");
+        assert.equal(res[0], "one", "Expected Result of 1st item");
+        assert.equal(res[1], null, "Expected Result of 2nd item");
+        assert.equal(res[2], "three", "Expected Result of 3rd item");
     });
 
-    QUnit.test("Async call (Test Empty Array):", function (assert)
+    QUnit.test("Async call (Test Empty Array):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const res = await boundAsync.echoArray([]);
 
-        boundAsync.echoArray([]).then(function (res)
-        {
-            assert.equal(Array.isArray(res), true, "Expected result is an array");
-            assert.equal(res.length, 0, "Expected result to be length 0 (empty array)");
-            asyncCallback();
-        });
+        assert.equal(Array.isArray(res), true, "Expected result is an array");
+        assert.equal(res.length, 0, "Expected result to be length 0 (empty array)");
     });
 
 
-    QUnit.test("Async call (echoValueTypeArray):", function (assert)
+    QUnit.test("Async call (echoValueTypeArray):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const res = await boundAsync.echoValueTypeArray([1, null, 3]);
 
-        boundAsync.echoValueTypeArray([1, null, 3]).then(function (res)
-        {
-            assert.equal(res.length, 3, "Expected result to be length 3");
-            assert.equal(res[0], 1, "Expected Result of 1st item");
-            assert.equal(res[1], 0, "Expected Result of 2nd item");
-            assert.equal(res[2], 3, "Expected Result of 3rd item");
-
-            asyncCallback();
-        });
+        assert.equal(res.length, 3, "Expected result to be length 3");
+        assert.equal(res[0], 1, "Expected Result of 1st item");
+        assert.equal(res[1], 0, "Expected Result of 2nd item");
+        assert.equal(res[2], 3, "Expected Result of 3rd item");
     });
 
-    QUnit.test("Async call (echoMultidimensionalArray):", function (assert)
+    QUnit.test("Async call (echoMultidimensionalArray):", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const res = await boundAsync.echoMultidimensionalArray([[1, 2], null, [3, 4]]);
 
-        boundAsync.echoMultidimensionalArray([[1, 2], null, [3, 4]]).then(function (res)
-        {
-            assert.equal(res.length, 3, "Expected result to be length 3");
-            assert.equal(res[0][0], 1, "Expected Result of 1st item");
-            assert.equal(res[0][1], 2, "Expected Result of 1st item");
-            assert.equal(res[1], null, "Expected Result of 2nd item");
-            assert.equal(res[2][0], 3, "Expected Result of 3rd item");
-            assert.equal(res[2][1], 4, "Expected Result of 3rd item");
-
-            asyncCallback();
-        });
+        assert.equal(res.length, 3, "Expected result to be length 3");
+        assert.equal(res[0][0], 1, "Expected Result of 1st item");
+        assert.equal(res[0][1], 2, "Expected Result of 1st item");
+        assert.equal(res[1], null, "Expected Result of 2nd item");
+        assert.equal(res[2][0], 3, "Expected Result of 3rd item");
+        assert.equal(res[2][1], 4, "Expected Result of 3rd item");
     });
 
-    QUnit.test("Async call (methodReturnList):", function (assert)
+    QUnit.test("Async call (methodReturnList):", async (assert) =>
     {
         const list1 =
             [
@@ -279,7 +156,6 @@
                 "Element 1",
                 "Element 2 - Last"
             ];
-
         const list2 =
             [
                 ["Element 0, 0", "Element 0, 1"],
@@ -287,20 +163,16 @@
                 ["Element 2, 0", "Element 2, 1"]
             ];
 
-        var asyncCallback = assert.async();
-        Promise.all([
+        const results = await Promise.all([
             boundAsync.methodReturnsList(),
             boundAsync.methodReturnsListOfLists(),
-        ]).then(function (results)
-        {
-            assert.ok(deepEqual(results[0], list1), "Call to boundAsync.MethodReturnsList() resulted in : " + JSON.stringify(results[0]));
-            assert.ok(deepEqual(results[1], list2), "Call to boundAsync.MethodReturnsListOfLists() resulted in : " + JSON.stringify(results[1]));
-            asyncCallback();
-        });
+        ]);
 
+        assert.deepEqual(results[0], list1, "Call to boundAsync.MethodReturnsList() resulted in : " + JSON.stringify(results[0]));
+        assert.deepEqual(results[1], list2, "Call to boundAsync.MethodReturnsListOfLists() resulted in : " + JSON.stringify(results[1]));
     });
 
-    QUnit.test("Async call (methodReturnsDictionary):", function (assert)
+    QUnit.test("Async call (methodReturnsDictionary):", async (assert) =>
     {
         const dict1 =
         {
@@ -325,74 +197,46 @@
             }
         };
 
-        var asyncCallback = assert.async();
-        Promise.all([
+        const results = await Promise.all([
             boundAsync.methodReturnsDictionary1(),
             boundAsync.methodReturnsDictionary2(),
             boundAsync.methodReturnsDictionary3()
-        ]).then(function (results)
-        {
-            assert.ok(deepEqual(results[0], dict1), "Call to boundAsync.MethodReturnsDictionary1() resulted in : " + JSON.stringify(results[0]));
-            assert.ok(deepEqual(results[1], dict2), "Call to boundAsync.MethodReturnsDictionary2() resulted in : " + JSON.stringify(results[1]));
-            assert.ok(deepEqual(results[2], dict3), "Call to boundAsync.MethodReturnsDictionary3() resulted in : " + JSON.stringify(results[2]));
-            asyncCallback();
-        });
+        ]);
+
+        assert.deepEqual(results[0], dict1, "Call to boundAsync.MethodReturnsDictionary1() resulted in : " + JSON.stringify(results[0]));
+        assert.deepEqual(results[1], dict2, "Call to boundAsync.MethodReturnsDictionary2() resulted in : " + JSON.stringify(results[1]));
+        assert.deepEqual(results[2], dict3, "Call to boundAsync.MethodReturnsDictionary3() resulted in : " + JSON.stringify(results[2]));
     });
 
-    QUnit.test("Bind boundAsync2 and call (Hello):", function (assert)
+    QUnit.test("Bind boundAsync2 and call (Hello):", async (assert) =>
     {
-        var asyncCallback = assert.async();
-
         //Can use both cefSharp.bindObjectAsync and CefSharp.BindObjectAsync, both do the same
-        cefSharp.bindObjectAsync({ NotifyIfAlreadyBound: true }, "boundAsync2").then(function (result)
-        {
-            boundAsync2.hello('CefSharp').then(function (res)
-            {
-                assert.equal(res, "Hello CefSharp")
+        const result = await cefSharp.bindObjectAsync({ NotifyIfAlreadyBound: true }, "boundAsync2");
+        const res = await boundAsync2.hello('CefSharp');
 
-                assert.equal(true, CefSharp.DeleteBoundObject("boundAsync2"), "Object was unbound");
-
-                assert.ok(window.boundAsync2 === undefined, "boundAsync2 is now undefined");
-
-                asyncCallback();
-            });
-        });
+        assert.equal(res, "Hello CefSharp")
+        assert.equal(true, CefSharp.DeleteBoundObject("boundAsync2"), "Object was unbound");
+        assert.ok(window.boundAsync2 === undefined, "boundAsync2 is now undefined");
     });
 
     //Repeat of the previous test to make sure binding a deleted object is working
-    QUnit.test("Bind boundAsync2 and call (Hello) Second Attempt:", function (assert)
+    QUnit.test("Bind boundAsync2 and call (Hello) Second Attempt:", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const result = await CefSharp.BindObjectAsync({ NotifyIfAlreadyBound: true, IgnoreCache: true }, "boundAsync2");
+        const res = await boundAsync2.hello('CefSharp');
 
-        CefSharp.BindObjectAsync({ NotifyIfAlreadyBound: true, IgnoreCache: true }, "boundAsync2").then(function (result)
-        {
-            boundAsync2.hello('CefSharp').then(function (res)
-            {
-                assert.equal(res, "Hello CefSharp")
-
-                asyncCallback();
-            });
-        });
+        assert.equal(res, "Hello CefSharp")
     });
 
     //Repeat of the previous test to make sure binding a deleted object is working
-    QUnit.test("Bind boundAsync2 and call (Hello) Third Attempt:", function (assert)
+    QUnit.test("Bind boundAsync2 and call (Hello) Third Attempt:", async (assert) =>
     {
-        var asyncCallback = assert.async();
+        const result = await CefSharp.BindObjectAsync({ NotifyIfAlreadyBound: true, IgnoreCache: true }, "boundAsync2");
+        const res = await boundAsync2.hello('CefSharp');
 
-        CefSharp.BindObjectAsync({ NotifyIfAlreadyBound: true, IgnoreCache: true }, "boundAsync2").then(function (result)
-        {
-            boundAsync2.hello('CefSharp').then(function (res)
-            {
-                assert.equal(res, "Hello CefSharp")
-
-                assert.equal(true, CefSharp.DeleteBoundObject("boundAsync2"), "Object was unbound");
-
-                assert.ok(window.boundAsync2 === undefined, "boundAsync2 is now undefined");
-
-                asyncCallback();
-            });
-        });
+        assert.equal(res, "Hello CefSharp")
+        assert.equal(true, CefSharp.DeleteBoundObject("boundAsync2"), "Object was unbound");
+        assert.ok(window.boundAsync2 === undefined, "boundAsync2 is now undefined");
     });
 
-})();
+});

--- a/CefSharp.Example/Resources/BindingTestNetCore.html
+++ b/CefSharp.Example/Resources/BindingTestNetCore.html
@@ -2,12 +2,12 @@
 <html>
 <head>
     <title>Binding Test (Net Core)</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+    <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
 
     <!--<script type="text/javascript">
     (async function() {

--- a/CefSharp.Example/Resources/BindingTestSingle.html
+++ b/CefSharp.Example/Resources/BindingTestSingle.html
@@ -2,12 +2,12 @@
 <html>
 <head>
     <title>Binding Test</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+    <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
 
     <script type="text/javascript">
         (async () =>

--- a/CefSharp.Example/Resources/BindingTestsAsyncTask.html
+++ b/CefSharp.Example/Resources/BindingTestsAsyncTask.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Binding Test Async Task</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
 </head>
 <body>
     <div>
@@ -12,7 +12,7 @@
 
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+    <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
 
     <script type="text/javascript">
         function getRandomInt(min, max)

--- a/CefSharp.Example/Resources/LegacyBindingTest.html
+++ b/CefSharp.Example/Resources/LegacyBindingTest.html
@@ -2,12 +2,12 @@
 <html>
     <head>
         <title>Legacy Binding Test</title>
-        <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+        <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
     </head>
     <body>
         <div id="qunit"></div>
         <div id="qunit-fixture"></div>
-        <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+        <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
 
         <script type="text/javascript">
         (function()

--- a/CefSharp.Example/Resources/PostMessageTest.html
+++ b/CefSharp.Example/Resources/PostMessageTest.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="utf-8" />
     <title>Post Message Test</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+    <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
 
     <script type="text/javascript">
         let PostMessageIntTestCallback;


### PR DESCRIPTION
**Summary:** Simplify BindObjectAsync unit tests.

**Changes:**
- Use native async-await where possible, as well as built-in QUnit methods as appropiate.