### PR TITLE
WPF - Fix chinese IMEs ( such as "sogou pinyin", "qq pinyin" etc. ) input window position.

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -377,6 +377,18 @@ namespace CefSharp.Wpf.Experimental
                 ImeNative.SetCaretPos(x, y);
             }
 
+            if (languageCodeId == ImeNative.LANG_CHINESE)
+            {
+                // Chinese IMEs need set composition window 
+                var compositionPotision = new ImeNative.COMPOSITIONFORM
+                {
+                    dwStyle = (int)ImeNative.CFS_POINT,
+                    ptCurrentPos = new ImeNative.POINT(x, y),
+                    rcArea = new ImeNative.RECT(0, 0, 0, 0)
+                };
+                ImeNative.ImmSetCompositionWindow(hIMC, ref compositionPotision);
+            }
+
             if (languageCodeId == ImeNative.LANG_KOREAN)
             {
                 // Chinese IMEs and Japanese IMEs require the upper-left corner of


### PR DESCRIPTION
**Fixes:** #3004
<!-- e.g Fixes: #2345 -->

**Summary:** 
   - Fix chinese IMEs ( such as "sogou pinyin", "qq pinyin" etc. ) input window position.

**Changes:** 
   - I have added a piece of code to WpfImeKeyboardHandler.cs to cast "ImmSetCompositionWindow" to set the chinese IME position. 
   
**How Has This Been Tested?**  
   - I have tested some chinese common IMEs ( such as "sogou pinyin", "qq pinyin" ,"Microsoft Pinyin IME" ) on Windows 10 and Windows 7, and it looks workable.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
