### PR TITLE
Fix not disposing callback in ResourceHandler.Skip

### DIFF
--- a/CefSharp.Example/AcceptRangeResourceHandler.cs
+++ b/CefSharp.Example/AcceptRangeResourceHandler.cs
@@ -151,6 +151,9 @@ namespace CefSharp.Example
 
         bool IResourceHandler.Skip(long bytesToSkip, out long bytesSkipped, IResourceSkipCallback callback)
         {
+            //We don't need the callback, as it's an unmanaged resource we should dispose it (could wrap it in a using statement).
+            callback.Dispose();
+
             //No Stream or Stream cannot seek then we indicate failure
             if (stream == null || !stream.CanSeek)
             {

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -138,6 +138,9 @@ namespace CefSharp
 
         bool IResourceHandler.Skip(long bytesToSkip, out long bytesSkipped, IResourceSkipCallback callback)
         {
+            //We don't need the callback, as it's an unmanaged resource we should dispose it (could wrap it in a using statement).
+            callback.Dispose();
+
             //No Stream or Stream cannot seek then we indicate failure
             if (Stream == null || !Stream.CanSeek)
             {


### PR DESCRIPTION
**Summary:**
Added disposal of unused callback to `ResourceHandler.Skip()` like it is in `Read()`.

**Changes:**
A trivial modification to `ResourceHandler` and `AcceptRangeResourceHandler`.

**How Has This Been Tested?**
As per our Gitter conversation, it has not been tested.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
