### PR TITLE
NetCore - Generate Reference Assemblies building with VS2022

### DIFF
--- a/CefSharp.Core/CefSharp.Core.netcore.csproj
+++ b/CefSharp.Core/CefSharp.Core.netcore.csproj
@@ -24,6 +24,7 @@
 
     <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+        <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
         <EmbedAllSources>True</EmbedAllSources>
         <DebugType>embedded</DebugType>
     </PropertyGroup>

--- a/CefSharp.Core/CefSharp.Core.netcore.csproj
+++ b/CefSharp.Core/CefSharp.Core.netcore.csproj
@@ -24,7 +24,7 @@
 
     <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-        <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+        <ProduceReferenceAssemblyInOutDir Condition="'$(VisualStudioVersion)'=='17.0'">true</ProduceReferenceAssemblyInOutDir>
         <EmbedAllSources>True</EmbedAllSources>
         <DebugType>embedded</DebugType>
     </PropertyGroup>

--- a/CefSharp.OffScreen/CefSharp.OffScreen.netcore.csproj
+++ b/CefSharp.OffScreen/CefSharp.OffScreen.netcore.csproj
@@ -24,6 +24,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp.OffScreen/CefSharp.OffScreen.netcore.csproj
+++ b/CefSharp.OffScreen/CefSharp.OffScreen.netcore.csproj
@@ -24,7 +24,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <ProduceReferenceAssemblyInOutDir Condition="'$(VisualStudioVersion)'=='17.0'">true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp.WinForms/CefSharp.WinForms.netcore.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.netcore.csproj
@@ -25,6 +25,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp.WinForms/CefSharp.WinForms.netcore.csproj
+++ b/CefSharp.WinForms/CefSharp.WinForms.netcore.csproj
@@ -25,7 +25,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <ProduceReferenceAssemblyInOutDir Condition="'$(VisualStudioVersion)'=='17.0'">true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp.Wpf/CefSharp.Wpf.netcore.csproj
+++ b/CefSharp.Wpf/CefSharp.Wpf.netcore.csproj
@@ -25,6 +25,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp.Wpf/CefSharp.Wpf.netcore.csproj
+++ b/CefSharp.Wpf/CefSharp.Wpf.netcore.csproj
@@ -25,7 +25,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <ProduceReferenceAssemblyInOutDir Condition="'$(VisualStudioVersion)'=='17.0'">true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp/CefSharp.netcore.csproj
+++ b/CefSharp/CefSharp.netcore.csproj
@@ -22,6 +22,7 @@
     
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/CefSharp/CefSharp.netcore.csproj
+++ b/CefSharp/CefSharp.netcore.csproj
@@ -22,7 +22,7 @@
     
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <ProduceReferenceAssemblyInOutDir Condition="'$(VisualStudioVersion)'=='17.0'">true</ProduceReferenceAssemblyInOutDir>
     <EmbedAllSources>True</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
**Fixes:** #4558 

**Summary:** The .NET 6.0 SDK introduced a breaking change meaning that reference assemblies are no longer automatically copied from the intermediate build directory to the output directory. An additional MsBuild property is now required.

**Changes:** Included the ProduceReferenceAssemblyInOutDir in all required netcore projects
      
**How Has This Been Tested?**  
Has been tested using build.ps1 script (VS2022) and building in Visual Studio 2022. 
Has not been tested with VS2019 build tools 

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code (if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
