### PR TITLE
WPF - Fix the Chinese IMEs (such as "sogou pinyin", "qq...") window position is incorrect in Winform form embedded wpf control.

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -41,6 +41,25 @@ namespace CefSharp.Wpf.Experimental
         }
 
         /// <summary>
+        /// Get the outermost element of the browser 
+        /// </summary>
+        /// <param name="control">The browser</param>
+        /// <returns>The outermost element </returns>
+        FrameworkElement GetOutermostElement(FrameworkElement control)
+        {
+            DependencyObject parent = VisualTreeHelper.GetParent(control);
+            DependencyObject current = control;
+
+            while (parent != null)
+            {
+                current = parent;
+                parent = VisualTreeHelper.GetParent(current);
+            }
+
+            return current as FrameworkElement;
+        }
+        
+        /// <summary>
         /// Change composition range.
         /// </summary>
         /// <param name="selectionRange">The selection range.</param>
@@ -61,7 +80,8 @@ namespace CefSharp.Wpf.Experimental
             {
                 //TODO: Getting the root window for every composition range change seems expensive,
                 //we should cache the position and update it on window move.
-                var parentWindow = Window.GetWindow(owner);
+                //In Winform embedded wpf borwser mode, Window.GetWindow(owner) is null, so use a custom function to get the outermost visual element.
+                var parentWindow = GetOutermostElement(owner);
                 if (parentWindow != null)
                 {
                     //TODO: What are we calculating here exactly???

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -10,7 +10,6 @@ using System.Windows.Interop;
 using CefSharp.Internals;
 using CefSharp.Structs;
 using CefSharp.Wpf.Internals;
-using 
 using Point = System.Windows.Point;
 using Range = CefSharp.Structs.Range;
 using Rect = CefSharp.Structs.Rect;

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -10,10 +10,11 @@ using System.Windows.Interop;
 using CefSharp.Internals;
 using CefSharp.Structs;
 using CefSharp.Wpf.Internals;
+using 
 using Point = System.Windows.Point;
 using Range = CefSharp.Structs.Range;
 using Rect = CefSharp.Structs.Rect;
-
+using System.Windows.Media;
 namespace CefSharp.Wpf.Experimental
 {
     /// <summary>


### PR DESCRIPTION
WPF - Fix chinese IMEs ( such as "sogou pinyin", "qq pinyin" etc. ) input window position, In Winform embedded wpf borwser mode.

**Fixes:** [issue-number] 
<!-- e.g Fixes: #2345 -->

**Summary:** [summary of the change and which issue is fixed here]
   - e.g. I have added a new feature to the Javascript Binding implementation

**Changes:** [specify the structures changed] 
   - e.g. I have modified the Javascript Binding Implementation
      - Added support for Async binding to return Task<T>
      - Added new QUnit Test cases
      
**How Has This Been Tested?**  
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, operating system, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
