### PR TITLE
Enhancement - Improve Promise support

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -41,6 +41,7 @@ namespace CefSharp
 
         public:
             static const CefString kPromiseCreatorScript;
+            static const CefString kPromiseResolverScript;
 
             CefAppUnmanagedWrapper(IRenderProcessHandler^ handler, List<CefCustomScheme^>^ schemes, bool enableFocusedNodeChanged, Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestroyed) : SubProcessApp(schemes)
             {

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -41,7 +41,6 @@ namespace CefSharp
 
         public:
             static const CefString kPromiseCreatorScript;
-            static const CefString kPromiseResolverScript;
 
             CefAppUnmanagedWrapper(IRenderProcessHandler^ handler, List<CefCustomScheme^>^ schemes, bool enableFocusedNodeChanged, Action<CefBrowserWrapper^>^ onBrowserCreated, Action<CefBrowserWrapper^>^ onBrowserDestroyed) : SubProcessApp(schemes)
             {

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -183,6 +183,8 @@
     <ClCompile Include="BrowserSubprocessExecutable.h" />
     <ClInclude Include="Cef.h" />
     <ClInclude Include="JavascriptPromiseHandler.h" />
+    <ClInclude Include="JavascriptPromiseResolverCatch.h" />
+    <ClInclude Include="JavascriptPromiseResolverThen.h" />
     <ClInclude Include="SubProcessApp.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodCallback.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodHandler.h" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj.filters
@@ -122,6 +122,12 @@
     <ClInclude Include="..\CefSharp.Core.Runtime\Internals\CefRefCountManaged.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="JavascriptPromiseResolverCatch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="JavascriptPromiseResolverThen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp">

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPromiseResolverCatch.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPromiseResolverCatch.h
@@ -1,0 +1,71 @@
+// Copyright © 2022 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "include/cef_v8.h"
+
+using namespace System;
+
+namespace CefSharp
+{
+    namespace BrowserSubprocess
+    {
+        private class JavascriptPromiseResolverCatch : public CefV8Handler
+        {
+            int64 _callbackId;
+            bool _isJsCallback;
+
+        public:
+            JavascriptPromiseResolverCatch(int64 callbackId, bool isJsCallback) : _callbackId(callbackId), _isJsCallback(isJsCallback)
+            {
+
+            }
+
+            virtual bool Execute(const CefString& name,
+                CefRefPtr<CefV8Value> object,
+                const CefV8ValueList& arguments,
+                CefRefPtr<CefV8Value>& retval,
+                CefString& exception)
+            {
+                auto context = CefV8Context::GetCurrentContext();
+
+                auto reason = arguments[0];
+                CefString reasonString;
+
+                if (reason->IsString())
+                {
+                    reasonString = reason->GetStringValue();
+                }
+                else
+                {
+                    //Convert value to String
+                    auto strFunc = context->GetGlobal()->GetValue("String");
+                    CefV8ValueList args;
+                    args.push_back(reason);
+                    auto strVal = strFunc->ExecuteFunction(nullptr, args);                    
+
+                    reasonString = strVal->GetStringValue();
+                }
+
+                auto response = CefProcessMessage::Create(_isJsCallback ? kJavascriptCallbackResponse : kEvaluateJavascriptResponse);
+                auto responseArgList = response->GetArgumentList();
+
+                //Success
+                responseArgList->SetBool(0, false);
+                //Callback Id
+                SetInt64(responseArgList, 1, _callbackId);
+                responseArgList->SetString(2, reasonString);
+
+                auto frame = context->GetFrame();
+
+                frame->SendProcessMessage(CefProcessId::PID_BROWSER, response);
+
+                return true;
+            }
+
+            IMPLEMENT_REFCOUNTINGM(JavascriptPromiseResolverCatch);
+        };
+    }
+}

--- a/CefSharp.BrowserSubprocess.Core/JavascriptPromiseResolverThen.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptPromiseResolverThen.h
@@ -1,0 +1,59 @@
+// Copyright © 2022 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "include/cef_v8.h"
+#include "..\CefSharp.Core.Runtime\Internals\Messaging\Messages.h"
+#include "..\CefSharp.Core.Runtime\Internals\Serialization\Primitives.h"
+#include "Serialization\V8Serialization.h"
+
+using namespace System;
+using namespace CefSharp::Internals::Messaging;
+using namespace CefSharp::BrowserSubprocess::Serialization;
+
+namespace CefSharp
+{
+    namespace BrowserSubprocess
+    {
+        private class JavascriptPromiseResolverThen : public CefV8Handler
+        {
+            int64 _callbackId;
+            bool _isJsCallback;
+
+        public:
+            JavascriptPromiseResolverThen(int64 callbackId, bool isJsCallback) : _callbackId(callbackId), _isJsCallback(isJsCallback)
+            {
+
+            }
+
+            virtual bool Execute(const CefString& name,
+                CefRefPtr<CefV8Value> object,
+                const CefV8ValueList& arguments,
+                CefRefPtr<CefV8Value>& retval,
+                CefString& exception)
+            {
+                auto response = CefProcessMessage::Create(_isJsCallback ? kJavascriptCallbackResponse : kEvaluateJavascriptResponse);
+
+                auto responseArgList = response->GetArgumentList();
+
+                //Success
+                responseArgList->SetBool(0, true);
+                //Callback Id
+                SetInt64(responseArgList, 1, _callbackId);
+                SerializeV8Object(arguments[0], responseArgList, 2, nullptr);
+
+                auto context = CefV8Context::GetCurrentContext();
+
+                auto frame = context->GetFrame();
+
+                frame->SendProcessMessage(CefProcessId::PID_BROWSER, response);
+
+                return true;
+            }
+
+            IMPLEMENT_REFCOUNTINGM(JavascriptPromiseResolverThen);
+        };
+    }
+}

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -81,6 +81,7 @@ namespace CefSharp.Example
             settings.CachePath = Path.GetFullPath("cache\\global");
             //settings.UserAgent = "CefSharp Browser" + Cef.CefSharpVersion; // Example User Agent
             //settings.CefCommandLineArgs.Add("renderer-startup-dialog");
+            //settings.CefCommandLineArgs.Add("disable-site-isolation-trials");
             //settings.CefCommandLineArgs.Add("enable-media-stream"); //Enable WebRTC
             //settings.CefCommandLineArgs.Add("no-proxy-server"); //Don't use a proxy server, always make direct connections. Overrides any other proxy server flags that are passed.
             //settings.CefCommandLineArgs.Add("allow-running-insecure-content"); //By default, an https page cannot run JavaScript or CSS from http URLs. This provides an override to get the old insecure behavior. Only available in 47 and above.


### PR DESCRIPTION
**Fixes:** #4276

**Summary:** 
Can now directly return a Promise when evaluating javascript

**Changes:** 
- EvaluateScriptAsync and IJavascriptCallback.ExecuteAsync now check if the returned object is a promise
and subscribe to the then/catch methods to send the deferred response back to the browser.
- Leaves the existing Evaluate As promise method unchanged.
      
**How Has This Been Tested?**  
New unit tests added

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
