### PR TITLE
WPF/OffScreen - Add WaitForRenderIdleAsync

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -678,7 +678,7 @@ namespace CefSharp.OffScreen
         /// <param name="timeout">optional timeout, if not specified defaults to thirty(30) seconds.</param>
         /// <param name="cancellationToken">optional CancellationToken</param>
         /// <returns>Task that resolves when page rendering has been idle for <paramref name="idleTimeInMs"/></returns>
-        public Task WaitForRenderIdleAsync(int idleTimeInMs = 500, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        public async Task WaitForRenderIdleAsync(int idleTimeInMs = 500, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             var renderIdleTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -711,18 +711,19 @@ namespace CefSharp.OffScreen
 
             Paint += handler;
 
-            var timeOutTask = TaskTimeoutExtensions.WaitAsync(renderIdleTcs.Task, timeout ?? TimeSpan.FromSeconds(30), cancellationToken);
-
-            timeOutTask.ContinueWith(x =>
+            try
+            {
+                await TaskTimeoutExtensions.WaitAsync(renderIdleTcs.Task, timeout ?? TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+            }
+            catch(Exception)
             {
                 Paint -= handler;
 
                 idleTimer?.Stop();
                 idleTimer?.Dispose();
 
-            }, TaskContinuationOptions.NotOnRanToCompletion);
-
-            return timeOutTask;
+                throw;
+            }
         }
 #endif
 

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -667,6 +667,52 @@ namespace CefSharp.OffScreen
             }
         }
 
+#if NETCOREAPP || NET462
+        /// <summary>
+        /// Waits for the page rendering to be idle for <paramref name="idleTimeInMs"/>.
+        /// This is useful for scenarios like taking a screen shot
+        /// </summary>
+        /// <param name="idleTimeInMs">optional idleTime in miliseconds, default to 500ms</param>
+        /// <param name="timeout">optional timeout, if not specified defaults to thirty(30) seconds.</param>
+        /// <param name="cancellationToken">optional CancellationToken</param>
+        /// <returns>Task that resolves when page rendering has been idle for <paramref name="idleTimeInMs"/></returns>
+        public Task WaitForRenderIdleAsync(int idleTimeInMs = 500, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var renderIdleTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var idleTimer = new System.Timers.Timer
+            {
+                Interval = idleTimeInMs,
+                AutoReset = false
+            };
+
+            EventHandler<OnPaintEventArgs> handler = null;
+
+            idleTimer.Elapsed += (sender, args) =>
+            {
+                Paint -= handler;
+
+                idleTimer.Stop();
+                idleTimer.Dispose();
+
+                renderIdleTcs.TrySetResult(true);
+            };
+
+            //Every time Paint is called we reset our timer
+            handler = (s, args) =>
+            {
+                idleTimer.Stop();
+                idleTimer.Start();
+            };
+
+            idleTimer.Start();
+
+            Paint += handler;
+
+            return TaskTimeoutExtensions.WaitAsync(renderIdleTcs.Task, timeout ?? TimeSpan.FromSeconds(30), cancellationToken);
+        }
+#endif
+
         /// <summary>
         /// The javascript object repository, one repository per ChromiumWebBrowser instance.
         /// </summary>

--- a/CefSharp.Test/Framework/HasHandlerFacts.cs
+++ b/CefSharp.Test/Framework/HasHandlerFacts.cs
@@ -13,11 +13,11 @@ namespace CefSharp.Test.Framework
             {
                 browser.Paint += OffScreenBrowserPaint;
 
-                Assert.True(browser.HasPaintEventHandler());
+                Assert.Equal(1, browser.PaintEventHandlerCount());
 
                 browser.Paint -= OffScreenBrowserPaint;
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.Equal(0, browser.PaintEventHandlerCount());
             }
         }
 
@@ -28,11 +28,11 @@ namespace CefSharp.Test.Framework
             {
                 browser.Paint += WpfBrowserPaint;
 
-                Assert.True(browser.HasPaintEventHandler());
+                Assert.Equal(1, browser.PaintEventHandlerCount());
 
                 browser.Paint -= WpfBrowserPaint;
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.Equal(0, browser.PaintEventHandlerCount());
             }
         }
 

--- a/CefSharp.Test/Framework/HasHandlerFacts.cs
+++ b/CefSharp.Test/Framework/HasHandlerFacts.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+namespace CefSharp.Test.Framework
+{
+    public class HasHandlerFacts
+    {
+        [Fact]
+        public void ShouldWorkForOffScreen()
+        {
+            using(var browser = new CefSharp.OffScreen.ChromiumWebBrowser(automaticallyCreateBrowser:false))
+            {
+                browser.Paint += OffScreenBrowserPaint;
+
+                Assert.True(browser.HasPaintEventHandler());
+
+                browser.Paint -= OffScreenBrowserPaint;
+
+                Assert.False(browser.HasPaintEventHandler());
+            }
+        }
+
+        [Fact]
+        public void ShouldWorkForWpf()
+        {
+            using (var browser = new CefSharp.Wpf.ChromiumWebBrowser())
+            {
+                browser.Paint += WpfBrowserPaint;
+
+                Assert.True(browser.HasPaintEventHandler());
+
+                browser.Paint -= WpfBrowserPaint;
+
+                Assert.False(browser.HasPaintEventHandler());
+            }
+        }
+
+        private void WpfBrowserPaint(object sender, CefSharp.Wpf.PaintEventArgs e)
+        {
+            
+        }
+
+        private void OffScreenBrowserPaint(object sender, CefSharp.OffScreen.OnPaintEventArgs e)
+        {
+            
+        }
+    }
+}

--- a/CefSharp.Test/Framework/HasHandlerFacts.cs
+++ b/CefSharp.Test/Framework/HasHandlerFacts.cs
@@ -2,6 +2,8 @@ using Xunit;
 
 namespace CefSharp.Test.Framework
 {
+    //NOTE: All Test classes must be part of this collection as it manages the Cef Initialize/Shutdown lifecycle
+    [Collection(CefSharpFixtureCollection.Key)]
     public class HasHandlerFacts
     {
         [Fact]

--- a/CefSharp.Test/Framework/HasHandlerFacts.cs
+++ b/CefSharp.Test/Framework/HasHandlerFacts.cs
@@ -21,7 +21,7 @@ namespace CefSharp.Test.Framework
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void ShouldWorkForWpf()
         {
             using (var browser = new CefSharp.Wpf.ChromiumWebBrowser())

--- a/CefSharp.Test/OffScreen/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/OffScreen/WaitForRenderIdleTests.cs
@@ -40,7 +40,7 @@ namespace CefSharp.Test.OffScreen
 
                 output.WriteLine("Time {0}ms", time);
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
             }
         }
 
@@ -77,7 +77,7 @@ namespace CefSharp.Test.OffScreen
                 Assert.True(end > start);
                 Assert.True(time > expected, $"Executed in {time}ms");
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
 
                 output.WriteLine("Time {0}ms", time);
             }
@@ -95,7 +95,7 @@ namespace CefSharp.Test.OffScreen
 
                 Assert.Equal("The operation has timed out.", exception.Message);
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
             }
         }        
     }

--- a/CefSharp.Test/OffScreen/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/OffScreen/WaitForRenderIdleTests.cs
@@ -1,0 +1,96 @@
+using CefSharp.Example;
+using CefSharp.OffScreen;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CefSharp.Test.OffScreen
+{
+    //NOTE: All Test classes must be part of this collection as it manages the Cef Initialize/Shutdown lifecycle
+    [Collection(CefSharpFixtureCollection.Key)]
+    public class WaitForRenderIdleTests
+    {
+
+        private readonly ITestOutputHelper output;
+        private readonly CefSharpFixture fixture;
+
+        public WaitForRenderIdleTests(ITestOutputHelper output, CefSharpFixture fixture)
+        {
+            this.fixture = fixture;
+            this.output = output;
+        }
+
+        [Fact]
+        public async Task ShouldWork()
+        {
+            const int expected = 500;
+
+            using (var browser = new ChromiumWebBrowser(CefExample.DefaultUrl))
+            {
+                var start = DateTime.Now;
+                await browser.WaitForRenderIdleAsync();
+
+                var end = DateTime.Now;
+
+                var time = (end - start).TotalMilliseconds;
+
+                Assert.True(end > start);
+                Assert.True(time > expected, $"Executed in {time}ms");
+
+                output.WriteLine("Time {0}ms", time);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldWorkForManualInvalidateCalls()
+        {
+            const int expected = 600;
+
+            using (var browser = new ChromiumWebBrowser(CefExample.DefaultUrl))
+            {
+                var start = DateTime.Now;
+
+                var invalidateTask = Task.Run(async () =>
+                {
+                    await Task.Delay(400);
+
+                    browser.GetBrowserHost().Invalidate(PaintElementType.View);
+
+                    await Task.Delay(100);
+
+                    browser.GetBrowserHost().Invalidate(PaintElementType.View);
+
+                    await Task.Delay(100);
+
+                    browser.GetBrowserHost().Invalidate(PaintElementType.View);
+                });
+
+                await Task.WhenAll(browser.WaitForRenderIdleAsync(), invalidateTask);
+
+                var end = DateTime.Now;
+
+                var time = (end - start).TotalMilliseconds;
+
+                Assert.True(end > start);
+                Assert.True(time > expected, $"Executed in {time}ms");
+
+                output.WriteLine("Time {0}ms", time);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldRespectTimeout()
+        {
+            using (var browser = new ChromiumWebBrowser(CefExample.DefaultUrl))
+            {
+                var exception = await Assert.ThrowsAsync<TimeoutException>(async () =>
+                {
+                    await browser.WaitForRenderIdleAsync(timeout: TimeSpan.FromMilliseconds(100));
+                });
+
+                Assert.Equal("The operation has timed out.", exception.Message);
+            }
+        }
+    }
+}

--- a/CefSharp.Test/OffScreen/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/OffScreen/WaitForRenderIdleTests.cs
@@ -40,7 +40,7 @@ namespace CefSharp.Test.OffScreen
 
                 output.WriteLine("Time {0}ms", time);
 
-                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
+                Assert.Equal(0, browser.PaintEventHandlerCount());
             }
         }
 
@@ -77,7 +77,7 @@ namespace CefSharp.Test.OffScreen
                 Assert.True(end > start);
                 Assert.True(time > expected, $"Executed in {time}ms");
 
-                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
+                Assert.Equal(0, browser.PaintEventHandlerCount());
 
                 output.WriteLine("Time {0}ms", time);
             }
@@ -95,7 +95,7 @@ namespace CefSharp.Test.OffScreen
 
                 Assert.Equal("The operation has timed out.", exception.Message);
 
-                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
+                Assert.Equal(0, browser.PaintEventHandlerCount());
             }
         }        
     }

--- a/CefSharp.Test/WebBrowserTestExtensions.cs
+++ b/CefSharp.Test/WebBrowserTestExtensions.cs
@@ -11,7 +11,7 @@ namespace CefSharp.Test
 {
     public static class WebBrowserTestExtensions
     {
-        public static bool HasPaintEventHandler(this CefSharp.Wpf.ChromiumWebBrowser browser)
+        public static int PaintEventHandlerCount(this CefSharp.Wpf.ChromiumWebBrowser browser)
         {
             var field = typeof(CefSharp.Wpf.ChromiumWebBrowser).GetField("Paint", BindingFlags.NonPublic | BindingFlags.Instance);
 
@@ -24,15 +24,15 @@ namespace CefSharp.Test
 
             if (handler == null)
             {
-                return false;
+                return 0;
             }
 
             var subscribers = handler.GetInvocationList();
 
-            return subscribers.Length > 0;
+            return subscribers.Length;
         }
 
-        public static bool HasPaintEventHandler(this ChromiumWebBrowser browser)
+        public static int PaintEventHandlerCount(this ChromiumWebBrowser browser)
         {
             var field = typeof(ChromiumWebBrowser).GetField("Paint", BindingFlags.NonPublic | BindingFlags.Instance);
 
@@ -45,12 +45,12 @@ namespace CefSharp.Test
 
             if (handler == null)
             {
-                return false;
+                return 0;
             }
 
             var subscribers = handler.GetInvocationList();
 
-            return subscribers.Length > 0;
+            return subscribers.Length;
         }
 
         public static Task<LoadUrlAsyncResponse> LoadRequestAsync(this IWebBrowser browser, IRequest request)

--- a/CefSharp.Test/WebBrowserTestExtensions.cs
+++ b/CefSharp.Test/WebBrowserTestExtensions.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using CefSharp.OffScreen;
 
@@ -10,6 +11,42 @@ namespace CefSharp.Test
 {
     public static class WebBrowserTestExtensions
     {
+        public static bool HasPaintEventHandler(this CefSharp.Wpf.ChromiumWebBrowser browser)
+        {
+            var field = typeof(CefSharp.Wpf.ChromiumWebBrowser).GetField("Paint", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            System.Diagnostics.Debug.Assert(field != null);
+
+            var handler = field.GetValue(browser) as Delegate;
+
+            if (handler == null)
+            {
+                return false;
+            }
+
+            var subscribers = handler.GetInvocationList();
+
+            return subscribers.Length > 0;
+        }
+
+        public static bool HasPaintEventHandler(this ChromiumWebBrowser browser)
+        {
+            var field = typeof(ChromiumWebBrowser).GetField("Paint", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            System.Diagnostics.Debug.Assert(field != null);
+
+            var handler = field.GetValue(browser) as Delegate;
+
+            if (handler == null)
+            {
+                return false;
+            }
+
+            var subscribers = handler.GetInvocationList();
+
+            return subscribers.Length > 0;
+        }
+
         public static Task<LoadUrlAsyncResponse> LoadRequestAsync(this IWebBrowser browser, IRequest request)
         {
             if(request == null)

--- a/CefSharp.Test/WebBrowserTestExtensions.cs
+++ b/CefSharp.Test/WebBrowserTestExtensions.cs
@@ -15,7 +15,10 @@ namespace CefSharp.Test
         {
             var field = typeof(CefSharp.Wpf.ChromiumWebBrowser).GetField("Paint", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            System.Diagnostics.Debug.Assert(field != null);
+            if(field == null)
+            {
+                throw new Exception("Unable to obtain Paint event handler");
+            }
 
             var handler = field.GetValue(browser) as Delegate;
 
@@ -33,7 +36,10 @@ namespace CefSharp.Test
         {
             var field = typeof(ChromiumWebBrowser).GetField("Paint", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            System.Diagnostics.Debug.Assert(field != null);
+            if (field == null)
+            {
+                throw new Exception("Unable to obtain Paint event handler");
+            }
 
             var handler = field.GetValue(browser) as Delegate;
 

--- a/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
@@ -58,6 +58,10 @@ namespace CefSharp.Test.Wpf
                 {
                     await Task.Delay(400);
 
+                    // Ensure the browser has finished loading before we attempt
+                    // to access BrowserHost
+                    await browser.WaitForInitialLoadAsync();
+
                     browser.GetBrowserHost().Invalidate(PaintElementType.View);
 
                     await Task.Delay(100);

--- a/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
@@ -41,7 +41,7 @@ namespace CefSharp.Test.Wpf
 
                 output.WriteLine("Time {0}ms", time);
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
             }
         }
 
@@ -78,7 +78,7 @@ namespace CefSharp.Test.Wpf
                 Assert.True(end > start);
                 Assert.True(time > expected, $"Executed in {time}ms");
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
 
                 output.WriteLine("Time {0}ms", time);
             }
@@ -96,7 +96,7 @@ namespace CefSharp.Test.Wpf
 
                 Assert.Equal("The operation has timed out.", exception.Message);
 
-                Assert.False(browser.HasPaintEventHandler());
+                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
             }
         }        
     }

--- a/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
@@ -1,11 +1,12 @@
 using CefSharp.Example;
-using CefSharp.OffScreen;
+using CefSharp.Wpf;
 using System;
 using System.Threading.Tasks;
+using System.Windows;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace CefSharp.Test.OffScreen
+namespace CefSharp.Test.Wpf
 {
     //NOTE: All Test classes must be part of this collection as it manages the Cef Initialize/Shutdown lifecycle
     [Collection(CefSharpFixtureCollection.Key)]
@@ -21,12 +22,12 @@ namespace CefSharp.Test.OffScreen
             this.output = output;
         }
 
-        [Fact]
+        [WpfFact]
         public async Task ShouldWork()
         {
             const int expected = 500;
 
-            using (var browser = new ChromiumWebBrowser(CefExample.DefaultUrl))
+            using (var browser = new ChromiumWebBrowser(null, CefExample.DefaultUrl, new Size(1024, 786)))
             {
                 var start = DateTime.Now;
                 await browser.WaitForRenderIdleAsync();
@@ -44,12 +45,12 @@ namespace CefSharp.Test.OffScreen
             }
         }
 
-        [Fact]
+        [WpfFact]
         public async Task ShouldWorkForManualInvalidateCalls()
         {
             const int expected = 600;
 
-            using (var browser = new ChromiumWebBrowser(CefExample.DefaultUrl))
+            using (var browser = new ChromiumWebBrowser(null, CefExample.DefaultUrl, new Size(1024, 786)))
             {
                 var start = DateTime.Now;
 
@@ -83,10 +84,10 @@ namespace CefSharp.Test.OffScreen
             }
         }
 
-        [Fact]
+        [WpfFact]
         public async Task ShouldRespectTimeout()
         {
-            using (var browser = new ChromiumWebBrowser(CefExample.DefaultUrl))
+            using (var browser = new ChromiumWebBrowser(null, CefExample.DefaultUrl, new Size(1024, 786)))
             {
                 var exception = await Assert.ThrowsAsync<TimeoutException>(async () =>
                 {

--- a/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
+++ b/CefSharp.Test/Wpf/WaitForRenderIdleTests.cs
@@ -41,7 +41,7 @@ namespace CefSharp.Test.Wpf
 
                 output.WriteLine("Time {0}ms", time);
 
-                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
+                Assert.Equal(0, browser.PaintEventHandlerCount());
             }
         }
 
@@ -78,7 +78,7 @@ namespace CefSharp.Test.Wpf
                 Assert.True(end > start);
                 Assert.True(time > expected, $"Executed in {time}ms");
 
-                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
+                Assert.Equal(0, browser.PaintEventHandlerCount());
 
                 output.WriteLine("Time {0}ms", time);
             }
@@ -96,7 +96,7 @@ namespace CefSharp.Test.Wpf
 
                 Assert.Equal("The operation has timed out.", exception.Message);
 
-                Assert.False(browser.HasPaintEventHandler(), "Paint event handler is null");
+                Assert.Equal(0, browser.PaintEventHandlerCount());
             }
         }        
     }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2586,7 +2586,7 @@ namespace CefSharp.Wpf
         /// <param name="timeout">optional timeout, if not specified defaults to thirty(30) seconds.</param>
         /// <param name="cancellationToken">optional CancellationToken</param>
         /// <returns>Task that resolves when page rendering has been idle for <paramref name="idleTimeInMs"/></returns>
-        public Task WaitForRenderIdleAsync(int idleTimeInMs = 500, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        public async Task WaitForRenderIdleAsync(int idleTimeInMs = 500, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             var renderIdleTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -2619,18 +2619,19 @@ namespace CefSharp.Wpf
 
             Paint += handler;
 
-            var timeOutTask = TaskTimeoutExtensions.WaitAsync(renderIdleTcs.Task, timeout ?? TimeSpan.FromSeconds(30), cancellationToken);
-
-            timeOutTask.ContinueWith(x =>
+            try
+            {
+                await TaskTimeoutExtensions.WaitAsync(renderIdleTcs.Task, timeout ?? TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
             {
                 Paint -= handler;
 
                 idleTimer?.Stop();
                 idleTimer?.Dispose();
 
-            }, TaskContinuationOptions.NotOnRanToCompletion);
-
-            return timeOutTask;
+                throw;
+            }
         }
 #endif
 

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2575,6 +2575,52 @@ namespace CefSharp.Wpf
             }
         }
 
+#if NETCOREAPP || NET462
+        /// <summary>
+        /// Waits for the page rendering to be idle for <paramref name="idleTimeInMs"/>.
+        /// This is useful for scenarios like taking a screen shot
+        /// </summary>
+        /// <param name="idleTimeInMs">optional idleTime in miliseconds, default to 500ms</param>
+        /// <param name="timeout">optional timeout, if not specified defaults to thirty(30) seconds.</param>
+        /// <param name="cancellationToken">optional CancellationToken</param>
+        /// <returns>Task that resolves when page rendering has been idle for <paramref name="idleTimeInMs"/></returns>
+        public Task WaitForRenderIdleAsync(int idleTimeInMs = 500, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var renderIdleTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var idleTimer = new System.Timers.Timer
+            {
+                Interval = idleTimeInMs,
+                AutoReset = false
+            };
+
+            EventHandler<PaintEventArgs> handler = null;
+
+            idleTimer.Elapsed += (sender, args) =>
+            {
+                Paint -= handler;
+
+                idleTimer.Stop();
+                idleTimer.Dispose();
+
+                renderIdleTcs.TrySetResult(true);
+            };
+
+            //Every time Paint is called we reset our timer
+            handler = (s, args) =>
+            {
+                idleTimer.Stop();
+                idleTimer.Start();
+            };
+
+            idleTimer.Start();
+
+            Paint += handler;
+
+            return TaskTimeoutExtensions.WaitAsync(renderIdleTcs.Task, timeout ?? TimeSpan.FromSeconds(30), cancellationToken);
+        }
+#endif
+
         /// <summary>
         /// Legacy keyboard handler uses WindowProc callback interceptor to forward keypress events
         /// the the browser. Use this method to revert to the previous keyboard handling behaviour

--- a/CefSharp/Internals/TaskTimeoutExtensions.cs
+++ b/CefSharp/Internals/TaskTimeoutExtensions.cs
@@ -13,7 +13,7 @@ namespace CefSharp.Internals
     /// WaitAsync polyfills imported from .Net Runtime
     /// as we don't get access to this method in older .net versions
     /// </summary>
-    internal static class TaskTimeoutExtensions
+    public static class TaskTimeoutExtensions
     {
         public static Task<TResult> WaitAsync<TResult>(Task<TResult> task, int millisecondsTimeout) =>
             WaitAsync(task, TimeSpan.FromMilliseconds(millisecondsTimeout), default);


### PR DESCRIPTION
**Summary:** 
- WPF/OffScreen - Add WaitForRenderIdleAsync method
- Only for .Net 4.6.2 and above

**Changes:**

- Task resolves when render has been idle for the specified time
- Make TaskTimeoutExtensions public (they're not extension methods as this was expected)
      
**How Has This Been Tested?**  
xUnit Tests

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
