### PR TITLE
 WPF - Fix the Chinese IMEs (such as "sogou pinyin", "qq...") window position is incorrect in Winform form embedded wpf control.

### DIFF
--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -10,10 +10,10 @@ using System.Windows.Interop;
 using CefSharp.Internals;
 using CefSharp.Structs;
 using CefSharp.Wpf.Internals;
+using System.Windows.Media;
 using Point = System.Windows.Point;
 using Range = CefSharp.Structs.Range;
 using Rect = CefSharp.Structs.Rect;
-using System.Windows.Media;
 namespace CefSharp.Wpf.Experimental
 {
     /// <summary>
@@ -45,7 +45,7 @@ namespace CefSharp.Wpf.Experimental
         /// </summary>
         /// <param name="control">The browser</param>
         /// <returns>The outermost element </returns>
-        FrameworkElement GetOutermostElement(FrameworkElement control)
+        private FrameworkElement GetOutermostElement(FrameworkElement control)
         {
             DependencyObject parent = VisualTreeHelper.GetParent(control);
             DependencyObject current = control;
@@ -79,9 +79,15 @@ namespace CefSharp.Wpf.Experimental
             owner.UiThreadRunAsync(() =>
             {
                 //TODO: Getting the root window for every composition range change seems expensive,
-                //we should cache the position and update it on window move.
+                //we should cache the position and update it on window move.                
+                var parentWindow = (FrameworkElement)Window.GetWindow(owner);
+                
                 //In Winform embedded wpf borwser mode, Window.GetWindow(owner) is null, so use a custom function to get the outermost visual element.
-                var parentWindow = GetOutermostElement(owner);
+                if(parentWindow == null)
+                {
+                    parentWindow = GetOutermostElement(owner);
+                }
+                
                 if (parentWindow != null)
                 {
                     //TODO: What are we calculating here exactly???

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -14,6 +14,7 @@ using System.Windows.Media;
 using Point = System.Windows.Point;
 using Range = CefSharp.Structs.Range;
 using Rect = CefSharp.Structs.Rect;
+
 namespace CefSharp.Wpf.Experimental
 {
     /// <summary>
@@ -38,26 +39,7 @@ namespace CefSharp.Wpf.Experimental
         /// <param name="owner">The owner.</param>
         public WpfImeKeyboardHandler(ChromiumWebBrowser owner) : base(owner)
         {
-        }
-
-        /// <summary>
-        /// Get the outermost element of the browser 
-        /// </summary>
-        /// <param name="control">The browser</param>
-        /// <returns>The outermost element </returns>
-        private FrameworkElement GetOutermostElement(FrameworkElement control)
-        {
-            DependencyObject parent = VisualTreeHelper.GetParent(control);
-            DependencyObject current = control;
-
-            while (parent != null)
-            {
-                current = parent;
-                parent = VisualTreeHelper.GetParent(current);
-            }
-
-            return current as FrameworkElement;
-        }
+        }        
         
         /// <summary>
         /// Change composition range.
@@ -465,6 +447,25 @@ namespace CefSharp.Wpf.Experimental
         private void UpdateCaretPosition(int index)
         {
             MoveImeWindow(source.Handle);
+        }
+
+        /// <summary>
+        /// Get the outermost element of the browser 
+        /// </summary>
+        /// <param name="control">The browser</param>
+        /// <returns>The outermost element </returns>
+        private FrameworkElement GetOutermostElement(FrameworkElement control)
+        {
+            DependencyObject parent = VisualTreeHelper.GetParent(control);
+            DependencyObject current = control;
+
+            while (parent != null)
+            {
+                current = parent;
+                parent = VisualTreeHelper.GetParent(current);
+            }
+
+            return current as FrameworkElement;
         }
     }
 }

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -41,6 +41,25 @@ namespace CefSharp.Wpf.Experimental
         }
 
         /// <summary>
+        /// Get the outermost element of the browser 
+        /// </summary>
+        /// <param name="control">The browser</param>
+        /// <returns>The outermost element </returns>
+        FrameworkElement GetOutermostElement(FrameworkElement control)
+        {
+            DependencyObject parent = VisualTreeHelper.GetParent(control);
+            DependencyObject current = control;
+
+            while (parent != null)
+            {
+                current = parent;
+                parent = VisualTreeHelper.GetParent(current);
+            }
+
+            return current as FrameworkElement;
+        }
+        
+        /// <summary>
         /// Change composition range.
         /// </summary>
         /// <param name="selectionRange">The selection range.</param>
@@ -61,7 +80,8 @@ namespace CefSharp.Wpf.Experimental
             {
                 //TODO: Getting the root window for every composition range change seems expensive,
                 //we should cache the position and update it on window move.
-                var parentWindow = Window.GetWindow(owner);
+                //In Winform embedded wpf borwser mode, Window.GetWindow(owner) is null, so use a custom function to get the outermost visual element.
+                var parentWindow = GetOutermostElement(owner);
                 if (parentWindow != null)
                 {
                     //TODO: What are we calculating here exactly???

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -10,7 +10,6 @@ using System.Windows.Interop;
 using CefSharp.Internals;
 using CefSharp.Structs;
 using CefSharp.Wpf.Internals;
-using 
 using Point = System.Windows.Point;
 using Range = CefSharp.Structs.Range;
 using Rect = CefSharp.Structs.Rect;

--- a/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
+++ b/CefSharp.Wpf/Experimental/WpfIMEKeyboardHandler.cs
@@ -10,10 +10,11 @@ using System.Windows.Interop;
 using CefSharp.Internals;
 using CefSharp.Structs;
 using CefSharp.Wpf.Internals;
+using 
 using Point = System.Windows.Point;
 using Range = CefSharp.Structs.Range;
 using Rect = CefSharp.Structs.Rect;
-
+using System.Windows.Media;
 namespace CefSharp.Wpf.Experimental
 {
     /// <summary>


### PR DESCRIPTION
**Summary:** 
 - Fix the WPF browser is embedded in the Winfrom form, the Chinese IMEs window (such as "sogou pinying","qq...") will not follow the cursor when inputting Chinese. This problem does not exist in the WPF form.
 
**Changes:**
 - Modify the WpfImeKeyboardHandler class and add a custom function GetOutermostElement to obtain the outermost visual element.
 - Modify the ChangeCompositionRange method and add that when the parent window Window.GetWindow(owner) is empty, call the function GetOutermostElement to obtain the outermost visual element as the input method window position calculation container.
      
**How Has This Been Tested?**  
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, operating system, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
**The wrong position**
![image](https://github.com/cefsharp/CefSharp/assets/15883404/f81960fb-1e8a-4358-bab0-a45b6ccfd81c)
**The correct position**
After the fix, the input method window correctly follows the cursor position.
![image](https://github.com/cefsharp/CefSharp/assets/15883404/aacbe969-12fc-4750-aab4-dd634c654c57)

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
