### PR TITLE
DevTools - Add GetNextDevToolsMessageId to IBrowserHost

### DIFF
--- a/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.cpp
@@ -270,6 +270,11 @@ IRegistration^ CefBrowserHostWrapper::AddDevToolsMessageObserver(IDevToolsMessag
     return gcnew CefRegistrationWrapper(registration);
 }
 
+int CefBrowserHostWrapper::GetNextDevToolsMessageId()
+{
+    return Interlocked::Increment(_lastDevToolsMessageId);
+}
+
 void CefBrowserHostWrapper::AddWordToDictionary(String^ word)
 {
     ThrowIfDisposed();

--- a/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.h
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserHostWrapper.h
@@ -21,6 +21,7 @@ namespace CefSharp
         {
         private:
             MCefRefPtr<CefBrowserHost> _browserHost;
+            int _lastDevToolsMessageId = 0;
 
             double GetZoomLevelOnUI();
 
@@ -75,6 +76,7 @@ namespace CefSharp
             virtual int ExecuteDevToolsMethod(int messageId, String^ method, String^ paramsAsJson);
             virtual int ExecuteDevToolsMethod(int messageId, String^ method, IDictionary<String^, Object^>^ paramaters);
             virtual IRegistration^ AddDevToolsMessageObserver(IDevToolsMessageObserver^ observer);
+            virtual int GetNextDevToolsMessageId();
 
             virtual void AddWordToDictionary(String^ word);
             virtual void ReplaceMisspelling(String^ word);

--- a/CefSharp/IBrowserHost.cs
+++ b/CefSharp/IBrowserHost.cs
@@ -128,6 +128,13 @@ namespace CefSharp
         int ExecuteDevToolsMethod(int messageId, string method, IDictionary<string, object> parameters = null);
 
         /// <summary>
+        /// Returns the next unique message id which can be used in <see cref="ExecuteDevToolsMethod(int, string, string)"/> or
+        /// <see cref="ExecuteDevToolsMethod(int, string, IDictionary{string, object})"/>.
+        /// </summary>
+        /// <returns>The next unique message id.</returns>
+        int GetNextDevToolsMessageId();
+
+        /// <summary>
         /// Add an observer for DevTools protocol messages (method results and events).
         /// The observer will remain registered until the returned Registration object
         /// is destroyed. See the SendDevToolsMessage documentation for additional


### PR DESCRIPTION
**Fixes:** #3341

**Summary:**
   - Added `GetNextDevToolsMessageId` to `IBrowserHost` to get browser scoped message ids for executing dev tools methods.

**Changes:**
   - Added `IBrowserHost.GetNextDevToolsMessageId` and using it inside of `DevToolsClient`.
      
**How Has This Been Tested?**  
Unittests

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [X] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
