### PR TITLE
JavascriptBinding - Add JavascriptBindingSettings.JavascriptBindingApiEnabled property

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -28,6 +28,7 @@ namespace CefSharp
             gcroot<ConcurrentDictionary<int, CefBrowserWrapper^>^> _browserWrappers;
             bool _focusedNodeChangedEnabled;
             bool _legacyBindingEnabled;
+            bool _jsBindingApiEnabled = true;
 
             // The property names used to call bound objects
             CefString _jsBindingPropertyName;

--- a/CefSharp.Core.Runtime/ManagedCefBrowserAdapter.cpp
+++ b/CefSharp.Core.Runtime/ManagedCefBrowserAdapter.cpp
@@ -41,14 +41,15 @@ namespace CefSharp
             }
 
             auto objectRepository = _javaScriptObjectRepository;
+            auto objectRepositorySettings = objectRepository->Settings;
 
             //It's no longer possible to change these settings
-            objectRepository->Settings->Freeze();
+            objectRepositorySettings->Freeze();
 
             CefRefPtr<CefDictionaryValue> extraInfo = CefDictionaryValue::Create();
             auto legacyBindingEnabled = false;
 
-            if (objectRepository->Settings->LegacyBindingEnabled)
+            if (objectRepositorySettings->LegacyBindingEnabled)
             {
                 auto legacyBoundObjects = objectRepository->GetLegacyBoundObjects();
 
@@ -67,9 +68,9 @@ namespace CefSharp
 
             extraInfo->SetBool("LegacyBindingEnabled", legacyBindingEnabled);
 
-            if (!String::IsNullOrEmpty(objectRepository->Settings->JavascriptBindingApiGlobalObjectName))
+            if (!String::IsNullOrEmpty(objectRepositorySettings->JavascriptBindingApiGlobalObjectName))
             {
-                auto globalObjName = objectRepository->Settings->JavascriptBindingApiGlobalObjectName;
+                auto globalObjName = objectRepositorySettings->JavascriptBindingApiGlobalObjectName;
 
                 if (StringCheck::IsFirstCharacterLowercase(globalObjName))
                 {
@@ -80,6 +81,8 @@ namespace CefSharp
                     extraInfo->SetString("JsBindingPropertyName", StringUtils::ToNative(globalObjName));
                 }
             }
+
+            extraInfo->SetBool("JavascriptBindingApiEnabled", objectRepositorySettings->JavascriptBindingApiEnabled);
 
             CefRefPtr<CefRequestContext> requestCtx;
 

--- a/CefSharp.Test/CefSharpFixture.cs
+++ b/CefSharp.Test/CefSharpFixture.cs
@@ -51,6 +51,7 @@ namespace CefSharp.Test
                 //HTML5 databases such as localStorage will only persist across sessions if a cache path is specified. 
                 settings.CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Tests\\Cache");
                 settings.RootCachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Tests");
+                //settings.CefCommandLineArgs.Add("renderer-startup-dialog");
 
                 Cef.Initialize(settings, performDependencyCheck: false, browserProcessHandler: null);
             }

--- a/CefSharp.Test/JavascriptBinding/IntegrationTestFacts.cs
+++ b/CefSharp.Test/JavascriptBinding/IntegrationTestFacts.cs
@@ -140,6 +140,54 @@ namespace CefSharp.Test.JavascriptBinding
             }
         }
 
+        [Fact]
+        public async Task JsBindingGlobalApiDisabled()
+        {
+            using (var browser = new ChromiumWebBrowser(CefExample.BindingApiCustomObjectNameTestUrl, automaticallyCreateBrowser: false))
+            {
+                var settings = browser.JavascriptObjectRepository.Settings;
+                settings.JavascriptBindingApiEnabled = false;
+
+                //To modify the settings we need to defer browser creation slightly
+                browser.CreateBrowser();
+
+                await browser.LoadPageAsync();
+
+                var response1 = await browser.EvaluateScriptAsync("typeof window.cefSharp === 'undefined'");
+                var response2 = await browser.EvaluateScriptAsync("typeof window.CefSharp === 'undefined'");
+
+                Assert.True(response1.Success);
+                Assert.True((bool)response1.Result);
+
+                Assert.True(response2.Success);
+                Assert.True((bool)response2.Result);
+            }
+        }
+
+        [Fact]
+        public async Task JsBindingGlobalApiEnabled()
+        {
+            using (var browser = new ChromiumWebBrowser(CefExample.BindingApiCustomObjectNameTestUrl, automaticallyCreateBrowser: false))
+            {
+                var settings = browser.JavascriptObjectRepository.Settings;
+                settings.JavascriptBindingApiEnabled = true;
+
+                //To modify the settings we need to defer browser creation slightly
+                browser.CreateBrowser();
+
+                await browser.LoadPageAsync();
+
+                var response1 = await browser.EvaluateScriptAsync("typeof window.cefSharp === 'undefined'");
+                var response2 = await browser.EvaluateScriptAsync("typeof window.CefSharp === 'undefined'");
+
+                Assert.True(response1.Success);
+                Assert.False((bool)response1.Result);
+
+                Assert.True(response2.Success);
+                Assert.False((bool)response2.Result);
+            }
+        }
+
         [Theory]
         [InlineData("CefSharp.RenderProcessId")]
         [InlineData("cefSharp.renderProcessId")]

--- a/CefSharp/JavascriptBinding/JavascriptBindingSettings.cs
+++ b/CefSharp/JavascriptBinding/JavascriptBindingSettings.cs
@@ -14,6 +14,24 @@ namespace CefSharp.JavascriptBinding
         private bool alwaysInterceptAsynchronously;
         private bool legacyBindingEnabled;
         private string jsBindingGlobalObjectName;
+        private bool jsBindingApiEnabled = true;
+
+        /// <summary>
+        /// The Javascript methods that CefSharp provides in relation to JavaScript Binding are
+        /// created using a Global (window) Object. Settings this property allows you to disable
+        /// the creation of this object. Features like EvaluateScriptAsPromiseAsync that rely on
+        /// the creation of this object will no longer function.
+        /// </summary>
+        public bool JavascriptBindingApiEnabled
+        {
+            get { return jsBindingApiEnabled; }
+            set
+            {
+                ThrowIfFrozen();
+
+                jsBindingApiEnabled = value;
+            }
+        }
 
         /// <summary>
         /// The Javascript methods that CefSharp provides in relation to JavaScript Binding are


### PR DESCRIPTION
**Summary:**
The Javascript methods that CefSharp provides in relation to JavaScript Binding are
  created using a Global (window) Object. Settings this property allows you to disable
  the creation of this object. Features like EvaluateScriptAsPromiseAsync that rely on
  the creation of this object will no longer function.

**Changes:** 
   - Add JavascriptBindingSettings.JavascriptBindingApiEnabled property
   - Added test cases
      
**How Has This Been Tested?**  
- Unit Tests included


**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
