### PR TITLE
WithTimeout: start timer after initialization

### DIFF
--- a/CefSharp/Internals/TaskExtensions.cs
+++ b/CefSharp/Internals/TaskExtensions.cs
@@ -17,10 +17,9 @@ namespace CefSharp.Internals
     {
         public static TaskCompletionSource<TResult> WithTimeout<TResult>(this TaskCompletionSource<TResult> taskCompletionSource, TimeSpan timeout, Action cancelled)
         {
-            Timer timer = null;
-            timer = new Timer(state =>
+            var timer = new Timer(state =>
             {
-                timer.Dispose();
+                ((Timer)state).Dispose();
                 if (taskCompletionSource.Task.Status != TaskStatus.RanToCompletion)
                 {
                     taskCompletionSource.TrySetCanceled();
@@ -29,7 +28,8 @@ namespace CefSharp.Internals
                         cancelled();
                     }
                 }
-            }, null, timeout, TimeSpan.FromMilliseconds(-1));
+            });
+            timer.Change(timeout, Timeout.InfiniteTimeSpan);
 
             return taskCompletionSource;
         }


### PR DESCRIPTION
**Summary:**
   - Starting the timer after it is initialized avoids a race condition where the callback could be called before the timer variable was assigned. See also https://stackoverflow.com/a/17263385

Sometimes I saw crashes like this when the timeout was quite small and the CPU usage was high.
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CefSharp.Internals.TaskExtensions.<>c__DisplayClass0_0`1.<WithTimeout>b__0(Object state) in C:\projects\cefsharp\CefSharp\Internals\TaskExtensions.cs:line 23
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.TimerQueue.FireNextTimers()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

**Changes:**
   - Using the Timer constructor which only takes the callback ensures that the timer is initialized before it is started.
      
**How Has This Been Tested?**  
Manually.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
