### PR TITLE
Fix FolderSchemeHandlerFactory locking files

### DIFF
--- a/CefSharp/SchemeHandler/FolderSchemeHandlerFactory.cs
+++ b/CefSharp/SchemeHandler/FolderSchemeHandlerFactory.cs
@@ -117,7 +117,7 @@ namespace CefSharp.SchemeHandler
                 var fileExtension = Path.GetExtension(filePath);
                 var mimeType = GetMimeTypeDelegate(fileExtension);
                 var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, resourceFileShare);
-                return ResourceHandler.FromStream(stream, mimeType);
+                return ResourceHandler.FromStream(stream, mimeType, autoDisposeStream: true);
             }
 
             return ResourceHandler.ForErrorMessage("File Not Found - " + filePath, HttpStatusCode.NotFound);


### PR DESCRIPTION
**Fixes:**
  - #2535 (better than this)

**Summary:** [summary of the change and which issue is fixed here]
   - Fix `FolderSchemeHandlerFactory` keeping files locked for the process lifetime

**Changes:** [specify the structures changed] 

If a page or other resource is loaded via a scheme that uses `FolderSchemeHandlerFactory`, subsequently attempting to delete or overwrite the corresponding file results in a "file in use" exception -- even if the browser has navigated elsewhere or disposed beforehand.

This appears to be because `ResourceHandler.FromStream` will by default not close streams even though (in this case) they are only used for a single request.  So we ought to tell it to do so.  (It would be safer if `FromStream` did dispose by default, but that would be a breaking change.)
      
**How Has This Been Tested?**  
I created a copy of this class in my test app with this change and performed some navigations where it deletes the loaded file (and creates a new one) before doing the next navigation.  With this change, it works.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
