### PR TITLE
Add property Cef.IsShutdown #3782

### DIFF
--- a/CefSharp.Core.Runtime/Cef.h
+++ b/CefSharp.Core.Runtime/Cef.h
@@ -94,6 +94,16 @@ namespace CefSharp
                 }
             }
 
+            /// <summary>Gets a value that indicates whether CefSharp was shutdown.</summary>
+            /// <value>true if CefSharp was shutdown; otherwise, false.</value>
+            static property bool IsShutdown
+            {
+                bool get()
+                {
+                    return _hasShutdown;
+                }
+            }
+
             /// <summary>Gets a value that indicates the version of CefSharp currently being used.</summary>
             /// <value>The CefSharp version.</value>
             static property String^ CefSharpVersion

--- a/CefSharp.Core/Cef.cs
+++ b/CefSharp.Core/Cef.cs
@@ -47,6 +47,13 @@ namespace CefSharp
             get { return Core.Cef.IsInitialized; }
         }
 
+        /// <summary>Gets a value that indicates whether CefSharp was shutdown.</summary>
+        /// <value>true if CefSharp was shutdown; otherwise, false.</value>
+        public static bool IsShutdown
+        {
+            get { return Core.Cef.IsShutdown; }
+        }
+
         /// <summary>Gets a value that indicates the version of CefSharp currently being used.</summary>
         /// <value>The CefSharp version.</value>
         public static string CefSharpVersion


### PR DESCRIPTION
Add property Cef.IsShutdown to allow checks for the shutdown state of Cef runtime (#3782)

… Cef runtime (#3782)

**Fixes:** #3782

**Summary:** Cef object will exponse the private `_hasShutdown` field as `IsShutdown` property.
    
**How Has This Been Tested?**  
Manual test of the code.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
