### PR TITLE
Add ChromeRuntime property to RefAssembly CefSharp.Core.Runtime.netcore

### DIFF
--- a/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
+++ b/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
@@ -110,6 +110,7 @@ namespace CefSharp.Core
         public string CachePath { get { throw null; } set { } }
         public CefSharp.Internals.CommandLineArgDictionary CefCommandLineArgs { get { throw null; } }
         public System.Collections.Generic.IEnumerable<CefSharp.CefCustomScheme> CefCustomSchemes { get { throw null; } }
+        public bool ChromeRuntime { get { throw null; } set { } }
         public bool CommandLineArgsDisabled { get { throw null; } set { } }
         public bool ExternalMessagePump { get { throw null; } set { } }
         public bool IgnoreCertificateErrors { get { throw null; } set { } }


### PR DESCRIPTION
**Summary:**
   - I build the netcore projects and this property got added automatically. Looks like it was missed in https://github.com/cefsharp/CefSharp/commit/94fb45766de8e0b809bc9ef9195c4e0a9259919f