### PR TITLE
Javascript Binding - Allow binding to classes in the global namespace

### DIFF
--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Framework\RequestContextFacts.cs" />
     <Compile Include="Framework\TestMemberInfo.cs" />
     <Compile Include="JavascriptBinding\IntegrationTestFacts.cs" />
+    <Compile Include="JavascriptBinding\JavaScriptObjectRepositoryFacts.cs" />
     <Compile Include="OffScreen\OffScreenBrowserBasicFacts.cs" />
     <Compile Include="CefSharpXunitTestFramework.cs" />
     <Compile Include="CefSharpFixture.cs" />

--- a/CefSharp.Test/JavascriptBinding/JavaScriptObjectRepositoryFacts.cs
+++ b/CefSharp.Test/JavascriptBinding/JavaScriptObjectRepositoryFacts.cs
@@ -1,11 +1,5 @@
 using CefSharp.Internals;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 internal class NoNamespaceClass
 {
@@ -25,26 +19,9 @@ internal class SomeElseClass
 
 
 namespace CefSharp.Test.JavascriptBinding
-{    /// <summary>
-     /// This is more a set of integration tests than it is unit tests, for now we need to
-     /// run our QUnit tests in an automated fashion and some other testing.
-     /// </summary>
-    //TODO: Improve Test Naming, we need a naming scheme that fits these cases that's consistent
-    //(Ideally we implement consistent naming accross all test classes, though I'm open to a different
-    //naming convention as these are more integration tests than unit tests).
-    //NOTE: All Test classes must be part of this collection as it manages the Cef Initialize/Shutdown lifecycle
-    [Collection(CefSharpFixtureCollection.Key)]
+{  
     public class JavaScriptObjectRepositoryFacts
     {
-        private readonly ITestOutputHelper output;
-        private readonly CefSharpFixture fixture;
-
-        public JavaScriptObjectRepositoryFacts(ITestOutputHelper output, CefSharpFixture fixture)
-        {
-            this.fixture = fixture;
-            this.output = output;
-        }
-
         [Fact]
         public void CanRegisterJavascriptObjectBindWhenNamespaceIsNull()
         {

--- a/CefSharp.Test/JavascriptBinding/JavaScriptObjectRepositoryFacts.cs
+++ b/CefSharp.Test/JavascriptBinding/JavaScriptObjectRepositoryFacts.cs
@@ -1,0 +1,61 @@
+using CefSharp.Internals;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+internal class NoNamespaceClass
+{
+    public SomeElseClass SomeElseClass { get; set; }
+    public int Year { get; set; }
+
+    public string GetExampleString()
+    {
+        return "ok";
+    }
+}
+
+internal class SomeElseClass
+{
+
+}
+
+
+namespace CefSharp.Test.JavascriptBinding
+{    /// <summary>
+     /// This is more a set of integration tests than it is unit tests, for now we need to
+     /// run our QUnit tests in an automated fashion and some other testing.
+     /// </summary>
+    //TODO: Improve Test Naming, we need a naming scheme that fits these cases that's consistent
+    //(Ideally we implement consistent naming accross all test classes, though I'm open to a different
+    //naming convention as these are more integration tests than unit tests).
+    //NOTE: All Test classes must be part of this collection as it manages the Cef Initialize/Shutdown lifecycle
+    [Collection(CefSharpFixtureCollection.Key)]
+    public class JavaScriptObjectRepositoryFacts
+    {
+        private readonly ITestOutputHelper output;
+        private readonly CefSharpFixture fixture;
+
+        public JavaScriptObjectRepositoryFacts(ITestOutputHelper output, CefSharpFixture fixture)
+        {
+            this.fixture = fixture;
+            this.output = output;
+        }
+
+        [Fact]
+        public void CanRegisterJavascriptObjectBindWhenNamespaceIsNull()
+        {
+            var javascriptObjectRepository = new JavascriptObjectRepository();
+            var name = nameof(NoNamespaceClass);
+            javascriptObjectRepository.Register(name, new NoNamespaceClass(), false, new BindingOptions() { });
+            Assert.True(javascriptObjectRepository.IsBound(name));
+
+            var result = ((IJavascriptObjectRepositoryInternal)javascriptObjectRepository).TryCallMethod(1, "getExampleString", new object[0]);
+            Assert.True(result.Success);
+            Assert.Equal("ok", result.ReturnValue.ToString());
+        }
+    }
+}

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -738,7 +738,7 @@ namespace CefSharp.Internals
                 baseType = Nullable.GetUnderlyingType(type);
             }
 
-            if (baseType == null || baseType.IsArray || (baseType.Namespace != null && baseType.Namespace.StartsWith("System")))
+            if (baseType == null || baseType.IsArray || baseType.Namespace?.StartsWith("System") == true)
             {
                 return false;
             }


### PR DESCRIPTION
**Fixes:** 

**Summary:** Sometimes, the registered Javascript object does not have a namespace, at this time this function will throw a ```NullReferenceException```.

**Changes:** 
      - Add null reference check for IsComplexType function 
      
**How Has This Been Tested?**  
This problem is obvious and does not need to be tested 

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
