### PR TITLE
Core - Basic ArrayBuffer support for EvaluateScriptAsync

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Serialization/V8Serialization.cpp
@@ -71,6 +71,10 @@ namespace CefSharp
                 {
                     SetCefTime(list, index, obj->GetDateValue().val);
                 }
+                else if (obj->IsArrayBuffer())
+                {
+                    SetArrayBuffer(list, index, obj->GetArrayBufferByteLength(), obj->GetArrayBufferData());
+                }
                 else if (obj->IsArray())
                 {
                     int arrLength = obj->GetArrayLength();

--- a/CefSharp.Core.Runtime/Internals/Serialization/ObjectsSerialization.cpp
+++ b/CefSharp.Core.Runtime/Internals/Serialization/ObjectsSerialization.cpp
@@ -38,6 +38,10 @@ namespace CefSharp
                     auto cefTime = GetCefTime(list, index);
                     result = CefTimeUtils::FromBaseTimeToDateTime(cefTime.val);
                 }
+                else if (IsArrayBuffer(list, index))
+                {
+                    result = GetArrayBuffer(list, index);
+                }
                 else if (IsJsCallback(list, index) && javascriptCallbackFactory != nullptr)
                 {
                     auto jsCallbackDto = GetJsCallback(list, index);

--- a/CefSharp.Core.Runtime/Internals/Serialization/Primitives.cpp
+++ b/CefSharp.Core.Runtime/Internals/Serialization/Primitives.cpp
@@ -19,7 +19,8 @@ namespace CefSharp
             {
                 INT64,
                 CEFTIME,
-                JSCALLBACK
+                JSCALLBACK,
+                ARRAYBUFFER
             };
 
             template<typename TList, typename TIndex>
@@ -91,6 +92,39 @@ namespace CefSharp
             {
                 return IsType(PrimitiveType::CEFTIME, list, index);
             }
+
+            template<typename TList, typename TIndex>
+            void SetArrayBuffer(const CefRefPtr<TList>& list, TIndex index, const size_t& size, const void* value)
+            {
+                const auto src = static_cast<const uint8_t*>(value);
+
+                auto dest = new uint8_t[size + 1];
+                dest[0] = static_cast<uint8_t>(PrimitiveType::ARRAYBUFFER);
+                memcpy(&dest[1], src, size);
+
+                list->SetBinary(index, CefBinaryValue::Create(dest, size + 1));
+            }
+
+            template<typename TList, typename TIndex>
+            cli::array<Byte>^ GetArrayBuffer(const CefRefPtr<TList>& list, TIndex index)
+            {
+                auto binaryValue = list->GetBinary(index);
+                auto size = binaryValue->GetSize() - 1;
+
+                auto bufferByte = gcnew cli::array<Byte>(static_cast<int>(size));
+                pin_ptr<Byte> src = &bufferByte[0]; // pin pointer to first element in arr
+
+                binaryValue->GetData(static_cast<void*>(src), size, 1);
+
+                return bufferByte;
+            }
+
+            template<typename TList, typename TIndex>
+            bool IsArrayBuffer(const CefRefPtr<TList>& list, TIndex index)
+            {
+                return IsType(PrimitiveType::ARRAYBUFFER, list, index);
+            }
+
             template<typename TList, typename TIndex>
             void SetJsCallback(const CefRefPtr<TList>& list, TIndex index, JavascriptCallback^ value)
             {

--- a/CefSharp.Core.Runtime/Internals/Serialization/Primitives.h
+++ b/CefSharp.Core.Runtime/Internals/Serialization/Primitives.h
@@ -27,6 +27,13 @@ namespace CefSharp
             bool IsCefTime(const CefRefPtr<TList>& list, TIndex index);
 
             template<typename TList, typename TIndex>
+            void SetArrayBuffer(const CefRefPtr<TList>& list, TIndex index, const size_t& size, const void* value);
+            template<typename TList, typename TIndex>
+            cli::array<Byte>^ GetArrayBuffer(const CefRefPtr<TList>& list, TIndex index);
+            template<typename TList, typename TIndex>
+            bool IsArrayBuffer(const CefRefPtr<TList>& list, TIndex index);
+
+            template<typename TList, typename TIndex>
             void SetJsCallback(const CefRefPtr<TList>& list, TIndex index, JavascriptCallback^ value);
             template<typename TList, typename TIndex>
             JavascriptCallback^ GetJsCallback(const CefRefPtr<TList>& list, TIndex index);
@@ -52,6 +59,16 @@ namespace CefSharp
             template bool IsCefTime(const CefRefPtr<CefListValue>& list, size_t index);
             template bool IsCefTime(const CefRefPtr<CefListValue>& list, int index);
             template bool IsCefTime(const CefRefPtr<CefDictionaryValue>& list, CefString index);
+
+            template void SetArrayBuffer(const CefRefPtr<CefListValue>& list, int index, const size_t& size, const void* value);
+            template void SetArrayBuffer(const CefRefPtr<CefListValue>& list, size_t index, const size_t& size, const void* value);
+            template void SetArrayBuffer(const CefRefPtr<CefDictionaryValue>& list, CefString index, const size_t& size, const void* value);
+            template cli::array<Byte>^ GetArrayBuffer(const CefRefPtr<CefListValue>& list, int index);
+            template cli::array<Byte>^ GetArrayBuffer(const CefRefPtr<CefListValue>& list, size_t index);
+            template cli::array<Byte>^ GetArrayBuffer(const CefRefPtr<CefDictionaryValue>& list, CefString index);
+            template bool IsArrayBuffer(const CefRefPtr<CefListValue>& list, size_t index);
+            template bool IsArrayBuffer(const CefRefPtr<CefListValue>& list, int index);
+            template bool IsArrayBuffer(const CefRefPtr<CefDictionaryValue>& list, CefString index);
 
             template void SetJsCallback(const CefRefPtr<CefListValue>& list, int index, JavascriptCallback^ value);
             template void SetJsCallback(const CefRefPtr<CefListValue>& list, size_t index, JavascriptCallback^ value);

--- a/CefSharp.Test/Javascript/EvaluateScriptAsyncTests.cs
+++ b/CefSharp.Test/Javascript/EvaluateScriptAsyncTests.cs
@@ -5,9 +5,12 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Bogus;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Repeat;
 
 namespace CefSharp.Test.Javascript
 {
@@ -251,6 +254,29 @@ namespace CefSharp.Test.Javascript
                 Assert.Equal(test, (string)javascriptResponse.Result);
                 output.WriteLine("{0} passes {1}", test, javascriptResponse.Result);
             }
+        }
+
+        [Theory]
+        [Repeat(20)]
+        public async Task CanEvaluateScriptAsyncReturnArrayBuffer(int iteration)
+        {
+            AssertInitialLoadComplete();
+
+            var randomizer = new Randomizer();
+
+            var expected = randomizer.Utf16String(minLength: iteration, maxLength:iteration);
+            var expectedBytes = Encoding.UTF8.GetBytes(expected);
+
+            var javascriptResponse = await Browser.EvaluateScriptAsync($"new TextEncoder().encode('{expected}').buffer");
+
+            Assert.True(javascriptResponse.Success);
+            Assert.IsType<byte[]>(javascriptResponse.Result);
+
+            var actualBytes = (byte[])javascriptResponse.Result;
+
+            Assert.Equal(expectedBytes, actualBytes);
+
+            Assert.Equal(expected, Encoding.UTF8.GetString(actualBytes));
         }
 
         [Theory]


### PR DESCRIPTION
Related #4358

**Summary:** 
   - Adds ability to return an ArrayBuffer copy via EvaluateScriptAsync
      
**How Has This Been Tested?**  
- xUnit tests

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
