### PR TITLE
Add in file paths data to DragData

### DIFF
--- a/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
+++ b/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
@@ -14,7 +14,6 @@ namespace CefSharp.Core
     {
         public BrowserSettings() { }
         public BrowserSettings(bool autoDispose) { }
-        public virtual string AcceptLanguageList { get { throw null; } set { } }
         public virtual bool AutoDispose { get { throw null; } }
         public virtual uint BackgroundColor { get { throw null; } set { } }
         public virtual string CursiveFontFamily { get { throw null; } set { } }
@@ -135,6 +134,7 @@ namespace CefSharp.Core
         internal DragData() { }
         public virtual string FileName { get { throw null; } set { } }
         public virtual System.Collections.Generic.IList<string> FileNames { get { throw null; } }
+        public virtual System.Collections.Generic.IList<string> FilePaths { get { throw null; } }
         public virtual string FragmentBaseUrl { get { throw null; } set { } }
         public virtual string FragmentHtml { get { throw null; } set { } }
         public virtual string FragmentText { get { throw null; } set { } }

--- a/CefSharp.Core.Runtime/DragData.h
+++ b/CefSharp.Core.Runtime/DragData.h
@@ -90,6 +90,18 @@ namespace CefSharp
                 }
             }
 
+            //TODO: Vector is a pointer, so can potentially be updated (items may be possibly removed)
+            virtual property IList<String^>^ FilePaths
+            {
+                IList<String^>^ get()
+                {
+                    auto paths = vector<CefString>();
+                    _wrappedDragData->GetFilePaths(paths);
+
+                    return StringUtils::ToClr(paths);
+                }
+            }
+
             virtual property String^ FragmentBaseUrl
             {
                 String^ get()

--- a/CefSharp/IDragData.cs
+++ b/CefSharp/IDragData.cs
@@ -36,6 +36,11 @@ namespace CefSharp
         IList<string> FileNames { get; }
 
         /// <summary>
+        /// Retrieve the list of file paths that are being dragged into the browser window
+        /// </summary>
+        IList<string> FilePaths { get; }
+
+        /// <summary>
         /// Return the base URL that the fragment came from. This value is used for resolving relative URLs and may be empty. 
         /// </summary>
         string FragmentBaseUrl { get; set; }


### PR DESCRIPTION
**Summary:**
The CEF side broke up filename and file paths.  For more info see: https://github.com/chromiumembedded/cef/issues/3568
This broke out application which was expecting them to be in the old format.
   - CEF changed DragData filenames to only be the the file names and removed path info
   - CEF added FilePaths as a separate filed in DragData
   - This PR makes that data available 

**Changes:** [specify the structures changed] 
   - FilePaths added to DragData
   
**How Has This Been Tested?**  
The test app doesn't expose this anywhere.  So I put a break point in IDragHandler.OnDragEnter in CefSharp\CefSharp.Wpf.Example\Handlers\DragHandler.cs and inspected the data manually.
Our application uses this data and ran through our internal unit tests to verify.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
