### PR TITLE
WPF - Fix WpfIMEKeyboardHandler crash when browser is not initalized.

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -190,7 +190,7 @@ namespace CefSharp.Wpf.Experimental
         {
             handled = false;
 
-            if (!isActive || !isSetup || owner == null || owner.IsDisposed || owner.GetBrowserHost() == null)
+            if (!isActive || !isSetup || owner == null || owner.IsDisposed || !owner.IsBrowserInitialized || owner.GetBrowserHost() == null)
             {
                 return IntPtr.Zero;
             }


### PR DESCRIPTION
**Fixes:**
`GetBrowserHost` will throw exception when browser is not initalized.

**Summary:**
Check `IsBrowserInitialized` before `GetBrowserHost`

**Changes:**
Check `IsBrowserInitialized` before `GetBrowserHost`
      
**How Has This Been Tested?** 
Set `ChromiumWebBrowser.WpfKeyboardHandler` to `WpfIMEKeyboardHandler` and test with CefSharp.Wpf.Example.

**Screenshots (if appropriate):**

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
