### PR TITLE
WPF - Send keyboard modifiers with drag events

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -2024,7 +2024,7 @@ namespace CefSharp.Wpf
         {
             var point = e.GetPosition(this);
 
-            return new MouseEvent((int)point.X, (int)point.Y, CefEventFlags.None);
+            return new MouseEvent((int)point.X, (int)point.Y, e.GetModifiers());
         }
 
         /// <summary>

--- a/CefSharp.Wpf/Internals/WpfExtensions.cs
+++ b/CefSharp.Wpf/Internals/WpfExtensions.cs
@@ -44,6 +44,17 @@ namespace CefSharp.Wpf.Internals
         }
 
         /// <summary>
+        /// Gets the modifiers.
+        /// </summary>
+        /// <param name="e">The <see cref="DragEventArgs"/> instance containing the event data.</param>
+        /// <returns>CefEventFlags.</returns>
+        public static CefEventFlags GetModifiers(this DragEventArgs e)
+        {
+            return GetModifierKeys();
+        }
+
+
+        /// <summary>
         /// Gets keyboard modifiers.
         /// </summary>
         /// <returns>CefEventFlags.</returns>


### PR DESCRIPTION
**Fixes:** #4286

**Summary:** 
Enable forwarding keyboard modifiers to drag events in WPF CefSharp

**Changes:** [specify the structures changed] 
- Added a new extension method next to the others in `WpfExtensions` to get a `CefEventFlags` value for the keyboard modifiers of drag events.
- Used said method in the `GetMouseEvent(DragEvent)` function of `ChromiumWebBrowser`.

**How Has This Been Tested?**  
- Tested by opening the fiddle from the issue (https://jsfiddle.net/_Yhn/24jmqgbh/) within the CefSharp.Wpf.Example and verifying the output of the events (Using Win10 in a VM)

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable) (not applicable)
- [x] New files have a license disclaimer (no new files)
- [x] The formatting is consistent with the project (project supports .editorconfig)
