### PR TITLE
WPF - Add support for Shift+AltGr

### DIFF
--- a/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
@@ -394,7 +394,6 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
             SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
             constexpr auto ctrlAlt = (2 | 4);
             constexpr auto shiftCtrlAlt = (1 | 2 | 4);
-
             if (((scan_res >> 8) & 0xFF) == ctrlAlt || ((scan_res >> 8) & 0xFF) == shiftCtrlAlt)
             {
                 keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);

--- a/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
@@ -388,22 +388,17 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
             // https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-vkkeyscanexw
             // ... high-order byte contains the shift state,
             // which can be a combination of the following flag bits.
+            // 1 Either SHIFT key is pressed.
             // 2 Either CTRL key is pressed.
             // 4 Either ALT key is pressed.
             SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
             constexpr auto ctrlAlt = (2 | 4);
             constexpr auto shiftCtrlAlt = (1 | 2 | 4);
 
-            if (((scan_res >> 8) & 0xFF) == ctrlAlt) // ctrl-alt pressed
+            if (((scan_res >> 8) & 0xFF) == ctrlAlt || ((scan_res >> 8) & 0xFF) == shiftCtrlAlt)
             {
                 keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
                 keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
-            }
-            else if (((scan_res >> 8) & 0xFF) == shiftCtrlAlt) // shift-ctrl-alt pressed
-            {
-                keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
-                keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
-                keyEvent.modifiers |= EVENTFLAG_SHIFT_DOWN;
             }
         }
     }

--- a/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
@@ -391,10 +391,19 @@ void CefBrowserHostWrapper::SendKeyEvent(int message, int wParam, int lParam)
             // 2 Either CTRL key is pressed.
             // 4 Either ALT key is pressed.
             SHORT scan_res = ::VkKeyScanExW(wParam, current_layout);
-            if (((scan_res >> 8) & 0xFF) == (2 | 4)) // ctrl-alt pressed
+            constexpr auto ctrlAlt = (2 | 4);
+            constexpr auto shiftCtrlAlt = (1 | 2 | 4);
+
+            if (((scan_res >> 8) & 0xFF) == ctrlAlt) // ctrl-alt pressed
             {
                 keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
                 keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
+            }
+            else if (((scan_res >> 8) & 0xFF) == shiftCtrlAlt) // shift-ctrl-alt pressed
+            {
+                keyEvent.modifiers &= ~(EVENTFLAG_CONTROL_DOWN | EVENTFLAG_ALT_DOWN);
+                keyEvent.modifiers |= EVENTFLAG_ALTGR_DOWN;
+                keyEvent.modifiers |= EVENTFLAG_SHIFT_DOWN;
             }
         }
     }


### PR DESCRIPTION
The handling of AltGr characters in CefBrowsterHostWrapper did not cover capital diacritic letters. This commit adds handling for the Shift + AltGr + modifier combination.

**Fixes: #3626**

**Summary:**
   - I have added support for Shift+AltGr character input in CefSharp WPF

**Changes:** 
   - I have modified the current handling of AltGr characters in the CefBrowsterHostWrapper class by extending support to Shift+Ctrl+Alt combination
      
**How Has This Been Tested?**  
   - ran CefSharp.WPF.Example
   - navigate to www.google.com
   - enter capital polish letters (Shift + AltGr + EOASLZXCN) 
   - enter small polish letters (AltGr + eoaslzxcn), 
   - enter special characters (Shift + 1-9)

**Screenshots (if appropriate):**
![obraz](https://user-images.githubusercontent.com/23400464/122350883-e79a1b80-cf4d-11eb-8eeb-6b39d027de2a.png)


**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
