### PR TITLE
Add async to EvaluateScriptAsPromiseAsync and tests

### DIFF
--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -227,6 +227,9 @@ namespace CefSharp.Test.OffScreen
         [InlineData("return 42;", true, "42")]
         [InlineData("return new Promise(function(resolve, reject) { resolve(42); });", true, "42")]
         [InlineData("return new Promise(function(resolve, reject) { reject('reject test'); });", false, "reject test")]
+        [InlineData("return await 42;", true, "42")]
+        [InlineData("return await (function() { throw('reject test'); })();", false, "reject test")]
+        [InlineData("var result = await fetch('./robots.txt'); return result.status;", true, "200")]
         public async Task CanEvaluateScriptAsPromiseAsync(string script, bool success, string expected)
         {
             using (var browser = new ChromiumWebBrowser("http://www.google.com"))
@@ -255,6 +258,8 @@ namespace CefSharp.Test.OffScreen
         [InlineData("return { a: 'CefSharp', b: 42, };", true, "CefSharp", "42")]
         [InlineData("return new Promise(function(resolve, reject) { resolve({ a: 'CefSharp', b: 42, }); });", true, "CefSharp", "42")]
         [InlineData("return new Promise(function(resolve, reject) { setTimeout(resolve.bind(null, { a: 'CefSharp', b: 42, }), 1000); });", true, "CefSharp", "42")]
+        [InlineData("return await { a: 'CefSharp', b: 42, };", true, "CefSharp", "42")]
+        [InlineData("return await new Promise(function(resolve, reject) { setTimeout(resolve.bind(null, { a: 'CefSharp', b: 42, }), 1000); }); ", true, "CefSharp", "42")]
         public async Task CanEvaluateScriptAsPromiseAsyncReturnObject(string script, bool success, string expectedA, string expectedB)
         {
             using (var browser = new ChromiumWebBrowser("http://www.google.com"))

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -1046,7 +1046,7 @@ namespace CefSharp
                     internalJsFunctionName += ".SendEvalScriptResponse";
                 }
             }
-            var promiseHandlerScript = "let innerImmediatelyInvokedFuncExpression = (function() { " + script + " })(); Promise.resolve(innerImmediatelyInvokedFuncExpression).then((val) => " + internalJsFunctionName + "(cefSharpInternalCallbackId, true, val)).catch ((reason) => " + internalJsFunctionName + "(cefSharpInternalCallbackId, false, String(reason))); return 'CefSharpDefEvalScriptRes';";
+            var promiseHandlerScript = "let innerImmediatelyInvokedFuncExpression = (async function() { " + script + " })(); Promise.resolve(innerImmediatelyInvokedFuncExpression).then((val) => " + internalJsFunctionName + "(cefSharpInternalCallbackId, true, val)).catch ((reason) => " + internalJsFunctionName + "(cefSharpInternalCallbackId, false, String(reason))); return 'CefSharpDefEvalScriptRes';";
 
             return promiseHandlerScript;
         }


### PR DESCRIPTION
**Fixes:** Stack Overflow issue https://stackoverflow.com/questions/65229445/evaulatescriptaspromiseasync-and-async-await

**Summary:**
   - Added `async` to the `GetPromiseHandlerScript` `innerImmediatelyInvokedFuncExpression` function. This allows for `await` to be used in methods passed to this. 

**Changes:** [specify the structures changed] 
   - Modified `GetPromiseHandlerScript` to use an async function
   - Added tests for async/await usage to `OffscreenBrowserBasicFacts`. Tests pass. 
      
**How Has This Been Tested?**  
   - Added tests Unit tests to `OffscreenBrowserBasicFacts.cs`, specifically returning values, as well as using `fetch` to make an AJAX request. 


**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
