### PR TITLE
Add Compatibility with Central Package Management

### DIFF
--- a/NuGet/PackageReference/CefSharp.Common.NETCore.targets
+++ b/NuGet/PackageReference/CefSharp.Common.NETCore.targets
@@ -142,14 +142,18 @@
     <Otherwise>
       <Choose>
         <When Condition="$(ManagePackageVersionsCentrallytrue) == 'true'">
-          <PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="109.1.11" />
-          <PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="109.1.11" />
-          <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="109.1.11" />
+          <ItemGroup>
+            <PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="109.1.11" />
+            <PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="109.1.11" />
+            <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="109.1.11" />
+          </ItemGroup>
         </When>
         <Otherwise>
-          <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="109.1.11" />
-          <PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="109.1.11" />
-          <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="109.1.11" />
+          <ItemGroup>
+            <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="109.1.11" />
+            <PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="109.1.11" />
+            <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="109.1.11" />
+          </ItemGroup>
         </Otherwise>
       </Choose>
       <ItemGroup>

--- a/NuGet/PackageReference/CefSharp.Common.NETCore.targets
+++ b/NuGet/PackageReference/CefSharp.Common.NETCore.targets
@@ -140,10 +140,19 @@
       </ItemGroup>
     </When>
     <Otherwise>
+      <Choose>
+        <When Condition="$(ManagePackageVersionsCentrallytrue) == 'true'">
+          <PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="109.1.11" />
+          <PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="109.1.11" />
+          <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="109.1.11" />
+        </When>
+        <Otherwise>
+          <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="109.1.11" />
+          <PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="109.1.11" />
+          <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="109.1.11" />
+        </Otherwise>
+      </Choose>
       <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="109.1.11" />
-        <PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="109.1.11" />
-        <PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="109.1.11" />
         <Content Include="@(CefRuntimeWin32Locales)">
           <Link>runtimes\win-x86\native\locales\%(RecursiveDir)%(FileName)%(Extension)</Link>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -165,7 +174,7 @@
           <Visible>false</Visible>
           <IncludeInVsix>true</IncludeInVsix>
         </Content>
-        
+
         <Content Include="@(CefRuntimeWin64Locales)">
           <Link>runtimes\win-x64\native\locales\%(RecursiveDir)%(FileName)%(Extension)</Link>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -187,7 +196,7 @@
           <Visible>false</Visible>
           <IncludeInVsix>true</IncludeInVsix>
         </Content>
-        
+
         <Content Include="@(CefRuntimeWinArm64Locales)">
           <Link>runtimes\win-arm64\native\locales\%(RecursiveDir)%(FileName)%(Extension)</Link>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
When a runtime identifier is NOT chosen, the default Nuget logic is to reference all possible compilations for compatibility purposes. However if Central Package Management, introduced in Nuget 6.2 ( https://devblogs.microsoft.com/nuget/introducing-central-package-management/ ) is enabled referencing the package directly in a targets file will causes an error. Additional since it is only imported at compile time, it triggers a infinite restore loop in visual studio.

**Fixes:** https://github.com/cefsharp/CefSharp/issues/4362

**Summary:** 
Updated CefSharp.Common.Netcore.Targets file to be compatible with Central Package Management. 

**Changes:** 
Added a check to see if Central package management is enabled and if so use "VersionOverride" to specify the fallback packages. 

**How Has This Been Tested?**  
Tested locally by modifying the existing, nuget packge to make sure it works, wasn't sure how to generate a Nuget test package, if you can point me at some docs I can do so if you'd like, my Organization has approved me some time to contribute and this change. 

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**

- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
