### PR TITLE
Fix Visual Studio 2022 support

### DIFF
--- a/CefSharp.props
+++ b/CefSharp.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <VisualStudioProductVersion>2019</VisualStudioProductVersion>
-    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='17.0' AND Exists('$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration)\VS2022\libcef_dll_wrapper.lib')">VS2022</VisualStudioProductVersion>
+    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='17.0' AND Exists('$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration)\VS2022\libcef_dll_wrapper.lib')">2022</VisualStudioProductVersion>
 
     <PlatformToolset>v142</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>


### PR DESCRIPTION
**Issue:**
There's no open issue, because I lost the logs and reproducing it would be quite time consuming. 
When build with Visual Studio Build Tools 2022 there's an error Message complating that the library libcef_dll_wrapper.lib was not found and the library path is similar to "[...]\**VSVS2022**\[...]".

**Summary:**

The msbuild property VisualStudioProductVersion is used to build the property AdditionalLibraryDirectories. For example here:
https://github.com/cefsharp/CefSharp/blob/a69e6ee2a48bfbbe6804608bbab86d2cb3fddd85/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj#L160
There's already the prefix "VS" in place, in front of $(VisualStudioProductVersion). Thus VisualStudioProductVersion should not contain the "VS" prefix.
Any other occurence of VisualStudioProductVersion  also contains the prefix.

**Changes:**
Change VisualStudioProductVersion to "2022" instead of "VS2022"
      
**How Has This Been Tested?**  
Docker container with VS Build Tools 2022. Running build.ps1

**Types of changes**
- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
