### PR TITLE
Core - Update CefErrorCode

### DIFF
--- a/CefSharp/Enums/CefErrorCode.cs
+++ b/CefSharp/Enums/CefErrorCode.cs
@@ -1464,5 +1464,12 @@ namespace CefSharp
         /// Failed to resolve the hostname of a DNS-over-HTTPS server.
         /// </summary>
         DnsSecureResolverHostnameResolutionFailed = -808,
+
+        /// <summary>
+        /// DNS identified the request as disallowed for insecure connection (http/ws).
+        /// Error should be handled as if an HTTP redirect was received to redirect to
+        /// https or wss.
+        /// </summary>
+        DnsNameHttpsOnly = 809,
     };
 }


### PR DESCRIPTION
**Related:** #3817 

**Summary:**
   - Updated CefErrorCode using https://raw.githubusercontent.com/chromium/chromium/94.0.4606.50/net/base/net_error_list.h and steps described in https://github.com/cefsharp/CefSharp/pull/3785

**Changes:**
   - See https://github.com/cefsharp/CefSharp/pull/3785

The [new error code `DNS_NAME_HTTPS_ONLY`](https://github.com/chromium/chromium/commit/ac9aafb6a3a81537bba6286f65aa84b885f062bd) is missing the minus sign which [got fixed in version `95`](https://github.com/chromium/chromium/commit/651bd32d5d559010ed5dd44aee0f33c7a0162301). 

**How Has This Been Tested?**  
Build works.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [X] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
