### PR TITLE
Core - Ignore netcore output in netframework projects

### DIFF
--- a/CefSharp.Core/CefSharp.Core.csproj
+++ b/CefSharp.Core/CefSharp.Core.csproj
@@ -42,5 +42,10 @@
     <Compile Remove="UrlRequest.netcore.cs" />
     <Compile Remove="WindowInfo.netcore.cs" />
   </ItemGroup>
-
+  <ItemGroup>
+    <Compile Remove="bin.netcore\**" />
+    <Compile Remove="obj.netcore\**" />
+    <None Remove="bin.netcore\**" />
+    <None Remove="obj.netcore\**" />
+  </ItemGroup>
 </Project>

--- a/CefSharp/CefSharp.csproj
+++ b/CefSharp/CefSharp.csproj
@@ -29,4 +29,10 @@
     <Compile Remove="Internals\Json\JsonEnumConverterFactory.cs" />
     <Compile Remove="Internals\Partial\ChromiumWebBrowser.Partial.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="bin.netcore\**" />
+    <Compile Remove="obj.netcore\**" />
+    <None Remove="bin.netcore\**" />
+    <None Remove="obj.netcore\**" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
**Summary:**
   - Ignore netcore output in netframework projects

**Changes:**
   - In https://github.com/cefsharp/CefSharp/commit/65534275b75ef41814770cc1947ba6f0e97b6995 these changes were missing. For WinForms / WPF / OffScreen they are already ignored: https://github.com/cefsharp/CefSharp/commit/e4e0f22ca7b574fb4a62d121c90c150c2a691876
      
**How Has This Been Tested?**  
Build works.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
