### PR TITLE
WPF - Add System.Windows.Controls.ContextMenu based ContextMenuHandler

### DIFF
--- a/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
@@ -4,15 +4,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
 
 namespace CefSharp.Wpf.Example.Handlers
 {
-    public class MenuHandler : IContextMenuHandler
+    public class MenuHandler : CefSharp.Wpf.Handler.ContextMenuHandler
     {
-        void IContextMenuHandler.OnBeforeContextMenu(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
+        public MenuHandler(bool addDevtoolsMenuItems = false) : base(addDevtoolsMenuItems)
+        {
+        }
+
+        protected override void OnBeforeContextMenu(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
         {
             Console.WriteLine("Context menu opened");
             Console.WriteLine(parameters.MisspelledWord);
@@ -22,15 +23,14 @@ namespace CefSharp.Wpf.Example.Handlers
                 model.AddSeparator();
             }
 
-            model.AddItem((CefMenuCommand)26501, "Show DevTools");
-            model.AddItem((CefMenuCommand)26502, "Close DevTools");
-
+            //For this menu handler 26501 and 26502 are used by the Show/Close DevTools commands
+            model.AddItem((CefMenuCommand)26503, "Do Something");
 
             //To disable context mode then clear
             // model.Clear();
         }
 
-        bool IContextMenuHandler.OnContextMenuCommand(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, CefMenuCommand commandId, CefEventFlags eventFlags)
+        protected override bool OnContextMenuCommand(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, CefMenuCommand commandId, CefEventFlags eventFlags)
         {
             if (commandId == (CefMenuCommand)26501)
             {
@@ -46,175 +46,16 @@ namespace CefSharp.Wpf.Example.Handlers
             return false;
         }
 
-        void IContextMenuHandler.OnContextMenuDismissed(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame)
+        protected override void ExecuteCommand(IBrowser browser, CefMenuCommand menuCommand, IList<string> dictionarySuggestions, int xCoord, int yCoord, string selectionText, string misspelledWord)
         {
-            var webBrowser = (ChromiumWebBrowser)chromiumWebBrowser;
-
-            webBrowser.Dispatcher.Invoke(() =>
+            //Custom item
+            if (menuCommand == (CefMenuCommand)26503)
             {
-                webBrowser.ContextMenu = null;
-            });
-        }
-
-        bool IContextMenuHandler.RunContextMenu(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model, IRunContextMenuCallback callback)
-        {
-            //NOTE: Return false to use the built in Context menu - in WPF this requires you integrate into your existing message loop, read the General Usage Guide for more details
-            //https://github.com/cefsharp/CefSharp/wiki/General-Usage#multithreadedmessageloop
-            //return false;
-
-            var webBrowser = (ChromiumWebBrowser)chromiumWebBrowser;
-
-            //IMenuModel is only valid in the context of this method, so need to read the values before invoking on the UI thread
-            var menuItems = GetMenuItems(model).ToList();
-
-            webBrowser.Dispatcher.Invoke(() =>
+                Console.WriteLine("Custom menu used");
+            }
+            else
             {
-                var menu = new ContextMenu
-                {
-                    IsOpen = true
-                };
-
-                RoutedEventHandler handler = null;
-
-                handler = (s, e) =>
-                {
-                    menu.Closed -= handler;
-
-                    //If the callback has been disposed then it's already been executed
-                    //so don't call Cancel
-                    if (!callback.IsDisposed)
-                    {
-                        callback.Cancel();
-                    }
-                };
-
-                menu.Closed += handler;
-
-                foreach (var item in menuItems)
-                {
-                    if (item.Item2 == CefMenuCommand.NotFound && string.IsNullOrWhiteSpace(item.Item1))
-                    {
-                        menu.Items.Add(new Separator());
-                        continue;
-                    }
-
-                    menu.Items.Add(new MenuItem
-                    {
-                        Header = item.Item1.Replace("&", "_"),
-                        IsEnabled = item.Item3,
-                        Command = new RelayCommand(() =>
-                        {
-                            //BUG: CEF currently not executing callbacks correctly so we manually map the commands below
-                            //see https://github.com/cefsharp/CefSharp/issues/1767
-                            //The following line worked in previous versions, it doesn't now, so custom EXAMPLE below
-                            //callback.Continue(item.Item2, CefEventFlags.None);
-
-                            //NOTE: Note all menu item options below have been tested, you can work out the rest
-                            switch (item.Item2)
-                            {
-                                case CefMenuCommand.Back:
-                                {
-                                    browser.GoBack();
-                                    break;
-                                }
-                                case CefMenuCommand.Forward:
-                                {
-                                    browser.GoForward();
-                                    break;
-                                }
-                                case CefMenuCommand.Cut:
-                                {
-                                    browser.FocusedFrame.Cut();
-                                    break;
-                                }
-                                case CefMenuCommand.Copy:
-                                {
-                                    browser.FocusedFrame.Copy();
-                                    break;
-                                }
-                                case CefMenuCommand.Paste:
-                                {
-                                    browser.FocusedFrame.Paste();
-                                    break;
-                                }
-                                case CefMenuCommand.Print:
-                                {
-                                    browser.GetHost().Print();
-                                    break;
-                                }
-                                case CefMenuCommand.ViewSource:
-                                {
-                                    browser.FocusedFrame.ViewSource();
-                                    break;
-                                }
-                                case CefMenuCommand.Undo:
-                                {
-                                    browser.FocusedFrame.Undo();
-                                    break;
-                                }
-                                case CefMenuCommand.StopLoad:
-                                {
-                                    browser.StopLoad();
-                                    break;
-                                }
-                                case CefMenuCommand.SelectAll:
-                                {
-                                    browser.FocusedFrame.SelectAll();
-                                    break;
-                                }
-                                case CefMenuCommand.Redo:
-                                {
-                                    browser.FocusedFrame.Redo();
-                                    break;
-                                }
-                                case CefMenuCommand.Find:
-                                {
-                                    browser.GetHost().Find(0, parameters.SelectionText, true, false, false);
-                                    break;
-                                }
-                                case CefMenuCommand.AddToDictionary:
-                                {
-                                    browser.GetHost().AddWordToDictionary(parameters.MisspelledWord);
-                                    break;
-                                }
-                                case CefMenuCommand.Reload:
-                                {
-                                    browser.Reload();
-                                    break;
-                                }
-                                case CefMenuCommand.ReloadNoCache:
-                                {
-                                    browser.Reload(ignoreCache: true);
-                                    break;
-                                }
-                                case (CefMenuCommand)26501:
-                                {
-                                    browser.GetHost().ShowDevTools();
-                                    break;
-                                }
-                                case (CefMenuCommand)26502:
-                                {
-                                    browser.GetHost().CloseDevTools();
-                                    break;
-                                }
-                            }
-                        })
-                    });
-                }
-                webBrowser.ContextMenu = menu;
-            });
-
-            return true;
-        }
-
-        private static IEnumerable<Tuple<string, CefMenuCommand, bool>> GetMenuItems(IMenuModel model)
-        {
-            for (var i = 0; i < model.Count; i++)
-            {
-                var header = model.GetLabelAt(i);
-                var commandId = model.GetCommandIdAt(i);
-                var isEnabled = model.IsEnabledAt(i);
-                yield return new Tuple<string, CefMenuCommand, bool>(header, commandId, isEnabled);
+                base.ExecuteCommand(browser, menuCommand, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord);
             }
         }
     }

--- a/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using CefSharp.Wpf.Handler;
 
 namespace CefSharp.Wpf.Example.Handlers
 {
@@ -46,16 +47,16 @@ namespace CefSharp.Wpf.Example.Handlers
             return false;
         }
 
-        protected override void ExecuteCommand(IBrowser browser, CefMenuCommand menuCommand, IList<string> dictionarySuggestions, int xCoord, int yCoord, string selectionText, string misspelledWord)
+        protected override void ExecuteCommand(IBrowser browser, ContextMenuExecuteModel model)
         {
             //Custom item
-            if (menuCommand == (CefMenuCommand)26503)
+            if (model.MenuCommand == (CefMenuCommand)26503)
             {
                 Console.WriteLine("Custom menu used");
             }
             else
             {
-                base.ExecuteCommand(browser, menuCommand, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord);
+                base.ExecuteCommand(browser, model);
             }
         }
     }

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -115,7 +115,7 @@ namespace CefSharp.Wpf.Example.Views
             //This LifeSpanHandler implementaion demos hosting a popup in a ChromiumWebBrowser
             //instance, it's still considered Experimental
             //browser.LifeSpanHandler = new ExperimentalLifespanHandler();
-            browser.MenuHandler = new MenuHandler();
+            browser.MenuHandler = new MenuHandler(addDevtoolsMenuItems:true);
 
             //Enable experimental Accessibility support 
             browser.AccessibilityHandler = new AccessibilityHandler(browser);

--- a/CefSharp.Wpf/Handler/ContextMenuExecuteModel.cs
+++ b/CefSharp.Wpf/Handler/ContextMenuExecuteModel.cs
@@ -1,0 +1,58 @@
+// Copyright © 2021 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Collections.Generic;
+
+namespace CefSharp.Wpf.Handler
+{
+    /// <summary>
+    /// ContextMenuExecuteModel
+    /// </summary>
+    public class ContextMenuExecuteModel
+    {
+        /// <summary>
+        /// Menu Command
+        /// </summary>
+        public CefMenuCommand MenuCommand { get; private set; }
+        /// <summary>
+        /// Dictioanry Suggestions
+        /// </summary>
+        public IList<string> DictionarySuggestions { get; private set; }
+        /// <summary>
+        /// X Coordinate
+        /// </summary>
+        public int XCoord { get; private set; }
+        /// <summary>
+        /// Y Coordinate
+        /// </summary>
+        public int YCoord { get; private set; }
+        /// <summary>
+        /// Selection Text
+        /// </summary>
+        public string SelectionText { get; private set; }
+        /// <summary>
+        /// Misspelled Word
+        /// </summary>
+        public string MisspelledWord { get; private set; }
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="menuCommand">menu command</param>
+        /// <param name="dictionarySuggestions">dictioanry suggestion</param>
+        /// <param name="xCoord">x coordinate</param>
+        /// <param name="yCoord">y coordinate</param>
+        /// <param name="selectionText">selection text</param>
+        /// <param name="misspelledWord">misspelled word</param>
+        public ContextMenuExecuteModel(CefMenuCommand menuCommand, IList<string> dictionarySuggestions, int xCoord, int yCoord, string selectionText, string misspelledWord)
+        {
+            MenuCommand = menuCommand;
+            DictionarySuggestions = dictionarySuggestions;
+            XCoord = xCoord;
+            YCoord = yCoord;
+            SelectionText = selectionText;
+            MisspelledWord = misspelledWord;
+        }
+    }
+}

--- a/CefSharp.Wpf/Handler/ContextMenuHandler.cs
+++ b/CefSharp.Wpf/Handler/ContextMenuHandler.cs
@@ -129,7 +129,7 @@ namespace CefSharp.Wpf.Handler
                             //see https://github.com/cefsharp/CefSharp/issues/1767
                             //The following line worked in previous versions, it doesn't now, so custom handling below
                             //callback.Continue(item.Item2, CefEventFlags.None);
-                            ExecuteCommand(browser, item.CommandId, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord);
+                            ExecuteCommand(browser, new ContextMenuExecuteModel(item.CommandId, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord));
                         }),
                     };
 
@@ -162,7 +162,7 @@ namespace CefSharp.Wpf.Handler
                                     //see https://github.com/cefsharp/CefSharp/issues/1767
                                     //The following line worked in previous versions, it doesn't now, so custom handling below
                                     //callback.Continue(item.Item2, CefEventFlags.None);
-                                    ExecuteCommand(browser, subItem.CommandId, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord);
+                                    ExecuteCommand(browser, new ContextMenuExecuteModel(subItem.CommandId, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord));
                                 }),
                             };
 
@@ -177,24 +177,24 @@ namespace CefSharp.Wpf.Handler
 
             return true;
         }
-        protected virtual void ExecuteCommand(IBrowser browser, CefMenuCommand menuCommand, IList<string> dictionarySuggestions, int xCoord, int yCoord, string selectionText, string misspelledWord)
+
+        protected virtual void ExecuteCommand(IBrowser browser, ContextMenuExecuteModel model)
         {
             // If the user chose a replacement word for a misspelling, replace it here.
-            if (menuCommand >= CefMenuCommand.SpellCheckSuggestion0 &&
-                menuCommand <= CefMenuCommand.SpellCheckSuggestion4)
+            if (model.MenuCommand >= CefMenuCommand.SpellCheckSuggestion0 &&
+                model.MenuCommand <= CefMenuCommand.SpellCheckSuggestion4)
             {
-                int sugestionIndex = ((int)menuCommand) - (int)CefMenuCommand.SpellCheckSuggestion0;
-                if (sugestionIndex < dictionarySuggestions.Count)
+                int sugestionIndex = ((int)model.MenuCommand) - (int)CefMenuCommand.SpellCheckSuggestion0;
+                if (sugestionIndex < model.DictionarySuggestions.Count)
                 {
-                    var suggestion = dictionarySuggestions[sugestionIndex];
+                    var suggestion = model.DictionarySuggestions[sugestionIndex];
                     browser.ReplaceMisspelling(suggestion);
                 }
 
                 return;
             }
 
-            //NOTE: Note all menu item options below have been tested, you can work out the rest
-            switch (menuCommand)
+            switch (model.MenuCommand)
             {
                 // Navigation.
                 case CefMenuCommand.Back:
@@ -273,20 +273,20 @@ namespace CefSharp.Wpf.Handler
                 }
                 case CefMenuCommand.Find:
                 {
-                    browser.GetHost().Find(0, selectionText, true, false, false);
+                    browser.GetHost().Find(0, model.SelectionText, true, false, false);
                     break;
                 }
 
                 // Spell checking.
                 case CefMenuCommand.AddToDictionary:
                 {
-                    browser.GetHost().AddWordToDictionary(misspelledWord);
+                    browser.GetHost().AddWordToDictionary(model.MisspelledWord);
                     break;
                 }
 
                 case (CefMenuCommand)26501:
                 {
-                    browser.GetHost().ShowDevTools(inspectElementAtX: xCoord, inspectElementAtY: yCoord);
+                    browser.GetHost().ShowDevTools(inspectElementAtX: model.XCoord, inspectElementAtY: model.YCoord);
                     break;
                 }
                 case (CefMenuCommand)26502:

--- a/CefSharp.Wpf/Handler/ContextMenuHandler.cs
+++ b/CefSharp.Wpf/Handler/ContextMenuHandler.cs
@@ -1,0 +1,348 @@
+// Copyright © 2021 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System.Collections.Generic;
+using System.Windows.Controls.Primitives;
+using System.Windows.Controls;
+using System.Windows;
+
+namespace CefSharp.Wpf.Handler
+{
+    /// <summary>
+    /// Implementation of <see cref="IContextMenuHandler"/> that uses a <see cref="ContextMenu"/>
+    /// to display the context menu.
+    /// </summary>
+    public class ContextMenuHandler : CefSharp.Handler.ContextMenuHandler
+    {
+        private readonly bool addDevtoolsMenuItems;
+
+        public ContextMenuHandler(bool addDevtoolsMenuItems = false)
+        {
+            this.addDevtoolsMenuItems = addDevtoolsMenuItems;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnBeforeContextMenu(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
+        {
+            if (addDevtoolsMenuItems)
+            {
+                if (model.Count > 0)
+                {
+                    model.AddSeparator();
+                }
+
+                model.AddItem((CefMenuCommand)26501, "Show DevTools");
+                model.AddItem((CefMenuCommand)26502, "Close DevTools");
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override bool OnContextMenuCommand(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, CefMenuCommand commandId, CefEventFlags eventFlags)
+        {
+            if (commandId == (CefMenuCommand)26501)
+            {
+                browser.GetHost().ShowDevTools();
+                return true;
+            }
+            if (commandId == (CefMenuCommand)26502)
+            {
+                browser.GetHost().CloseDevTools();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnContextMenuDismissed(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame)
+        {
+            var webBrowser = (ChromiumWebBrowser)chromiumWebBrowser;
+
+            webBrowser.UiThreadRunAsync(() =>
+            {
+                webBrowser.ContextMenu = null;
+            });
+        }
+
+
+        /// <inheritdoc/>
+        protected override bool RunContextMenu(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model, IRunContextMenuCallback callback)
+        {
+            var webBrowser = (ChromiumWebBrowser)chromiumWebBrowser;
+
+            //IMenuModel is only valid in the context of this method, so need to read the values before invoking on the UI thread
+            var menuItems = GetMenuItems(model);
+            var dictionarySuggestions = parameters.DictionarySuggestions;
+            var xCoord = parameters.XCoord;
+            var yCoord = parameters.YCoord;
+            var misspelledWord = parameters.MisspelledWord;
+            var selectionText = parameters.SelectionText;
+
+            webBrowser.UiThreadRunAsync(() =>
+            {
+                var menu = new ContextMenu
+                {
+                    IsOpen = true,
+                    Placement = PlacementMode.Mouse
+                };
+
+                RoutedEventHandler handler = null;
+
+                handler = (s, e) =>
+                {
+                    menu.Closed -= handler;
+
+                    //If the callback has been disposed then it's already been executed
+                    //so don't call Cancel
+                    if (!callback.IsDisposed)
+                    {
+                        callback.Cancel();
+                    }
+                };
+
+                menu.Closed += handler;
+
+                foreach (var item in menuItems)
+                {
+                    if (item.CommandId == CefMenuCommand.NotFound)
+                    {
+                        continue;
+                    }
+
+                    if(item.IsSeperator)
+                    {
+                        menu.Items.Add(new Separator());
+
+                        continue;
+                    }
+
+                    var menuItem = new MenuItem
+                    {
+                        Header = item.Label.Replace("&", "_"),
+                        IsEnabled = item.IsEnabled,
+                        IsChecked = item.IsChecked.GetValueOrDefault(),
+                        IsCheckable = item.IsChecked.HasValue,
+                        Command = new DelegateCommand(() =>
+                        {
+                            //BUG: CEF currently not executing callbacks correctly so we manually map the commands below
+                            //see https://github.com/cefsharp/CefSharp/issues/1767
+                            //The following line worked in previous versions, it doesn't now, so custom handling below
+                            //callback.Continue(item.Item2, CefEventFlags.None);
+                            ExecuteCommand(browser, item.CommandId, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord);
+                        }),
+                    };
+
+                    //TODO: Make this recursive and remove duplicate code
+                    if(item.SubMenus != null && item.SubMenus.Count > 0)
+                    {
+                        foreach(var subItem in item.SubMenus)
+                        {
+                            if (subItem.CommandId == CefMenuCommand.NotFound)
+                            {
+                                continue;
+                            }
+
+                            if (subItem.IsSeperator)
+                            {
+                                menu.Items.Add(new Separator());
+
+                                continue;
+                            }
+
+                            var subMenuItem = new MenuItem
+                            {
+                                Header = subItem.Label.Replace("&", "_"),
+                                IsEnabled = subItem.IsEnabled,
+                                IsChecked = subItem.IsChecked.GetValueOrDefault(),
+                                IsCheckable = subItem.IsChecked.HasValue,
+                                Command = new DelegateCommand(() =>
+                                {
+                                    //BUG: CEF currently not executing callbacks correctly so we manually map the commands below
+                                    //see https://github.com/cefsharp/CefSharp/issues/1767
+                                    //The following line worked in previous versions, it doesn't now, so custom handling below
+                                    //callback.Continue(item.Item2, CefEventFlags.None);
+                                    ExecuteCommand(browser, subItem.CommandId, dictionarySuggestions, xCoord, yCoord, selectionText, misspelledWord);
+                                }),
+                            };
+
+                            menuItem.Items.Add(subMenuItem);
+                        }
+                    }
+
+                    menu.Items.Add(menuItem);
+                }
+                webBrowser.ContextMenu = menu;
+            });
+
+            return true;
+        }
+        protected virtual void ExecuteCommand(IBrowser browser, CefMenuCommand menuCommand, IList<string> dictionarySuggestions, int xCoord, int yCoord, string selectionText, string misspelledWord)
+        {
+            // If the user chose a replacement word for a misspelling, replace it here.
+            if (menuCommand >= CefMenuCommand.SpellCheckSuggestion0 &&
+                menuCommand <= CefMenuCommand.SpellCheckSuggestion4)
+            {
+                int sugestionIndex = ((int)menuCommand) - (int)CefMenuCommand.SpellCheckSuggestion0;
+                if (sugestionIndex < dictionarySuggestions.Count)
+                {
+                    var suggestion = dictionarySuggestions[sugestionIndex];
+                    browser.ReplaceMisspelling(suggestion);
+                }
+
+                return;
+            }
+
+            //NOTE: Note all menu item options below have been tested, you can work out the rest
+            switch (menuCommand)
+            {
+                // Navigation.
+                case CefMenuCommand.Back:
+                {
+                    browser.GoBack();
+                    break;
+                }
+                case CefMenuCommand.Forward:
+                {
+                    browser.GoForward();
+                    break;
+                }
+                case CefMenuCommand.Reload:
+                {
+                    browser.Reload();
+                    break;
+                }
+                case CefMenuCommand.ReloadNoCache:
+                {
+                    browser.Reload(ignoreCache: true);
+                    break;
+                }
+                case CefMenuCommand.StopLoad:
+                {
+                    browser.StopLoad();
+                    break;
+                }
+
+                //Editing
+                case CefMenuCommand.Undo:
+                {
+                    browser.FocusedFrame.Undo();
+                    break;
+                }
+                case CefMenuCommand.Redo:
+                {
+                    browser.FocusedFrame.Redo();
+                    break;
+                }
+                case CefMenuCommand.Cut:
+                {
+                    browser.FocusedFrame.Cut();
+                    break;
+                }
+                case CefMenuCommand.Copy:
+                {
+                    browser.FocusedFrame.Copy();
+                    break;
+                }
+                case CefMenuCommand.Paste:
+                {
+                    browser.FocusedFrame.Paste();
+                    break;
+                }
+                case CefMenuCommand.Delete:
+                {
+                    browser.FocusedFrame.Delete();
+                    break;
+                }
+                case CefMenuCommand.SelectAll:
+                {
+                    browser.FocusedFrame.SelectAll();
+                    break;
+                }
+
+                // Miscellaneous.
+                case CefMenuCommand.Print:
+                {
+                    browser.GetHost().Print();
+                    break;
+                }
+                case CefMenuCommand.ViewSource:
+                {
+                    browser.FocusedFrame.ViewSource();
+                    break;
+                }
+                case CefMenuCommand.Find:
+                {
+                    browser.GetHost().Find(0, selectionText, true, false, false);
+                    break;
+                }
+
+                // Spell checking.
+                case CefMenuCommand.AddToDictionary:
+                {
+                    browser.GetHost().AddWordToDictionary(misspelledWord);
+                    break;
+                }
+
+                case (CefMenuCommand)26501:
+                {
+                    browser.GetHost().ShowDevTools(inspectElementAtX: xCoord, inspectElementAtY: yCoord);
+                    break;
+                }
+                case (CefMenuCommand)26502:
+                {
+                    browser.GetHost().CloseDevTools();
+                    break;
+                }
+            }
+        }
+
+        private static IList<MenuModel> GetMenuItems(IMenuModel model)
+        {
+            var menuItems = new List<MenuModel>();
+
+            for (var i = 0; i < model.Count; i++)
+            {
+                var type = model.GetTypeAt(i);
+                bool? isChecked = null;
+
+                if(type == MenuItemType.Check)
+                {
+                    isChecked = model.IsCheckedAt(i);
+                }
+
+                var subItems = model.GetSubMenuAt(i);
+
+                IList<MenuModel> subMenus = subItems == null ? null : GetMenuItems(subItems);
+
+                var menuItem = new MenuModel
+                {
+                    Label = model.GetLabelAt(i),
+                    CommandId = model.GetCommandIdAt(i),
+                    IsEnabled = model.IsEnabledAt(i),
+                    Type = type,
+                    IsSeperator = type == MenuItemType.Separator,
+                    IsChecked = isChecked,
+                    SubMenus = subMenus
+                };
+
+                menuItems.Add(menuItem);
+            }
+
+            return menuItems;
+        }
+
+        //TODO: One class per file
+        internal class MenuModel
+        {
+            internal string Label { get; set; }
+            internal CefMenuCommand CommandId { get; set; }
+            internal bool IsEnabled { get; set; }
+            internal bool IsSeperator { get; set; }
+            internal bool? IsChecked { get; set; }
+            internal MenuItemType Type { get; set; }
+
+            internal IList<MenuModel> SubMenus { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
**Summary:**

Implements a native `WPF` context menu

Based of https://github.com/chromiumembedded/cef/blob/ba46b8c53ed0f46cec82a1aebaec173784deb6e4/libcef/browser/menu_manager.cc#L385


**Changes:**
- Adds `WPF` specific IContextMenuHandler implementation that creates a native System.Windows.Controls.ContextMenu
      
**How Has This Been Tested?**  
Manual testing so far

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
