### PR TITLE
Updated example for Audio Handler

### DIFF
--- a/CefSharp.Example/CefSharp.Example.csproj
+++ b/CefSharp.Example/CefSharp.Example.csproj
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -39,6 +40,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +51,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -59,6 +62,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/CefSharp.Example/CefSharp.Example.netcore.csproj
+++ b/CefSharp.Example/CefSharp.Example.netcore.csproj
@@ -16,17 +16,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/CefSharp.Example/CefSharp.Example.netcore.csproj
+++ b/CefSharp.Example/CefSharp.Example.netcore.csproj
@@ -17,6 +17,15 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/CefSharp.Example/Handlers/AudioHandler.cs
+++ b/CefSharp.Example/Handlers/AudioHandler.cs
@@ -2,15 +2,14 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
-using CefSharp;
 using CefSharp.Enums;
-using CefSharp.Handler;
+using CefSharp.Structs;
 using System;
 using System.IO;
 
 namespace CefSharp.Example.Handlers
 {
-    public class AudioHandlerExample : AudioHandler
+    public class AudioHandler : Handler.AudioHandler
     {
         private readonly string pathToSaveAudioData;
         private ChannelLayout channelLayout;
@@ -18,20 +17,20 @@ namespace CefSharp.Example.Handlers
         private int sampleRate;
         private readonly FileStream rawAudioFile;
 
-        public AudioHandlerExample(string path) : base()
+        public AudioHandler(string path) : base()
         {
             // The output file with raw audio data (PCM, 32-bit, float) will be saved in this path
             this.pathToSaveAudioData = path;
             this.rawAudioFile = new FileStream(this.pathToSaveAudioData, FileMode.Create, FileAccess.Write);
         }
 
-        protected override bool GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref CefSharp.Structs.AudioParameters parameters)
+        protected override bool GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref AudioParameters parameters)
         {
             // return true to activate audio stream capture
             return true;
         }
 
-        protected override void OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, CefSharp.Structs.AudioParameters parameters, int channels)
+        protected override void OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, AudioParameters parameters, int channels)
         {
             this.channelLayout = parameters.ChannelLayout;
             this.sampleRate = parameters.SampleRate;

--- a/CefSharp.Example/Handlers/AudioHandler.cs
+++ b/CefSharp.Example/Handlers/AudioHandler.cs
@@ -11,7 +11,6 @@ namespace CefSharp.Example.Handlers
 {
     public class AudioHandler : Handler.AudioHandler
     {
-        private readonly string pathToSaveAudioData;
         private ChannelLayout channelLayout;
         private int channelCount;
         private int sampleRate;
@@ -20,8 +19,7 @@ namespace CefSharp.Example.Handlers
         public AudioHandler(string path) : base()
         {
             // The output file with raw audio data (PCM, 32-bit, float) will be saved in this path
-            this.pathToSaveAudioData = path;
-            this.rawAudioFile = new FileStream(this.pathToSaveAudioData, FileMode.Create, FileAccess.Write);
+            this.rawAudioFile = new FileStream(path, FileMode.Create, FileAccess.Write);
         }
 
         protected override bool GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref AudioParameters parameters)
@@ -63,11 +61,8 @@ namespace CefSharp.Example.Handlers
                             *pDest++ = channelData[c][i];
                         }
                     }
-
-                    var ustream = new UnmanagedMemoryStream(pDestByte, size);
-                    ustream.CopyTo(rawAudioFile);
-                    ustream.Close();
                 }
+                rawAudioFile.Write(samples, 0, size);
             }
         }
 

--- a/CefSharp.Example/Handlers/AudioHandler.cs
+++ b/CefSharp.Example/Handlers/AudioHandler.cs
@@ -2,29 +2,36 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
-using System;
+using CefSharp;
 using CefSharp.Enums;
-using CefSharp.Structs;
+using CefSharp.Handler;
+using System;
+using System.IO;
 
 namespace CefSharp.Example.Handlers
 {
-    public class AudioHandler : Handler.AudioHandler
+    public class AudioHandlerExample : AudioHandler
     {
+        private readonly string pathToSaveAudioData;
         private ChannelLayout channelLayout;
         private int channelCount;
         private int sampleRate;
+        private readonly FileStream rawAudioFile;
 
-        protected override bool GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref AudioParameters parameters)
+        public AudioHandlerExample(string path) : base()
         {
-            //Cancel Capture
-            return false;
-        }
-        protected override void OnAudioStreamError(IWebBrowser chromiumWebBrowser, IBrowser browser, string errorMessage)
-        {
-            base.OnAudioStreamError(chromiumWebBrowser, browser, errorMessage);
+            // The output file with raw audio data (PCM, 32-bit, float) will be saved in this path
+            this.pathToSaveAudioData = path;
+            this.rawAudioFile = new FileStream(this.pathToSaveAudioData, FileMode.Create, FileAccess.Write);
         }
 
-        protected override void OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, AudioParameters parameters, int channels)
+        protected override bool GetAudioParameters(IWebBrowser chromiumWebBrowser, IBrowser browser, ref CefSharp.Structs.AudioParameters parameters)
+        {
+            // return true to activate audio stream capture
+            return true;
+        }
+
+        protected override void OnAudioStreamStarted(IWebBrowser chromiumWebBrowser, IBrowser browser, CefSharp.Structs.AudioParameters parameters, int channels)
         {
             this.channelLayout = parameters.ChannelLayout;
             this.sampleRate = parameters.SampleRate;
@@ -33,10 +40,36 @@ namespace CefSharp.Example.Handlers
 
         protected override void OnAudioStreamPacket(IWebBrowser chromiumWebBrowser, IBrowser browser, IntPtr data, int noOfFrames, long pts)
         {
-            //NOTE: data is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s)
-            //Based on and the channelLayout value passed to IAudioHandler.OnAudioStreamStarted
-            //you can calculate the size of the data array in bytes.
-            //See https://github.com/cefsharp/CefSharp/issues/2806 for discussion on implementing an example.
+            /*
+             * NOTE: data is an array representing the raw PCM data as a floating point type, i.e. 4-byte value(s)
+             * Based on noOfFrames and the channels value passed to IAudioHandler.OnAudioStreamStarted
+             * you can calculate the size of the data array in bytes.
+             * 
+             * Audio data (PCM, 32-bit, float) will be save to rawAudioFile stream.
+             */
+
+            unsafe
+            {
+                float** channelData = (float**)data.ToPointer();
+                int size = channelCount * noOfFrames * 4;
+                byte[] samples = new byte[size];
+                fixed (byte* pDestByte = samples)
+                {
+                    float* pDest = (float*)pDestByte;
+
+                    for (int i = 0; i < noOfFrames; i++)
+                    {
+                        for (int c = 0; c < channelCount; c++)
+                        {
+                            *pDest++ = channelData[c][i];
+                        }
+                    }
+
+                    var ustream = new UnmanagedMemoryStream(pDestByte, size);
+                    ustream.CopyTo(rawAudioFile);
+                    ustream.Close();
+                }
+            }
         }
 
         protected override void OnAudioStreamStopped(IWebBrowser chromiumWebBrowser, IBrowser browser)
@@ -44,8 +77,14 @@ namespace CefSharp.Example.Handlers
             base.OnAudioStreamStopped(chromiumWebBrowser, browser);
         }
 
+        protected override void OnAudioStreamError(IWebBrowser chromiumWebBrowser, IBrowser browser, string errorMessage)
+        {
+            base.OnAudioStreamError(chromiumWebBrowser, browser, errorMessage);
+        }
+
         protected override void Dispose(bool disposing)
         {
+            rawAudioFile.Close();
             base.Dispose(disposing);
         }
     }

--- a/CefSharp.WinForms.Example/BrowserTabUserControl.cs
+++ b/CefSharp.WinForms.Example/BrowserTabUserControl.cs
@@ -41,7 +41,7 @@ namespace CefSharp.WinForms.Example
             browser.RequestHandler = new WinFormsRequestHandler(openNewTab);
             browser.JsDialogHandler = new JsDialogHandler();
             browser.DownloadHandler = new DownloadHandler();
-            browser.AudioHandler = new AudioHandler();
+            browser.AudioHandler = new CefSharp.Handler.AudioHandler();
 
             if (multiThreadedMessageLoopEnabled)
             {

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -132,7 +132,7 @@ namespace CefSharp.Wpf.Example.Views
             downloadHandler.OnBeforeDownloadFired += OnBeforeDownloadFired;
             downloadHandler.OnDownloadUpdatedFired += OnDownloadUpdatedFired;
             browser.DownloadHandler = downloadHandler;
-            browser.AudioHandler = new AudioHandler();
+            browser.AudioHandler = new CefSharp.Handler.AudioHandler();
 
             //Read an embedded bitmap into a memory stream then register it as a resource you can then load custom://cefsharp/images/beach.jpg
             var beachImageStream = new MemoryStream();


### PR DESCRIPTION
**Fixes:** #2806

**Summary:** I have updated example for Audio Handler

**Changes:**
   - Overrided GetAudioParameters method. return true to activate audio stream capture
   - Overrided OnAudioStreamPacket method. Data from data pointer converted to PCM, 32-bit, float and written to file.
      
**How Has This Been Tested?**  
I tested AudioHandler example class in my application. Application has Offscreen type.
In my application used Nuget packet CefSharp.OffScreen, v91.1.211
PC: Windows 10, AMD Ryzen 7, 3700X, NVidia GT1030, RAM 32GB
Visual Studio 2019 Community

**Screenshots (if appropriate):**

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
