### PR TITLE
Test - Fix CanEvaluateDoubleValues by not relying on the current culture

### DIFF
--- a/CefSharp.Test/Javascript/EvaluateScriptAsyncFacts.cs
+++ b/CefSharp.Test/Javascript/EvaluateScriptAsyncFacts.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -64,7 +65,7 @@ namespace CefSharp.Test.Javascript
 
             Assert.False(browser.IsLoading);
 
-            var javascriptResponse = await browser.EvaluateScriptAsync(num.ToString());
+            var javascriptResponse = await browser.EvaluateScriptAsync(num.ToString(CultureInfo.InvariantCulture));
             Assert.True(javascriptResponse.Success);
 
             var actualType = javascriptResponse.Result.GetType();


### PR DESCRIPTION
**Summary:** Fixes CanEvaluateDoubleValues test by not relying on the current culture
These tests fail with e.g. german locale.

**How Has This Been Tested?**  
Running unittest with german locale.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
