### PR TITLE
Use decimal instead of hexadecimal notation for "editbin" command

### DIFF
--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.csproj
@@ -35,6 +35,6 @@
         <None Remove="obj.netcore\**" />
     </ItemGroup>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-      <Exec Command="if $(PlatformName) == x86 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars32.bat&quot;&#xD;&#xA;  editbin /largeaddressaware /TSAWARE &quot;$(TargetPath)&quot;  &#xD;&#xA;  sn -R &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\CefSharp.snk&quot;&#xD;&#xA;) else (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat&quot;&#xD;&#xA;  editbin /TSAWARE /STACK:0x800000 &quot;$(TargetPath)&quot;&#xD;&#xA;  sn -R &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\CefSharp.snk&quot;&#xD;&#xA;)" />
+      <Exec Command="if $(PlatformName) == x86 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars32.bat&quot;&#xD;&#xA;  editbin /largeaddressaware /TSAWARE &quot;$(TargetPath)&quot;  &#xD;&#xA;  sn -R &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\CefSharp.snk&quot;&#xD;&#xA;) else (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat&quot;&#xD;&#xA;  editbin /TSAWARE /STACK:8388608 &quot;$(TargetPath)&quot;&#xD;&#xA;  sn -R &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\CefSharp.snk&quot;&#xD;&#xA;)" />
     </Target>
 </Project>

--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj
@@ -57,7 +57,7 @@
     </ItemGroup>
 
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-        <Exec Command="if $(PlatformName) == x86 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars32.bat&quot;&#xD;&#xA;  editbin /largeaddressaware /TSAWARE &quot;$(TargetDir)CefSharp.BrowserSubprocess.exe&quot;  &#xD;&#xA;) else if $(PlatformName) == x64 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat&quot;&#xD;&#xA;  editbin /STACK:0x800000 &quot;$(TargetDir)CefSharp.BrowserSubprocess.exe&quot;&#xD;&#xA;) else if $(PlatformName) == arm64 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvarsamd64_arm64.bat&quot;&#xD;&#xA;  editbin /STACK:0x800000 &quot;$(TargetDir)CefSharp.BrowserSubprocess.exe&quot;&#xD;&#xA;)&#xD;&#xA;" />
+        <Exec Command="if $(PlatformName) == x86 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars32.bat&quot;&#xD;&#xA;  editbin /largeaddressaware /TSAWARE &quot;$(TargetDir)CefSharp.BrowserSubprocess.exe&quot;  &#xD;&#xA;) else if $(PlatformName) == x64 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat&quot;&#xD;&#xA;  editbin /STACK:8388608 &quot;$(TargetDir)CefSharp.BrowserSubprocess.exe&quot;&#xD;&#xA;) else if $(PlatformName) == arm64 (&#xD;&#xA;  call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvarsamd64_arm64.bat&quot;&#xD;&#xA;  editbin /STACK:8388608 &quot;$(TargetDir)CefSharp.BrowserSubprocess.exe&quot;&#xD;&#xA;)&#xD;&#xA;" />
     </Target>
 
     <!-- Implicit bottom import -->


### PR DESCRIPTION
**Fixes:**
https://github.com/cefsharp/CefSharp/discussions/4231

Follow-Up to #3986 

**Summary:**
   - Use decimal instead of hexadecimal notation for the `editbin /STACK:` command, to work-around a regression introduced in editbin v14.33 (and possibly 14.32 or 14.31) that no longer recognizes the `0x...` hex format.

**Changes:** 
   - I modified the `editbin` command line in `CefSharp.BrowserSubprocess.csproj` and `CefSharp.BrowserSubprocess.netcore.csproj` to specify `/STACK:8388608` instead of `/STACK:0x800000` for the `editbin` command, which works with editbin v14.33.
      
**How Has This Been Tested?**  
- Built the projects using Visual Studio 2022 Version 17.3.3, and verified with `dumpbin /headers` that before the change, for `CefSharp.BrowserSubprocess.exe` it showed `0 size of stack reserve`, and after the change it showed `800000 size of stack reserve` for the `x64` and `arm64` binaries.
  (Note: For testing `arm64`, I needed to change the `TargetFramework` of `CefSharp.BrowserSubprocess.Core` from `netcoreapp3.1` to `net5.0`, due to the build error described in https://github.com/cefsharp/CefSharp/issues/3284#issuecomment-1239177704 with VS 2022.)

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
