### PR TITLE
OffScreen - Check if browser is not null in GetScreenInfo/GetViewRect

### DIFF
--- a/CefSharp.OffScreen/DefaultRenderHandler.cs
+++ b/CefSharp.OffScreen/DefaultRenderHandler.cs
@@ -98,7 +98,14 @@ namespace CefSharp.OffScreen
         /// <returns>Return null if no screenInfo structure is provided.</returns>	
         public virtual ScreenInfo? GetScreenInfo()
         {
-            var screenInfo = new ScreenInfo { DeviceScaleFactor = browser.DeviceScaleFactor };
+            var deviceScaleFactor = browser?.DeviceScaleFactor;
+
+            if (deviceScaleFactor == null)
+            {
+                return null;
+            }
+
+            var screenInfo = new ScreenInfo { DeviceScaleFactor = deviceScaleFactor.Value };
 
             return screenInfo;
         }
@@ -111,9 +118,14 @@ namespace CefSharp.OffScreen
         public virtual Rect GetViewRect()
         {
             //TODO: See if this can be refactored and remove browser reference
-            var size = browser.Size;
+            var size = browser?.Size;
 
-            var viewRect = new Rect(0, 0, size.Width, size.Height);
+            if (size == null)
+            {
+                return new Rect(0, 0, 1, 1);
+            }
+
+            var viewRect = new Rect(0, 0, size.Value.Width, size.Value.Height);
 
             return viewRect;
         }


### PR DESCRIPTION
**Summary:**
It can happen when a `RenderHandler` is detached from the browser and then disposed that `GetScreenInfo` still gets called because of the local copy [here](https://github.com/cefsharp/CefSharp/blob/ed1763ee9510dca9e54ab766ea7cf305f71d2aa2/CefSharp.OffScreen/ChromiumWebBrowser.cs#L807) which then results in a NRE.

Our simplified code looks something like this:
```c#
var renderHandler = new DefaultRenderHandler(browser);
browser.RenderHandler = renderHandler;

// take screenshot here

browser.RenderHandler = null; // detach renderHandler
renderHandler.Dispose();
// NRE on different / cef thread => crash
```

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CefSharp.OffScreen.DefaultRenderHandler.GetScreenInfo() in C:\projects\cefsharp\CefSharp.OffScreen\DefaultRenderHandler.cs:line 103
   at CefSharp.OffScreen.ChromiumWebBrowser.GetScreenInfo() in C:\projects\cefsharp\CefSharp.OffScreen\ChromiumWebBrowser.cs:line 816
   at CefSharp.Internals.RenderClientAdapter.GetScreenInfo(RenderClientAdapter*, scoped_refptr<CefBrowser>* browser, CefScreenInfo* screen_info)
```

This is super rare and I got this crash only once.
I updated `GetViewRect` as well also I haven't see a crash from that yet.

Since both of these methods are virtual I have overriden them locally and not blocked by this.

All methods on `IRenderHandler` are always called from the browser, would it make sense to pass the browser instance into these methods so that the `DefaultRenderHandler` does not need a reference to it itself?

**Changes:**
   - Added null check for browser.
      
**How Has This Been Tested?**  
It hasn't crashed with this change yet.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
