### PR TITLE
Core - ClientAdapter improve HasParent checks

### DIFF
--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
@@ -95,13 +95,13 @@ namespace CefSharp
             return nullptr;
         }
 
-        // Is a Hosted browser if the IBrowser instance is directly associated
+        // Is a main browser if isPopuo == false or the IBrowser instance is directly associated
         // with the ChromiumWebBrowser instance. Should be true in cases
         // where ChromiumWebBrowser is instanciated directly or
         // when a popup is hosted in a ChromiumWebBrowser instance
         // For popups hosted in ChromiumWebBrowser instances it's important
         // that DevTools popups return false;
-        bool ClientAdapter::IsHostedBrowser(bool isPopup, int browserId)
+        bool ClientAdapter::IsMainBrowser(bool isPopup, int browserId)
         {
             // Main browser is always true
             if (!isPopup)
@@ -219,7 +219,7 @@ namespace CefSharp
 
             auto browserWrapper = gcnew CefBrowserWrapper(browser);
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserHwnd = browser->GetHost()->GetWindowHandle();
                 _cefBrowser = browser;
@@ -276,7 +276,7 @@ namespace CefSharp
                 handler->OnBeforeClose(_browserControl, %browserWrapper);
             }
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _cefBrowser = nullptr;
             }
@@ -297,7 +297,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             auto args = gcnew LoadingStateChangedEventArgs(browserWrapper, canGoBack, canGoForward, isLoading);
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->SetLoadingStateChange(args);
             }
@@ -315,7 +315,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             auto args = gcnew AddressChangedEventArgs(browserWrapper, StringUtils::ToClr(address));
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->SetAddress(args);
             }
@@ -388,7 +388,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             auto args = gcnew TitleChangedEventArgs(browserWrapper, StringUtils::ToClr(title));
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->SetTitle(args);
             }
@@ -460,7 +460,7 @@ namespace CefSharp
                     returnFlag = handler->OnTooltipChanged(_browserControl, tooltip);
                 }
 
-                if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+                if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
                 {
                     _tooltip = tooltip;
                     _browserControl->SetTooltipText(_tooltip);
@@ -476,7 +476,7 @@ namespace CefSharp
 
             auto args = gcnew ConsoleMessageEventArgs(browserWrapper, (LogSeverity)level, StringUtils::ToClr(message), StringUtils::ToClr(source), line);
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->OnConsoleMessage(args);
             }
@@ -495,7 +495,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             auto args = gcnew StatusMessageEventArgs(browserWrapper, StringUtils::ToClr(value));
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->OnStatusMessage(args);
             }
@@ -546,7 +546,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             CefFrameWrapper frameWrapper(frame);
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->OnFrameLoadStart(gcnew FrameLoadStartEventArgs(browserWrapper, %frameWrapper, (CefSharp::TransitionType)transitionType));
             }
@@ -563,7 +563,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             CefFrameWrapper frameWrapper(frame);
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->OnFrameLoadEnd(gcnew FrameLoadEndEventArgs(browserWrapper, %frameWrapper, httpStatusCode));
             }
@@ -581,7 +581,7 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
             CefFrameWrapper frameWrapper(frame);
 
-            if (IsHostedBrowser(browser->IsPopup(), browser->GetIdentifier()))
+            if (IsMainBrowser(browser->IsPopup(), browser->GetIdentifier()))
             {
                 _browserControl->OnLoadError(gcnew LoadErrorEventArgs(browserWrapper, %frameWrapper,
                     (CefErrorCode)errorCode, StringUtils::ToClr(errorText), StringUtils::ToClr(failedUrl)));

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
@@ -115,17 +115,17 @@ namespace CefSharp
                 return false;
             }
 
-            // This method is called from OnAfterCreated before _browser is set
-            // If the _browser reference is null then this should be a ChromiumWebBrowser
+            // This method is called from OnAfterCreated before _cefBrowser is set
+            // If the _cefBrowser reference is null then this should be a ChromiumWebBrowser
             // hosted as a popup
-            if (Object::ReferenceEquals(_browser, nullptr))
+            if (!_cefBrowser.get())
             {
                 return true;
             }
 
             // For popups hosted in ChromiumWebBrowser instance directly (non DevTools popup)
             // then return true;
-            if (_browser->Identifier == browserId)
+            if (_cefBrowser->GetIdentifier() == browserId)
             {
                 return true;
             }

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
@@ -1118,7 +1118,18 @@ namespace CefSharp
                 auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
                 auto frameWrapper = gcnew CefFrameWrapper(frame);
 
-                handler->OnFrameCreated(_browserControl, browserWrapper, frameWrapper);
+                if (browserWrapper == nullptr)
+                {
+                    // Very first OnFrameCreated called may happen before OnAfterCreated
+                    // so we have to create a new wrapper that's lifespan is scoped to this single call.
+                    CefBrowserWrapper browserWrapper(browser);
+
+                    handler->OnFrameCreated(_browserControl, %browserWrapper, frameWrapper);
+                }
+                else
+                {
+                    handler->OnFrameCreated(_browserControl, browserWrapper, frameWrapper);
+                }
             }
         }
 

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
@@ -75,23 +75,24 @@ namespace CefSharp
 
         IBrowser^ ClientAdapter::GetBrowserWrapper(int browserId, bool isPopup)
         {
+            if (!isPopup)
+            {
+                return _browser;
+            }
+
+            IBrowser^ popupBrowser;
+            if (_popupBrowsers->TryGetValue(browserId, popupBrowser))
+            {
+                return popupBrowser;
+            }
+
+            // For popups that were hosted using a ChromiumWebBrowser instance
             if (_browserControl->HasParent)
             {
                 return _browser;
             }
 
-            if (isPopup)
-            {
-                IBrowser^ popupBrowser;
-                if (_popupBrowsers->TryGetValue(browserId, popupBrowser))
-                {
-                    return popupBrowser;
-                }
-
-                return nullptr;
-            }
-
-            return _browser;
+            return nullptr;
         }
 
         void ClientAdapter::CloseAllPopups(bool forceClose)

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.h
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.h
@@ -87,7 +87,7 @@ namespace CefSharp
             void CloseAllPopups(bool forceClose);
             void MethodInvocationComplete(MethodInvocationResult^ result);
             IBrowser^ GetBrowserWrapper(int browserId);
-            bool IsHostedBrowser(bool isPopup, int browserId);
+            bool IsMainBrowser(bool isPopup, int browserId);
 
             // CefClient
             virtual DECL CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.h
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.h
@@ -87,6 +87,7 @@ namespace CefSharp
             void CloseAllPopups(bool forceClose);
             void MethodInvocationComplete(MethodInvocationResult^ result);
             IBrowser^ GetBrowserWrapper(int browserId);
+            bool IsHostedBrowser(bool isPopup, int browserId);
 
             // CefClient
             virtual DECL CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }

--- a/CefSharp.WinForms.Example/Handlers/WinFormsLifeSpanHandlerEx.cs
+++ b/CefSharp.WinForms.Example/Handlers/WinFormsLifeSpanHandlerEx.cs
@@ -1,0 +1,170 @@
+// Copyright © 2023 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+using System;
+using System.Windows.Forms;
+using CefSharp.WinForms.Host;
+
+namespace CefSharp.WinForms.Example.Handlers
+{
+    /// <summary>
+    /// A WinForms Specific <see cref="ILifeSpanHandler"/> implementation that demos
+    /// the process of hosting a Popup using a <see cref="ChromiumWebBrowser"/> instance.
+    /// This <see cref="ILifeSpanHandler"/> implementation returns true in <see cref="ILifeSpanHandler.DoClose(IWebBrowser, IBrowser)"/>
+    /// so no WM_CLOSE message is sent, this differs from the default CEF behaviour.
+    /// </summary>
+    internal class WinFormsLifeSpanHandlerEx : CefSharp.Handler.LifeSpanHandler
+    {
+        private Action<ChromiumWebBrowser> onPopupBrowserCreated;
+        private Action<ChromiumWebBrowser> onPopupDestroyed;
+        private Action<ChromiumWebBrowser, string> onPopupCreated;
+
+        /// <summary>
+        /// The <paramref name="onPopupBrowserCreated"/> delegate will be called when the underlying CEF <see cref="IBrowser"/> has been
+        /// created. The <see cref="IBrowser"/> instance is valid until <see cref="OnPopupDestroyed(Action{ChromiumWebBrowser})"/>
+        /// is called. <see cref="IBrowser"/> provides low level access to the CEF Browser, you can access frames, view source,
+        /// perform navigation (via frame) etc. This is equivilent to the <see cref="ILifeSpanHandler.OnAfterCreated(IWebBrowser, IBrowser)"/>.
+        /// </summary>
+        /// <param name="onPopupBrowserCreated">Action to be invoked when the <see cref="IBrowser"/> has been created.</param>
+        /// <returns><see cref="WinFormsLifeSpanHandlerEx"/> instance allowing you to chain method calls together</returns>
+        public WinFormsLifeSpanHandlerEx OnPopupBrowserCreated(Action<ChromiumWebBrowser> onPopupBrowserCreated)
+        {
+            this.onPopupBrowserCreated = onPopupBrowserCreated;
+
+            return this;
+        }
+
+        /// <summary>
+        /// The <paramref name="onPopupDestroyed"/> will be called when the <see cref="ChromiumWebBrowser"/> is to be
+        /// removed from it's parent.
+        /// When the <see cref="OnPopupDestroyedDelegate"/> is called you must remove/dispose of the <see cref="ChromiumWebBrowser"/>.
+        /// </summary>
+        /// <param name="onPopupDestroyed">Action to be invoked when the Popup is to be destroyed.</param>
+        /// <returns><see cref="WinFormsLifeSpanHandlerEx"/> instance allowing you to chain method calls together</returns>
+        public WinFormsLifeSpanHandlerEx OnPopupDestroyed(Action<ChromiumWebBrowser> onPopupDestroyed)
+        {
+            this.onPopupDestroyed = onPopupDestroyed;
+
+            return this;
+        }
+
+        /// <summary>
+        /// The <paramref name="onPopupCreated"/> will be called when the<see cref="ChromiumWebBrowser"/> has been
+        /// created. When the <paramref name="onPopupCreated"/> is called you must add the control to it's intended parent.
+        /// </summary>
+        /// <param name="onPopupCreated">Action to be invoked when the Popup host has been created and is ready to be attached to it's parent.</param>
+        /// <returns><see cref="WinFormsLifeSpanHandlerEx"/> instance allowing you to chain method calls together</returns>
+        public WinFormsLifeSpanHandlerEx OnPopupCreated(Action<ChromiumWebBrowser, string> onPopupCreated)
+        {
+            this.onPopupCreated = onPopupCreated;
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        protected override bool DoClose(IWebBrowser chromiumWebBrowser, IBrowser browser)
+        {
+            if (browser.IsPopup)
+            {
+                var control = ChromiumHostControlBase.FromBrowser<ChromiumWebBrowser>(browser);
+
+                //We don't have a parent control so we allow the default behaviour, required to close
+                //default popups e.g. DevTools
+                if (control == null)
+                {
+                    return false;
+                }
+
+                //If the main browser is disposed or the handle has been released then we don't
+                //need to remove the popup (likely removed from menu)
+                if (!control.IsDisposed && control.IsHandleCreated)
+                {
+                    try
+                    {
+                        control.BeginInvoke(new Action(() =>
+                        {
+                            onPopupDestroyed?.Invoke(control);
+
+                            control.Dispose();
+                        }));
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // If the popup is being hosted on a Form that is being
+                        // Closed/Disposed as we attempt to call Control.BeginInvoke
+                        // we can end up with an ObjectDisposedException
+                        // return false (Default behaviour).
+                        return false;
+                    }
+                }
+            }
+
+            //No WM_CLOSE message will be sent, manually handle closing
+            return true;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnAfterCreated(IWebBrowser chromiumWebBrowser, IBrowser browser)
+        {
+            if (browser.IsPopup)
+            {
+                var control = ChromiumHostControlBase.FromBrowser<ChromiumWebBrowser>(browser);
+
+                if (control != null)
+                {
+                    onPopupBrowserCreated?.Invoke(control);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnBeforeClose(IWebBrowser chromiumWebBrowser, IBrowser browser)
+        {
+            if (!browser.IsDisposed && browser.IsPopup)
+            {
+                
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// NOTE: DevTools popups DO NOT trigger OnBeforePopup.
+        /// </remarks>
+        protected override bool OnBeforePopup(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string targetUrl, string targetFrameName, WindowOpenDisposition targetDisposition, bool userGesture, IPopupFeatures popupFeatures, IWindowInfo windowInfo, IBrowserSettings browserSettings, ref bool noJavascriptAccess, out IWebBrowser newBrowser)
+        {
+            newBrowser = null;
+
+            var webBrowser = (ChromiumWebBrowser)chromiumWebBrowser;
+
+            ChromiumWebBrowser control = null;
+
+            //We need to execute sync here so IWindowInfo.SetAsChild is called before we return false;
+            webBrowser.Invoke(new Action(() =>
+            {
+                control = new ChromiumWebBrowser
+                {
+                    Dock = DockStyle.Fill
+                };
+
+                //NOTE: This is important and must be called before the handle is created
+                control.SetAsPopup();
+                control.LifeSpanHandler = this;
+
+                control.CreateControl();
+
+                var rect = control.ClientRectangle;
+
+                var windowBounds = new CefSharp.Structs.Rect(rect.X, rect.Y, rect.Width, rect.Height);
+
+                windowInfo.SetAsChild(control.Handle, windowBounds);
+
+                onPopupCreated?.Invoke(control, targetUrl);
+            }));
+
+            newBrowser = control;
+
+            return false;
+        }
+    }
+}

--- a/CefSharp.WinForms.Example/Handlers/WinFormsLifeSpanHandlerEx.cs
+++ b/CefSharp.WinForms.Example/Handlers/WinFormsLifeSpanHandlerEx.cs
@@ -18,7 +18,7 @@ namespace CefSharp.WinForms.Example.Handlers
     {
         private Action<ChromiumWebBrowser> onPopupBrowserCreated;
         private Action<ChromiumWebBrowser> onPopupDestroyed;
-        private Action<ChromiumWebBrowser, string> onPopupCreated;
+        private Action<ChromiumWebBrowser, string, string, CefSharp.Structs.Rect> onPopupCreated;
 
         /// <summary>
         /// The <paramref name="onPopupBrowserCreated"/> delegate will be called when the underlying CEF <see cref="IBrowser"/> has been
@@ -55,7 +55,7 @@ namespace CefSharp.WinForms.Example.Handlers
         /// </summary>
         /// <param name="onPopupCreated">Action to be invoked when the Popup host has been created and is ready to be attached to it's parent.</param>
         /// <returns><see cref="WinFormsLifeSpanHandlerEx"/> instance allowing you to chain method calls together</returns>
-        public WinFormsLifeSpanHandlerEx OnPopupCreated(Action<ChromiumWebBrowser, string> onPopupCreated)
+        public WinFormsLifeSpanHandlerEx OnPopupCreated(Action<ChromiumWebBrowser, string, string, CefSharp.Structs.Rect> onPopupCreated)
         {
             this.onPopupCreated = onPopupCreated;
 
@@ -109,12 +109,18 @@ namespace CefSharp.WinForms.Example.Handlers
         {
             if (browser.IsPopup)
             {
-                var control = ChromiumHostControlBase.FromBrowser<ChromiumWebBrowser>(browser);
+                var webBrowser = (ChromiumWebBrowser)chromiumWebBrowser;
 
-                if (control != null)
+                webBrowser.BeginInvoke((Action) (() =>
                 {
-                    onPopupBrowserCreated?.Invoke(control);
-                }
+                    var control = ChromiumHostControlBase.FromBrowser<ChromiumWebBrowser>(browser);
+
+                    if (control != null)
+                    {
+                        onPopupBrowserCreated?.Invoke(control);
+                    }
+                }));
+                
             }
         }
 
@@ -159,7 +165,7 @@ namespace CefSharp.WinForms.Example.Handlers
 
                 windowInfo.SetAsChild(control.Handle, windowBounds);
 
-                onPopupCreated?.Invoke(control, targetUrl);
+                onPopupCreated?.Invoke(control, targetUrl, targetFrameName, windowBounds);
             }));
 
             newBrowser = control;


### PR DESCRIPTION
Related discussion https://github.com/cefsharp/CefSharp/discussions/4438

**Summary:** 
- Rewrite HasParent checks to make sure that IWebBrowser.Set* methods are only called for a IBrowser
  instance that's directly associated with a ChromiumWebBrowser instance

**Changes:**
- HasParent check has now been replaced with IsHostedBrowser
  which has additional check to make sure the internal
  IWebBrowser.Set* methods are only called for a IBrowser
  instance that's directly associated with a ChromiumWebBrowser instance
  This resolves issues with DevTools being opened for a popup hosted
  in a ChromiumWebBrowser instance.

      
**How Has This Been Tested?**  
Tested using the `LifeSpanHandler` implementation in the comment below.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
