### PR TITLE
OffScreen - Fix ResizeAsync with deviceScalingFactor

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -543,20 +543,35 @@ namespace CefSharp.OffScreen
 
             using (var devToolsClient = browser.GetDevToolsClient())
             {
-                if(viewport == null)
+                if (viewport == null)
                 {
                     var screenShot = await devToolsClient.Page.CaptureScreenshotAsync(format, quality, fromSurface: true).ConfigureAwait(continueOnCapturedContext: false);
 
                     return screenShot.Data;
                 }
 
-                //TODO: Check scale
                 //https://bitbucket.org/chromiumembedded/cef/issues/3103/offscreen-capture-screenshot-with-devtools
                 //CEF OSR mode doesn't set the size internally when CaptureScreenShot is called with a clip param specified, so
                 //we must manually resize our view if size is greater
-                if (viewport.Scale > deviceScaleFactor || (int)viewport.Width > size.Width || (int)viewport.Height > size.Height)
+                var newWidth = viewport.Width + viewport.X;
+                if (newWidth < size.Width)
                 {
-                    await ResizeAsync((int)viewport.Width, (int)viewport.Height, (float)viewport.Scale).ConfigureAwait(continueOnCapturedContext:false);
+                    newWidth = size.Width;
+                }
+                var newHeight = viewport.Height + viewport.Y;
+                if (newHeight < size.Height)
+                {
+                    newHeight = size.Height;
+                }
+                var newScale = viewport.Scale;
+                if (newScale == 0)
+                {
+                    newScale = deviceScaleFactor;
+                }
+
+                if ((int)newWidth > size.Width || (int)newHeight > size.Height || newScale != deviceScaleFactor)
+                {
+                    await ResizeAsync((int)newWidth, (int)newHeight, (float)newScale).ConfigureAwait(continueOnCapturedContext:false);
                 }
 
                 //Create a copy instead of modifying users object as we need to set Scale to 1
@@ -592,7 +607,7 @@ namespace CefSharp.OffScreen
             ThrowExceptionIfDisposed();
             ThrowExceptionIfBrowserNotInitialized();
 
-            if(size.Width == width && size.Height == height && deviceScaleFactor == null)
+            if (size.Width == width && size.Height == height && (deviceScaleFactor == null || deviceScaleFactor == DeviceScaleFactor))
             {
                 return Task.FromResult(true);
             }

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -597,12 +597,15 @@ namespace CefSharp.OffScreen
                 return Task.FromResult(true);
             }
 
+            var scaledWidth = (int)(width * DeviceScaleFactor);
+            var scaledHeight = (int)(height * DeviceScaleFactor);
+
             var tcs = new TaskCompletionSource<bool>();
             EventHandler<OnPaintEventArgs> handler = null;
 
             handler = (s, e) =>
             {
-                if (e.Width == width && e.Height == height)
+                if (e.Width == scaledWidth && e.Height == scaledHeight)
                 {
                     AfterPaint -= handler;
 
@@ -616,6 +619,8 @@ namespace CefSharp.OffScreen
             //a call to NotifyScreenInfoChanged will be made.
             if (deviceScaleFactor.HasValue)
             {
+                scaledWidth = (int)(width * deviceScaleFactor.Value);
+                scaledHeight = (int)(height * deviceScaleFactor.Value);
                 DeviceScaleFactor = deviceScaleFactor.Value;
             }
             Size = new Size(width, height);

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -774,6 +774,60 @@ namespace CefSharp.Test.OffScreen
             }
         }
 
+        [Fact]
+        public async Task CanResizeWithDeviceScalingFactor()
+        {
+            using (var browser = new ChromiumWebBrowser("http://www.google.com"))
+            {
+                var response = await browser.WaitForInitialLoadAsync();
+
+                Assert.True(response.Success);
+
+                Assert.Equal(1366, browser.Size.Width);
+                Assert.Equal(768, browser.Size.Height);
+                Assert.Equal(1, browser.DeviceScaleFactor);
+
+
+                await browser.ResizeAsync(800, 600, 2);
+
+                Assert.Equal(800, browser.Size.Width);
+                Assert.Equal(600, browser.Size.Height);
+                Assert.Equal(2, browser.DeviceScaleFactor);
+
+                using (var screenshot = browser.ScreenshotOrNull())
+                {
+                    Assert.Equal(1600, screenshot.Width);
+                    Assert.Equal(1200, screenshot.Height);
+                }
+
+
+                await browser.ResizeAsync(400, 300);
+
+                Assert.Equal(400, browser.Size.Width);
+                Assert.Equal(300, browser.Size.Height);
+                Assert.Equal(2, browser.DeviceScaleFactor);
+
+                using (var screenshot = browser.ScreenshotOrNull())
+                {
+                    Assert.Equal(800, screenshot.Width);
+                    Assert.Equal(600, screenshot.Height);
+                }
+
+
+                await browser.ResizeAsync(1366, 768, 1);
+
+                Assert.Equal(1366, browser.Size.Width);
+                Assert.Equal(768, browser.Size.Height);
+                Assert.Equal(1, browser.DeviceScaleFactor);
+
+                using (var screenshot = browser.ScreenshotOrNull())
+                {
+                    Assert.Equal(1366, screenshot.Width);
+                    Assert.Equal(768, screenshot.Height);
+                }
+            }
+        }
+
 #if DEBUG
         [Fact]
         public async Task CanLoadMultipleBrowserInstancesSequentially()

--- a/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
+++ b/CefSharp.Test/OffScreen/OffScreenBrowserBasicFacts.cs
@@ -4,11 +4,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CefSharp.DevTools.Page;
 using CefSharp.Example;
 using CefSharp.Example.Handlers;
 using CefSharp.Internals;
@@ -771,6 +774,60 @@ namespace CefSharp.Test.OffScreen
                 Assert.True(result);
                 Assert.NotNull(browserCore);
                 Assert.Equal(browser.BrowserCore.Identifier, browserCore.Identifier);
+            }
+        }
+
+        [Fact]
+        public async Task CanCaptureScreenshotAsync()
+        {
+            using (var browser = new ChromiumWebBrowser("http://www.google.com"))
+            {
+                var response = await browser.WaitForInitialLoadAsync();
+
+                Assert.True(response.Success);
+
+                var result1 = await browser.CaptureScreenshotAsync();
+                Assert.Equal(1366, browser.Size.Width);
+                Assert.Equal(768, browser.Size.Height);
+                Assert.Equal(1, browser.DeviceScaleFactor);
+                using (var screenshot = Image.FromStream(new MemoryStream(result1)))
+                {
+                    Assert.Equal(1366, screenshot.Width);
+                    Assert.Equal(768, screenshot.Height);
+                }
+
+
+                var result2 = await browser.CaptureScreenshotAsync(viewport: new Viewport { Width = 1366, Height = 768, X = 100, Y = 200, Scale = 2 });
+                Assert.Equal(1466, browser.Size.Width);
+                Assert.Equal(968, browser.Size.Height);
+                Assert.Equal(2, browser.DeviceScaleFactor);
+                using (var screenshot = Image.FromStream(new MemoryStream(result2)))
+                {
+                    Assert.Equal(2732, screenshot.Width);
+                    Assert.Equal(1536, screenshot.Height);
+                }
+
+
+                var result3 = await browser.CaptureScreenshotAsync(viewport: new Viewport { Width = 100, Height = 200 });
+                Assert.Equal(1466, browser.Size.Width);
+                Assert.Equal(968, browser.Size.Height);
+                Assert.Equal(2, browser.DeviceScaleFactor);
+                using (var screenshot = Image.FromStream(new MemoryStream(result3)))
+                {
+                    Assert.Equal(200, screenshot.Width);
+                    Assert.Equal(400, screenshot.Height);
+                }
+
+
+                var result4 = await browser.CaptureScreenshotAsync(viewport: new Viewport { Width = 100, Height = 200, Scale = 1 });
+                Assert.Equal(1466, browser.Size.Width);
+                Assert.Equal(968, browser.Size.Height);
+                Assert.Equal(1, browser.DeviceScaleFactor);
+                using (var screenshot = Image.FromStream(new MemoryStream(result4)))
+                {
+                    Assert.Equal(100, screenshot.Width);
+                    Assert.Equal(200, screenshot.Height);
+                }
             }
         }
 


### PR DESCRIPTION
**Fixes:** https://github.com/cefsharp/CefSharp/discussions/3959#discussioncomment-1947117

**Summary:** The `AfterPaint` event receives the scaled `Width` and `Height`, so the check for that must account for that.
That's what I meant with this comment:
>  (Scale does not work as the check for width / height needs to use the scaled sizes: * deviceScaleFactor)

**Changes:**
- Fix ResizeAsync with deviceScalingFactor
- Added new Test cases
      
**How Has This Been Tested?**  
Unittest

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
