### PR TITLE
Core - Add Cef.ParseUrl to RefAssembly

### DIFF
--- a/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
+++ b/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
@@ -85,6 +85,7 @@ namespace CefSharp.Core
         public static bool Initialize(CefSharp.Core.CefSettingsBase cefSettings, bool performDependencyCheck) { throw null; }
         public static bool Initialize(CefSharp.Core.CefSettingsBase cefSettings, bool performDependencyCheck, CefSharp.IApp cefApp) { throw null; }
         public static bool Initialize(CefSharp.Core.CefSettingsBase cefSettings, bool performDependencyCheck, CefSharp.IBrowserProcessHandler browserProcessHandler) { throw null; }
+        public static CefSharp.UrlParts ParseUrl(string url) { throw null; }
         public static void PreShutdown() { }
         public static void QuitMessageLoop() { }
         public static void RefreshWebPlugins() { }


### PR DESCRIPTION
**Summary:**
   - Add `Cef.ParseUrl` to RefAssembly

**Changes:**
   - It got added automatically when building the netcore version.
   - The method was originally added in https://github.com/cefsharp/CefSharp/commit/c5ba1ce43053575faac6a938042e77c12d1a9f97
      
**How Has This Been Tested?**  
Build works.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
