### PR TITLE
WPF - Use WpfImeKeyboardHandler for supported KeyboardLayoutIds

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -800,7 +800,7 @@ namespace CefSharp.Wpf
                 }
                 else
                 {
-                    InputLanguageManager.Current.InputLanguageChanged += OnInputLangageChanged;
+                    InputLanguageManager.Current.InputLanguageChanged += OnInputLanguageChanged;
 
                     WpfKeyboardHandler = new WpfKeyboardHandler(this);
                 }
@@ -808,7 +808,7 @@ namespace CefSharp.Wpf
             catch (Exception ex)
             {
                 //For now we'll ignore any errors
-                Trace.TraceError($"Error unsubscribing from InputLanguageChanged {ex.ToString()}");
+                Trace.TraceError($"Error initializing keyboard handler: {ex.ToString()}");
 
                 // For now we'll ignore any errors and just use the default keyboard handler
                 WpfKeyboardHandler = new WpfKeyboardHandler(this);
@@ -1796,7 +1796,7 @@ namespace CefSharp.Wpf
             }
         }
 
-        private void OnInputLangageChanged(object sender, InputLanguageEventArgs e)
+        private void OnInputLanguageChanged(object sender, InputLanguageEventArgs e)
         {
             // If we are already using the WpfImeKeyboardHandler then we'll ignore any changes
             if (WpfKeyboardHandler?.GetType() == typeof(WpfImeKeyboardHandler))
@@ -1812,7 +1812,7 @@ namespace CefSharp.Wpf
                 WpfKeyboardHandler = new WpfImeKeyboardHandler(this);
                 oldKeyboardHandler?.Dispose();                
 
-                InputLanguageManager.Current.InputLanguageChanged -= OnInputLangageChanged;
+                InputLanguageManager.Current.InputLanguageChanged -= OnInputLanguageChanged;
             }
         }
 
@@ -2925,7 +2925,7 @@ namespace CefSharp.Wpf
             }
         }
 
-        private void UnsubsribeInputLanguageChanged()
+        private void UnsubscribeInputLanguageChanged()
         {
             // If we are using WpfImeKeyboardHandler then we
             // shouldn't need to unsubsribe from the handler
@@ -2944,7 +2944,7 @@ namespace CefSharp.Wpf
 
                     if (inputLangManager != null)
                     {
-                        inputLangManager.InputLanguageChanged -= OnInputLangageChanged;
+                        inputLangManager.InputLanguageChanged -= OnInputLanguageChanged;
                     }
                 });
             }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -759,7 +759,7 @@ namespace CefSharp.Wpf
                 // is called.
                 LifeSpanHandler = null;
 
-                UnsubsribeInputLanguageChanged();
+                UnsubscribeInputLanguageChanged();
 
                 WpfKeyboardHandler?.Dispose();
                 WpfKeyboardHandler = null;

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -354,7 +354,7 @@ namespace CefSharp.Wpf.Experimental
             }
         }
 
-        private int PrimaryLangId(int lgid)
+        private static int PrimaryLangId(int lgid)
         {
             return lgid & 0x3ff;
         }
@@ -466,6 +466,26 @@ namespace CefSharp.Wpf.Experimental
             }
 
             return current as FrameworkElement;
+        }
+
+        /// <summary>
+        /// Based on the <paramref name="keyboardLayoutId"/> determine if we
+        /// should be using IME.
+        /// </summary>
+        /// <param name="keyboardLayoutId">Keyboard Layout Id (obtained from <see cref="System.Globalization.CultureInfo.KeyboardLayoutId"/></param>
+        /// <returns>
+        /// returns true if the keyboard layout matches one of our listed that support IME, otherwise false.
+        /// </returns>
+        public static bool UseImeKeyboardHandler(int keyboardLayoutId)
+        {
+            var langId = PrimaryLangId(keyboardLayoutId);
+
+            if (langId == ImeNative.LANG_KOREAN || langId == ImeNative.LANG_JAPANESE || langId == ImeNative.LANG_CHINESE)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -472,7 +472,7 @@ namespace CefSharp.Wpf.Experimental
         /// Based on the <paramref name="keyboardLayoutId"/> determine if we
         /// should be using IME.
         /// </summary>
-        /// <param name="keyboardLayoutId">Keyboard Layout Id (obtained from <see cref="System.Globalization.CultureInfo.KeyboardLayoutId"/></param>
+        /// <param name="keyboardLayoutId">Keyboard Layout Id (obtained from <see cref="System.Globalization.CultureInfo.KeyboardLayoutId"/>)</param>
         /// <returns>
         /// returns true if the keyboard layout matches one of our listed that support IME, otherwise false.
         /// </returns>


### PR DESCRIPTION
**Fixes:** #1262

**Summary:** 
- Determine which keyboard handler to use based on CurrentInputLanguage

**Changes:**
- Setup default keyboard handler based on `CurrentInputLanguage`
- Detect changes in input language
      
**How Has This Been Tested?**  
Minimal Testing, requires user feedback

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved keyboard handler to dynamically adapt to input language changes, providing better support for languages requiring IME (e.g., Korean, Japanese, Chinese).
- **Bug Fixes**
  - Enhanced event management to ensure proper cleanup of input language event subscriptions, reducing potential issues during language switching.
- **Refactor**
  - Streamlined logic for determining when to use IME keyboard handling based on keyboard layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->