### PR TITLE
WPF - WritableBitmapRenderHandler Avoid null bitmap references upon wakeup.

### DIFF
--- a/CefSharp.Wpf/Rendering/WritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/WritableBitmapRenderHandler.cs
@@ -134,7 +134,7 @@ namespace CefSharp.Wpf.Rendering
                             return;
                         }
 
-                        if (createNewBitmap)
+                        if (createNewBitmap || image.Source is null)
                         {
                             if (image.Source != null)
                             {


### PR DESCRIPTION
Force initial bitmap creation upon wakeup when the image.source is null... Happens if sizing etc. rapidly and the UI thread short circuits when CreateNewBitMap is true and the first wake up occurs with it 'false' amd image.Source is still null...

**Fixes:** [issue-number] 
Fixes: #4612 

**Summary:** [summary of the change and which issue is fixed here]

 - Add a missing null reference check to force bitmap creation in relation to #4612

**Changes:** [specify the structures changed] 

- I added a missing null check to force Bitmap creation when dispatch to UI thread first wakes up. 

**How Has This Been Tested?**  
We consume CEFSharp as part of a larger application.. The issue at hand was noticed when using our system's scripting/playback mechanism.  I have locally merged the fix into a version of CEFSharp we use and done extensive testing runs and local manual testing and all issues we were experiencing related to the nullreference are gone. 

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
