### PR TITLE
WPF - Japanese IME unable to enter space

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -246,11 +246,8 @@ namespace CefSharp.Wpf.Experimental
             if (ImeHandler.GetResult(hwnd, (uint)lParam, out text))
             {
                 owner.GetBrowserHost().ImeCommitText(text, new Range(int.MaxValue, int.MaxValue), 0);
-                if (languageCodeId == ImeNative.LANG_KOREAN || languageCodeId == ImeNative.LANG_CHINESE)
-                {
-                    owner.GetBrowserHost().ImeSetComposition(text, new CompositionUnderline[0], new Range(int.MaxValue, int.MaxValue), new Range(0, 0));
-                    owner.GetBrowserHost().ImeFinishComposingText(false);
-                }
+                owner.GetBrowserHost().ImeSetComposition(text, new CompositionUnderline[0], new Range(int.MaxValue, int.MaxValue), new Range(0, 0));
+                owner.GetBrowserHost().ImeFinishComposingText(false);
             }
             else
             {


### PR DESCRIPTION
This is a fix in response to the issue of not emitting spaces in Japanese IME (from @karthikeyancdm).
After all, it turns out that ImeSetComposition() and ImeFinishComposingText() should be invoked inside OnImeComposition() regardless of the current state of the IME language.

**Issue: #1262

**Summary:** 
   - Fixed an error that a user cannot type spaces during Japanese IME is on 

**Changes:** 
   - Removed the if (lang == KOREAN || lang == CHINESE) statement in OnImeComposition() so that it effectively makes it equivalent to if (lang == KOREAN || lang == CHINESE || lang == JAPANESE). (e.g. executing it if the language is Japanese as well)
      
**How Has This Been Tested?**  
Tested with Japanese IME installed on Windows 10 (20H2).

**Screenshots (if appropriate):**

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
