### PR TITLE
WPF - Allow ToolTip timer configuration

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1680,16 +1680,18 @@ namespace CefSharp.Wpf
         /// <param name="newValue">new value</param>
         protected virtual void OnTooltipTextChanged(string oldValue, string newValue)
         {
-            var timer = tooltipTimer;
-            if (timer == null)
-            {
-                return;
-            }
-
             // There are cases where oldValue is null and newValue is string.Empty
             // and vice versa, simply ignore when string.IsNullOrEmpty for both.
             if (string.IsNullOrEmpty(oldValue) && string.IsNullOrEmpty(newValue))
             {
+                return;
+            }
+
+            var timer = tooltipTimer;
+            if (timer == null)
+            {
+                OpenOrCloseToolTip(newValue);
+
                 return;
             }
 
@@ -2151,14 +2153,18 @@ namespace CefSharp.Wpf
         /// <param name="routedEventArgs">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
         private void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
         {
-            // TODO: Consider making the delay here configurable.
-            tooltipTimer = new DispatcherTimer(
-                TimeSpan.FromSeconds(0.5),
-                DispatcherPriority.Render,
-                OnTooltipTimerTick,
-                Dispatcher
-                );
-            tooltipTimer.IsEnabled = false;
+            var initialShowDelay = ToolTipService.GetInitialShowDelay(this);
+
+            if (initialShowDelay > 0)
+            {
+                tooltipTimer = new DispatcherTimer(
+                    TimeSpan.FromMilliseconds(initialShowDelay),
+                    DispatcherPriority.Render,
+                    OnTooltipTimerTick,
+                    Dispatcher
+                    );
+                tooltipTimer.IsEnabled = false;
+            }
 
             //Initial value for screen location
             browserScreenLocation = GetBrowserScreenLocation();


### PR DESCRIPTION
Related to issue #4048

**Summary:** 
Allow programmatic configuration of ToolTip timer delay.

**Changes:** 
- Can set initial show delay in xaml via existing ToolTipService e.g. ToolTipService.InitialShowDelay="100"
- If InitialShowDelay = 0 then no timer is used and ToolTip is immediately shown
- Previous delay was 500ms, new delay is the .Net default (typically 1000ms)
- ToolTipService.GetInitialShowDelay is currently only called in `OnLoaded`, setting the delay dynamically is not currently supported. Simplest option is to set the delay in `xaml`

**How Has This Been Tested?**  
- Manually via CefSharp.Wpf.Example

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior for the ChromiumWebBrowser control so tooltips open and close more reliably when content changes.
  * Tooltip show delay now respects system/user settings (initial show delay), giving a more consistent and expected experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->