### PR TITLE
Update docs for IResourceRequestHandlerFactory

### DIFF
--- a/CefSharp/IResourceRequestHandlerFactory.cs
+++ b/CefSharp/IResourceRequestHandlerFactory.cs
@@ -16,6 +16,13 @@ namespace CefSharp
         /// <summary>
         /// Are there any <see cref="ResourceHandler"/>'s registered?
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Implementors must return <see langword="true"/> from this method if the factory is to be used.
+        /// The <see cref="GetResourceRequestHandler"/> method will not be executed if this property returns
+        /// <see langword="false"/>, presumably as an optimisation.
+        /// </para>
+        /// </remarks>
         bool HasHandlers { get; }
 
         /// <summary>


### PR DESCRIPTION
I have just discovered that when `HasHandlers` returns `false`, the `GetResourceRequestHandler` method is never executed.  Presumably this is an optimisation which happens inside of CEF, as I can see that the `HasHandlers` property value goes all way back to the C++ native project.

I was about to suggest removing this optimisation because it'd be trivial to optimise and return early inside the default factory impl in C# world.  If it goes all the way down to CEF then that's less easy and so the next best thing would be to document it.

**Fixes:** _Has no related issue_

**Summary:** Addition to docs (more info above)

**Changes:** `IResourceRequestHandlerFactory` (comments only)
      
**How Has This Been Tested?**  It has not, no functional changes made

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
