### PR TITLE
WPF Example - Implement Material Design

### DIFF
--- a/CefSharp.Wpf.Example/App.xaml
+++ b/CefSharp.Wpf.Example/App.xaml
@@ -1,55 +1,62 @@
 <Application x:Class="CefSharp.Wpf.Example.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:controls="clr-namespace:CefSharp.Wpf.Example.Controls"
              xmlns:view="clr-namespace:CefSharp.Wpf.Example.Views"
              xmlns:viewModel="clr-namespace:CefSharp.Wpf.Example.ViewModels"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <!-- Used for testing https://github.com/cefsharp/CefSharp/issues/2488 -->
-        <!--<Style TargetType="ToolTip">
-            <Setter Property="ContentTemplate">
-                <Setter.Value>
-                    <DataTemplate>
-                        <StackPanel>
-                            <TextBlock Text="{Binding}"  MaxWidth="400" TextWrapping='Wrap' />
-                        </StackPanel>
-                    </DataTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>-->
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-        <Style TargetType="{x:Type controls:NonReloadingTabControl}">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type controls:NonReloadingTabControl}">
-                        <Grid Background="{TemplateBinding Background}"
+            <!-- Used for testing https://github.com/cefsharp/CefSharp/issues/2488 -->
+            <!--<Style TargetType="ToolTip">
+                <Setter Property="ContentTemplate">
+                    <Setter.Value>
+                        <DataTemplate>
+                            <StackPanel>
+                                <TextBlock Text="{Binding}"  MaxWidth="400" TextWrapping='Wrap' />
+                            </StackPanel>
+                        </DataTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>-->
+
+            <Style TargetType="{x:Type controls:NonReloadingTabControl}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type controls:NonReloadingTabControl}">
+                            <Grid Background="{TemplateBinding Background}"
                               ClipToBounds="True"
                               KeyboardNavigation.TabNavigation="Local"
                               SnapsToDevicePixels="True">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="ColumnDefinition0" />
-                                <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition x:Name="RowDefinition0" Height="Auto" />
-                                <RowDefinition x:Name="RowDefinition1" Height="*" />
-                            </Grid.RowDefinitions>
-                            <StackPanel Orientation="Horizontal">
-                                <TabPanel x:Name="HeaderPanel"
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition x:Name="ColumnDefinition0" />
+                                    <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition x:Name="RowDefinition0" Height="Auto" />
+                                    <RowDefinition x:Name="RowDefinition1" Height="*" />
+                                </Grid.RowDefinitions>
+                                <StackPanel Orientation="Horizontal">
+                                    <TabPanel x:Name="HeaderPanel"
                                           Margin="0,0,0,-1"
                                           VerticalAlignment="Bottom"
                                           Panel.ZIndex="1"
                                           IsItemsHost="True"
                                           KeyboardNavigation.TabIndex="1" />
-                                <Button Content="+"
-                                        FontSize="12"
-                                        FontWeight="Bold"
-                                        Margin="10, 0, 0, 0"
+                                    <Button Margin="10, 0, 0, 0"
+                                        ToolTip="Open new Tab"
+                                        Style="{StaticResource MaterialDesignToolButton}"
+                                        Content="{materialDesign:PackIcon Kind=TabAdd, Size=16}"
                                         Width="25"
                                         Command="ApplicationCommands.New" />
-                            </StackPanel>
-                            <Border x:Name="ContentPanel"
+                                </StackPanel>
+                                <Border x:Name="ContentPanel"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Background="Transparent"
@@ -58,42 +65,43 @@
                                     KeyboardNavigation.DirectionalNavigation="Contained"
                                     KeyboardNavigation.TabIndex="2"
                                     KeyboardNavigation.TabNavigation="Local">
-                                <Grid x:Name="PART_ItemsHolder"
+                                    <Grid x:Name="PART_ItemsHolder"
                                       Margin="{TemplateBinding Padding}"
                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                            </Border>
-                        </Grid>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
+                                </Border>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
 
-        <Style TargetType="TabItem">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="TabItem">
-                        <Border Name="Border" BorderThickness="1,1,1,0" BorderBrush="Gainsboro" Margin="2,0">
-                            <ContentPresenter x:Name="ContentSite"
+            <Style TargetType="TabItem">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TabItem">
+                            <Border Name="Border" BorderThickness="1,1,1,0" BorderBrush="Gainsboro" Margin="2,0">
+                                <ContentPresenter x:Name="ContentSite"
                                               VerticalAlignment="Center"
                                               HorizontalAlignment="Center"
                                               ContentSource="Header"
                                               Margin="10,2"/>
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsSelected" Value="True">
-                                <Setter TargetName="Border" Property="Background" Value="LightSkyBlue" />
-                            </Trigger>
-                            <Trigger Property="IsSelected" Value="False">
-                                <Setter TargetName="Border" Property="Background" Value="GhostWhite" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <DataTemplate DataType="{x:Type viewModel:BrowserTabViewModel}">
-            <view:BrowserTabView />
-        </DataTemplate>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter TargetName="Border" Property="Background" Value="LightSkyBlue" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="False">
+                                    <Setter TargetName="Border" Property="Background" Value="GhostWhite" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            
+            <DataTemplate DataType="{x:Type viewModel:BrowserTabViewModel}">
+                <view:BrowserTabView />
+            </DataTemplate>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -32,6 +32,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="chromiumembeddedframework.runtime" Version="111.2.7" />
+        <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="bin.netcore\**" />

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
     <!-- Note: We cannot use the recommended style of specifying <Project Sdk=...> because we need
        to set BaseIntermediateOutputPath and BaseOutputPath before the SDK props are imported. -->
@@ -42,6 +42,7 @@
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
         <PackageReference Include="chromiumembeddedframework.runtime" Version="111.2.7" />
         <PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
+        <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -1,8 +1,16 @@
 <Window x:Class="CefSharp.Wpf.Example.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:controls="clr-namespace:CefSharp.Wpf.Example.Controls"
         xmlns:ex="clr-namespace:CefSharp.Example;assembly=CefSharp.Example"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal" 
+        TextOptions.TextRenderingMode="Auto"        
+        Background="{DynamicResource MaterialDesignPaper}"
+        FontFamily="{DynamicResource MaterialDesignFont}"
         Title="CefSharp.Wpf.Example"
         WindowState="Maximized">
     <Window.InputBindings>
@@ -63,12 +71,10 @@
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="{Binding Title}"/>
-                        <Button Content="X"
-                                Height="20"
+                        <Button Height="20"
                                 Width="20"
-                                FontFamily="Courier"
-                                FontWeight="Bold"
-                                Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                                Style="{StaticResource MaterialDesignToolButton}"
+                                Content="{materialDesign:PackIcon Kind=Close, Size=14}"
                                 Command="Close"
                                 FontSize="10"
                                 Padding="0"

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -18,7 +18,7 @@
         <KeyBinding Key="W" Modifiers="Control" Command="Close"/>
     </Window.InputBindings>
     <DockPanel>
-        <Menu DockPanel.Dock="Top">
+        <Menu DockPanel.Dock="Top" materialDesign:MenuAssist.TopLevelMenuItemHeight="25">
             <MenuItem Header="_File">
                 <MenuItem Header="_New Tab" Command="New"/>
                 <MenuItem Header="_Close Tab" Command="Close"/>

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
@@ -61,6 +61,7 @@
         </DockPanel>
         <StackPanel DockPanel.Dock="Right"
                         Margin="6,3"
+                        Width="300"
                         Visibility="{Binding ShowSidebar, Converter={StaticResource BooleanToVisibilityConverter}}">
             <GroupBox Header="Tweak WPF Rendering">
                 <Grid>
@@ -102,15 +103,15 @@
                 </Grid>
             </GroupBox>
             <GroupBox Header="Execute Javascript (asynchronously)">
-                <Grid Width="300">
+                <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="75" />
-                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <TextBox x:Name="ExecuteJavascriptTextBox"
                                  Grid.Row="0"
                                  AcceptsReturn="True"
-                                 Margin="6"
+                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                  Text="$('#modify-me').text('See how easy that was?')">
                         <TextBox.InputBindings>
                             <KeyBinding Key="Enter"
@@ -120,26 +121,26 @@
                         </TextBox.InputBindings>
                     </TextBox>
                     <Button Grid.Row="1"
-                                HorizontalAlignment="Left"
-                                Margin="6,0,6,6"
-                                Padding="5,2"
-                                Content="Run"
+                                HorizontalAlignment="Center"
+                                Margin="0, 5, 0, 0"
+                                Content="Execute"
+                                ToolTip="Execute JavaScript"
                                 Command="{Binding ExecuteJavaScriptCommand}"
                                 CommandParameter="{Binding Text, ElementName=ExecuteJavascriptTextBox}" />
                 </Grid>
             </GroupBox>
             <GroupBox Header="Evaluate Javascript (Async)">
-                <Grid Width="300">
+                <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="75" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <TextBox x:Name="EvaluateJavascriptTextBox"
                                  Grid.Row="0"
-                                 Margin="6"
                                  AcceptsReturn="True"
+                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                  Text="1 + 1">
                         <TextBox.InputBindings>
                             <KeyBinding Key="Enter"
@@ -149,14 +150,13 @@
                         </TextBox.InputBindings>
                     </TextBox>
                     <Button Grid.Row="1"
-                                HorizontalAlignment="Left"
-                                Margin="6,0"
-                                Padding="5,2"
-                                Content="Run"
+                                HorizontalAlignment="Center"
+                                Margin="0, 5, 0, 0"
+                                Content="Evaluate"
+                                ToolTip="Evaluate JavaScript"
                                 Command="{Binding EvaluateJavaScriptCommand}"
                                 CommandParameter="{Binding Text, ElementName=EvaluateJavascriptTextBox}" />
-                    <TextBlock Grid.Row="2"
-                                   Margin="6">Result:</TextBlock>
+                    <TextBlock Grid.Row="2" Margin="6">Result:</TextBlock>
                     <TextBox Grid.Row="3"
                                  IsReadOnly="True"
                                  Margin="6,0,6,6"
@@ -164,7 +164,7 @@
                 </Grid>
             </GroupBox>
             <GroupBox Header="Tests">
-                <Button HorizontalAlignment="Left"
+                <Button HorizontalAlignment="Center"
                             Margin="6,0"
                             Padding="5,2"
                             Command="{Binding JavascriptBindingStressTest}"

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
@@ -112,7 +112,7 @@
                                  Grid.Row="0"
                                  AcceptsReturn="True"
                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                 Text="$('#modify-me').text('See how easy that was?')">
+                                 Text="document.body.style.backgroundColor = 'red';">
                         <TextBox.InputBindings>
                             <KeyBinding Key="Enter"
                                             Modifiers="Control"

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:cefSharp="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
              xmlns:local="clr-namespace:CefSharp.Wpf.Example.ViewModels"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -19,412 +20,420 @@
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
     </UserControl.Resources>
-    <Grid>
-        <DockPanel>
-            <DockPanel VerticalAlignment="Top"
-                       DockPanel.Dock="Top">
-                <Button Height="23"
-                        Width="75"
-                        Command="{Binding HomeCommand}">Home</Button>
-                <Button Height="23"
-                        Width="75"
-                        Command="{Binding WebBrowser.BackCommand}">Back</Button>
-                <Button Height="23"
-                        Width="75"
-                        Command="{Binding WebBrowser.ForwardCommand}">Forward</Button>
-                <Button Height="23"
-                        Width="75"
-                        Command="{Binding WebBrowser.ReloadCommand}">Reload</Button>
-                <Button Height="23"
-                        Name="goStopButton"
-                        Width="75"
-                        DockPanel.Dock="Right"
-                        Command="{Binding GoCommand}">Go</Button>
-                <TextBox Height="23"
-                         Text="{Binding AddressEditable, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         GotKeyboardFocus="OnTextBoxGotKeyboardFocus"
-                         GotMouseCapture="OnTextBoxGotMouseCapture">
-                    <TextBox.InputBindings>
-                        <KeyBinding Key="Enter"
+    <DockPanel LastChildFill="True">
+        <DockPanel DockPanel.Dock="Top" Margin="5">
+            <Button Command="{Binding HomeCommand}"
+                    Margin="16,0,0,0"
+                    ToolTip="Navigate Home"
+                    Style="{StaticResource MaterialDesignToolButton}"
+                    Content="{materialDesign:PackIcon Kind=Home, Size=24}"/>
+            <Button Command="{Binding WebBrowser.BackCommand}"
+                    Margin="24,0,0,0"
+                    ToolTip="Navigate Back"
+                    Content="{materialDesign:PackIcon Kind=NavigateBefore, Size=24}"
+                    Style="{StaticResource MaterialDesignToolButton}"/>
+            <Button Command="{Binding WebBrowser.ForwardCommand}"
+                    Margin="24,0,0,0"
+                    ToolTip="Navigate Forward"
+                    Content="{materialDesign:PackIcon Kind=NavigateNext, Size=24}"
+                    Style="{StaticResource MaterialDesignToolButton}"/>
+            <Button Command="{Binding WebBrowser.ReloadCommand}"
+                    ToolTip="Reload Browser"
+                    Margin="24,0,0,0"
+                    Content="{materialDesign:PackIcon Kind=Reload, Size=24}"
+                    Style="{StaticResource MaterialDesignToolButton}"/>
+            <Button Command="{Binding GoCommand}"
+                    ToolTip="Navigate To Url"
+                    Margin="16,0,0,0"
+                    Content="{materialDesign:PackIcon Kind=OpenInBrowser, Size=24}"
+                    Style="{StaticResource MaterialDesignToolButton}"
+                    DockPanel.Dock="Right"/>
+            <TextBox Text="{Binding AddressEditable, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                     Margin="16,0,0,0"
+                     GotKeyboardFocus="OnTextBoxGotKeyboardFocus"
+                     GotMouseCapture="OnTextBoxGotMouseCapture">
+                <TextBox.InputBindings>
+                    <KeyBinding Key="Enter"
                                     Command="{Binding GoCommand}" />
-                    </TextBox.InputBindings>
-                </TextBox>
-            </DockPanel>
-            <StackPanel DockPanel.Dock="Right"
+                </TextBox.InputBindings>
+            </TextBox>
+        </DockPanel>
+        <StackPanel DockPanel.Dock="Right"
                         Margin="6,3"
                         Visibility="{Binding ShowSidebar, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <GroupBox Header="Tweak WPF Rendering">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Label Grid.Row="0"
+            <GroupBox Header="Tweak WPF Rendering">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0"
                                Grid.Column="0"
                                Content="Angle:" />
-                        <Slider Grid.Row="0"
+                    <Slider Grid.Row="0"
                                 Grid.Column="1"
                                 Name="angleSlider"
                                 Minimum="-180"
                                 Maximum="180" />
-                        <Label Grid.Row="1"
+                    <Label Grid.Row="1"
                                Grid.Column="0"
                                Content="Watermark Opacity:" />
-                        <Slider Grid.Row="1"
+                    <Slider Grid.Row="1"
                                 Grid.Column="1"
                                 Name="opacitySlider"
                                 Minimum="0"
                                 Maximum="1"
                                 TickFrequency="0.01"
                                 Value="0.95" />
-                        <Label Grid.Row="2"
+                    <Label Grid.Row="2"
                                Grid.Column="0"
                                Content="Bitmap Scaling Mode:" />
-                        <ComboBox Grid.Row="2"
+                    <ComboBox Grid.Row="2"
                                   Grid.Column="1"
                                   Name="scalingModeComboBox"
                                   ItemsSource="{Binding Source={StaticResource BitmapScalingModeEnum}}"
                                   SelectedIndex="1"/>
-                    </Grid>
-                </GroupBox>
-                <GroupBox Header="Execute Javascript (asynchronously)">
-                    <Grid Width="300">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="75" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <TextBox x:Name="ExecuteJavascriptTextBox"
+                </Grid>
+            </GroupBox>
+            <GroupBox Header="Execute Javascript (asynchronously)">
+                <Grid Width="300">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="75" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <TextBox x:Name="ExecuteJavascriptTextBox"
                                  Grid.Row="0"
                                  AcceptsReturn="True"
                                  Margin="6"
                                  Text="$('#modify-me').text('See how easy that was?')">
-                            <TextBox.InputBindings>
-                                <KeyBinding Key="Enter"
+                        <TextBox.InputBindings>
+                            <KeyBinding Key="Enter"
                                             Modifiers="Control"
                                             Command="{Binding ExecuteJavaScriptCommand}"
                                             CommandParameter="{Binding Text, RelativeSource={RelativeSource AncestorType=TextBox}}" />
-                            </TextBox.InputBindings>
-                        </TextBox>
-                        <Button Grid.Row="1"
+                        </TextBox.InputBindings>
+                    </TextBox>
+                    <Button Grid.Row="1"
                                 HorizontalAlignment="Left"
                                 Margin="6,0,6,6"
                                 Padding="5,2"
                                 Content="Run"
                                 Command="{Binding ExecuteJavaScriptCommand}"
                                 CommandParameter="{Binding Text, ElementName=ExecuteJavascriptTextBox}" />
-                    </Grid>
-                </GroupBox>
-                <GroupBox Header="Evaluate Javascript (Async)">
-                    <Grid Width="300">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="75" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <TextBox x:Name="EvaluateJavascriptTextBox"
+                </Grid>
+            </GroupBox>
+            <GroupBox Header="Evaluate Javascript (Async)">
+                <Grid Width="300">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="75" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <TextBox x:Name="EvaluateJavascriptTextBox"
                                  Grid.Row="0"
                                  Margin="6"
                                  AcceptsReturn="True"
                                  Text="1 + 1">
-                            <TextBox.InputBindings>
-                                <KeyBinding Key="Enter"
+                        <TextBox.InputBindings>
+                            <KeyBinding Key="Enter"
                                             Modifiers="Control"
                                             Command="{Binding EvaluateJavaScriptCommand}"
                                             CommandParameter="{Binding Text, RelativeSource={RelativeSource AncestorType=TextBox}}" />
-                            </TextBox.InputBindings>
-                        </TextBox>
-                        <Button Grid.Row="1"
+                        </TextBox.InputBindings>
+                    </TextBox>
+                    <Button Grid.Row="1"
                                 HorizontalAlignment="Left"
                                 Margin="6,0"
                                 Padding="5,2"
                                 Content="Run"
                                 Command="{Binding EvaluateJavaScriptCommand}"
                                 CommandParameter="{Binding Text, ElementName=EvaluateJavascriptTextBox}" />
-                        <TextBlock Grid.Row="2"
+                    <TextBlock Grid.Row="2"
                                    Margin="6">Result:</TextBlock>
-                        <TextBox Grid.Row="3"
+                    <TextBox Grid.Row="3"
                                  IsReadOnly="True"
                                  Margin="6,0,6,6"
                                  Text="{Binding EvaluateJavaScriptResult}" />
-                    </Grid>
-                </GroupBox>
-                <GroupBox Header="Tests">
-                    <Button HorizontalAlignment="Left"
+                </Grid>
+            </GroupBox>
+            <GroupBox Header="Tests">
+                <Button HorizontalAlignment="Left"
                             Margin="6,0"
                             Padding="5,2"
                             Command="{Binding JavascriptBindingStressTest}"
                             Content="Javascript Binding Stress Test"/>
-                </GroupBox>
-            </StackPanel>
-            <StackPanel
+            </GroupBox>
+        </StackPanel>
+        <StackPanel
                 Margin="6,3"
                 DockPanel.Dock="Right"
                 Visibility="{Binding ShowDownloadInfo, Converter={StaticResource BooleanToVisibilityConverter}}"
                 >
-                <GroupBox Header="Download info">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" MinWidth="50" />
-                        </Grid.ColumnDefinitions>
-                        <Label
+            <GroupBox Header="Download info">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" MinWidth="50" />
+                    </Grid.ColumnDefinitions>
+                    <Label
                             Grid.Row="0"
                             Grid.Column="0"
                             Content="Last action:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="0"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding LastDownloadAction}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="1"
                             Grid.Column="0"
                             Content="IsInProgress:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="1"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.IsInProgress}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="2"
                             Grid.Column="0"
                             Content="IsComplete:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="2"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.IsComplete}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="3"
                             Grid.Column="0"
                             Content="IsCancelled:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="3"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.IsCancelled}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="4"
                             Grid.Column="0"
                             Content="CurrentSpeed:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="4"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.CurrentSpeed}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="5"
                             Grid.Column="0"
                             Content="PercentComplete:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="5"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.PercentComplete}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="6"
                             Grid.Column="0"
                             Content="TotalBytes:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="6"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.TotalBytes}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="7"
                             Grid.Column="0"
                             Content="ReceivedBytes:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="7"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.ReceivedBytes}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="8"
                             Grid.Column="0"
                             Content="StartTime:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="8"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.StartTime}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="9"
                             Grid.Column="0"
                             Content="EndTime:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="9"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.EndTime}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="10"
                             Grid.Column="0"
                             Content="FullPath:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="10"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.FullPath}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="11"
                             Grid.Column="0"
                             Content="Id:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="11"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.Id}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="12"
                             Grid.Column="0"
                             Content="Url:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="12"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.Url}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="13"
                             Grid.Column="0"
                             Content="OriginalUrl:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="13"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.OriginalUrl}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="14"
                             Grid.Column="0"
                             Content="SuggestedFileName:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="14"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.SuggestedFileName}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="15"
                             Grid.Column="0"
                             Content="ContentDisposition:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="15"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.ContentDisposition}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="16"
                             Grid.Column="0"
                             Content="MimeType:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="16"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.MimeType}"
                             />
-                        <Label
+                    <Label
                             Grid.Row="17"
                             Grid.Column="0"
                             Content="IsValid:"
                             />
-                        <TextBox
+                    <TextBox
                             Grid.Row="17"
                             Grid.Column="1"
                             IsReadOnly="True"
                             Text="{Binding DownloadItem.IsValid}"
                             />
-                    </Grid>
-                </GroupBox>
-            </StackPanel>
-            <StatusBar DockPanel.Dock="Bottom">
-                <ProgressBar HorizontalAlignment="Right"
+                </Grid>
+            </GroupBox>
+        </StackPanel>
+        <StatusBar DockPanel.Dock="Bottom">
+            <ProgressBar HorizontalAlignment="Right"
                              IsIndeterminate="{Binding WebBrowser.IsLoading}"
                              Width="100"
                              Height="16"
                              Margin="3" />
-                <TextBlock Text="{Binding StatusMessage}" />
-                <Separator />
-                <TextBlock Text="{Binding OutputMessage}" />
-            </StatusBar>
-            <Grid Background="#FFF0F0F0">
-                <Rectangle>
-                    <Rectangle.Fill>
-                        <VisualBrush TileMode="Tile"
+            <TextBlock Text="{Binding StatusMessage}" />
+            <Separator />
+            <TextBlock Text="{Binding OutputMessage}" />
+        </StatusBar>
+        <Grid Background="#FFF0F0F0">
+            <Rectangle>
+                <Rectangle.Fill>
+                    <VisualBrush TileMode="Tile"
                                      Viewport="0,0,500,90"
                                      ViewportUnits="Absolute"
                                      Opacity="0.05">
-                            <VisualBrush.Visual>
-                                <StackPanel>
-                                    <TextBlock Margin="6,12"
+                        <VisualBrush.Visual>
+                            <StackPanel>
+                                <TextBlock Margin="6,12"
                                                FontWeight="Bold">CefSharp Rocks!</TextBlock>
-                                </StackPanel>
-                            </VisualBrush.Visual>
-                            <VisualBrush.Transform>
-                                <RotateTransform Angle="-22.5" />
-                            </VisualBrush.Transform>
-                        </VisualBrush>
-                    </Rectangle.Fill>
-                </Rectangle>
+                            </StackPanel>
+                        </VisualBrush.Visual>
+                        <VisualBrush.Transform>
+                            <RotateTransform Angle="-22.5" />
+                        </VisualBrush.Transform>
+                    </VisualBrush>
+                </Rectangle.Fill>
+            </Rectangle>
 
-                <cefSharp:ChromiumWebBrowser x:Name="browser"
+            <cefSharp:ChromiumWebBrowser x:Name="browser"
                                   Opacity="{Binding ElementName=opacitySlider, Path=Value}"
                                   Address="{Binding Address, Mode=TwoWay}"
                                   Title="{Binding Title, Mode=OneWayToSource}"
@@ -432,20 +441,20 @@
                                   WebBrowser="{Binding WebBrowser, Mode=OneWayToSource}"
                                   DataContext="{Binding}"
                                   RenderOptions.BitmapScalingMode="{Binding ElementName=scalingModeComboBox, Path=SelectedItem}">
-                    <!-- Just an example of how you may override the BrowserSettings. Disabled by default since it looks so
+                <!-- Just an example of how you may override the BrowserSettings. Disabled by default since it looks so
                          incredibly ugly... -->
-                    <!--<cefSharp:ChromiumWebBrowser.BrowserSettings>
+                <!--<cefSharp:ChromiumWebBrowser.BrowserSettings>
                         <CefSharp:BrowserSettings MinimumFontSize="36" />
                     </cefSharp:ChromiumWebBrowser.BrowserSettings>-->
-                    <FrameworkElement.LayoutTransform>
-                        <TransformGroup>
-                            <RotateTransform Angle="{Binding Value, ElementName=angleSlider}" />
-                        </TransformGroup>
-                    </FrameworkElement.LayoutTransform>
-                    <!--<cefSharp:ChromiumWebBrowser.Resources>
+                <FrameworkElement.LayoutTransform>
+                    <TransformGroup>
+                        <RotateTransform Angle="{Binding Value, ElementName=angleSlider}" />
+                    </TransformGroup>
+                </FrameworkElement.LayoutTransform>
+                <!--<cefSharp:ChromiumWebBrowser.Resources>
                         -->
-                    <!-- Apply custom style to wrap ToolTip Issue https://github.com/cefsharp/CefSharp/issues/2488 -->
-                    <!--
+                <!-- Apply custom style to wrap ToolTip Issue https://github.com/cefsharp/CefSharp/issues/2488 -->
+                <!--
                         <Style TargetType="ToolTip">
                             <Style.Resources>
                                 <Style TargetType="ContentPresenter">
@@ -459,8 +468,7 @@
                             <Setter Property="MaxWidth" Value="500" />
                         </Style>
                     </cefSharp:ChromiumWebBrowser.Resources>-->
-                </cefSharp:ChromiumWebBrowser>
-            </Grid>
-        </DockPanel>
-    </Grid>
+            </cefSharp:ChromiumWebBrowser>
+        </Grid>
+    </DockPanel>
 </UserControl>


### PR DESCRIPTION
Some very minor UI improvements to the WPF Example using https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit

There are further improvements that could be made, the custom TabControl needs restyling, tweaks to button colours, handle light/dark mode etc.