### PR TITLE
Fix for arrays with empty elements

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
@@ -59,15 +59,12 @@ namespace CefSharp
                 else if (obj->IsArray())
                 {
                     int arrLength = obj->GetArrayLength();
-                    std::vector<CefString> keys;
                     auto array = CefListValue::Create();
-                    if (arrLength > 0 && obj->GetKeys(keys))
+                    if (arrLength > 0)
                     {
-                        int index = 0;
                         for (int i = 0; i < arrLength; i++)
                         {
-                            if (obj->HasValue(i))
-                                SerializeV8Object(obj->GetValue(keys[index++]), array, i, callbackRegistry, seen);
+                            SerializeV8Object(obj->GetValue(i), array, i, callbackRegistry, seen);
                         }
                     }
 

--- a/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
@@ -63,11 +63,12 @@ namespace CefSharp
                     auto array = CefListValue::Create();
                     if (arrLength > 0 && obj->GetKeys(keys))
                     {
+                        int index = 0;
                         for (int i = 0; i < arrLength; i++)
                         {
-                            SerializeV8Object(obj->GetValue(keys[i]), array, i, callbackRegistry, seen);
+                            if (obj->HasValue(i))
+                                SerializeV8Object(obj->GetValue(keys[index++]), array, i, callbackRegistry, seen);
                         }
-
                     }
 
                     list->SetList(index, array);

--- a/CefSharp.Test/JavascriptBinding/IntegrationTestFacts.cs
+++ b/CefSharp.Test/JavascriptBinding/IntegrationTestFacts.cs
@@ -230,5 +230,28 @@ namespace CefSharp.Test.JavascriptBinding
                 Assert.Equal(JavascriptObjectRepository.AllObjects, evt.Arguments.ObjectName);
             }
         }
+
+        [Fact]
+        public async Task CanSerializePartiallyEmptyArrays()
+        {
+            using (var browser = new ChromiumWebBrowser(CefExample.HelloWorldUrl))
+            {
+                var testCases = new[]
+                {
+                    ("[1,2,,5]", new object[] { 1, 2, null, 5 }),
+                    ("[1,2,,]", new object[] { 1, 2, null }),
+                    ("[,2,3]", new object[] { null, 2, 3 }),
+                    ("[,2,,3,,4,,,,5,,,]", new object[] {null, 2, null, 3, null, 4, null, null, null, 5, null, null })
+                };
+                await browser.LoadUrlAsync();
+                foreach (var testCase in testCases)
+                {
+                    var result = await browser.EvaluateScriptAsync(testCase.Item1);
+
+                    Assert.True(result.Success);
+                    Assert.Equal(testCase.Item2, result.Result);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
**Fixes:**
 Resolves #3808

**Summary:** [summary of the change and which issue is fixed here]
   - Array serialization now correctly handles empty elements within the source array

**Changes:** [specify the structures changed] 
   -No structural changes - use HasValue to check if an element is empty
      
**How Has This Been Tested?**  
Used WinForms example with several inputs to try and break it but - it works.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
