### PR TITLE
WPF - Accessibility check for "ax_tree_id" key and avoid referencing IValue in class member

### DIFF
--- a/CefSharp.Wpf/Experimental/Accessibility/AccessibilityHandler.cs
+++ b/CefSharp.Wpf/Experimental/Accessibility/AccessibilityHandler.cs
@@ -58,6 +58,11 @@ namespace CefSharp.Wpf.Experimental.Accessibility
             }
 
             var accessibilityUpdateDictionary = value.GetDictionary();
+            if (accessibilityUpdateDictionary == null || !accessibilityUpdateDictionary.ContainsKey("ax_tree_id"))
+            {
+                return;
+            }
+
             string treeId = accessibilityUpdateDictionary["ax_tree_id"].GetString();
 
             owner.Dispatcher.Invoke(new Action(() =>

--- a/CefSharp.Wpf/Experimental/Accessibility/AccessibilityNode.cs
+++ b/CefSharp.Wpf/Experimental/Accessibility/AccessibilityNode.cs
@@ -25,7 +25,6 @@ namespace CefSharp.Wpf.Experimental.Accessibility
         private CefSharp.Structs.Point scroll;
         private int offsetContainerId = -1;
         private HashSet<int> childIds;
-        private IDictionary<string, IValue> attributes;
 
         // Mapping implemented according to the following link
         // https://docs.microsoft.com/en-us/windows/desktop/winauto/uiauto-ariaspecification
@@ -251,7 +250,7 @@ namespace CefSharp.Wpf.Experimental.Accessibility
 
             if (node.ContainsKey("attributes"))
             {
-                attributes = node["attributes"].GetDictionary();
+                IDictionary<string, IValue> attributes = node["attributes"].GetDictionary();
                 if (attributes != null)
                 {
                     if (attributes.ContainsKey("name"))

--- a/CefSharp.Wpf/Experimental/Accessibility/AccessibilityTree.cs
+++ b/CefSharp.Wpf/Experimental/Accessibility/AccessibilityTree.cs
@@ -50,7 +50,7 @@ namespace CefSharp.Wpf.Experimental.Accessibility
 
         public virtual void Update(IDictionary<string, IValue> accessibilityUpdateDictionary)
         {
-            if (accessibilityUpdateDictionary == null || !accessibilityUpdateDictionary.ContainsKey("events"))
+            if (accessibilityUpdateDictionary == null || !accessibilityUpdateDictionary.ContainsKey("events") || !accessibilityUpdateDictionary.ContainsKey("updates"))
             {
                 return;
             }


### PR DESCRIPTION
**Fixes:** #3766

**Summary:**
   - Added `ContainsKey` check for `ax_tree_id` to avoid `KeyNotFoundException`.
   - Convert class member `attributes` to a local variable to avoid `SEHException` when browser gets closed.

<details>
<summary>SEHException (in german)</summary>

```
System.Runtime.InteropServices.SEHException
  HResult=0x80004005
  Nachricht = Eine externe Komponente hat eine Ausnahme ausgelöst.
  Quelle = <Die Ausnahmequelle kann nicht ausgewertet werden.>
  Stapelüberwachung:
<Die Ausnahmestapelüberwachung kann nicht ausgewertet werden.>

  Diese Ausnahme wurde ursprünglich von dieser Aufrufliste ausgelöst:
    CefSharp::Internals::MCefRefPtr<CefValue>::!MCefRefPtr<CefValue>(void) in MCefRefPtr.h
    [Externer Code]
```

</details>
      
**How Has This Been Tested?**  
Manually with WPF example.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
