### PR TITLE
fix: actually support vswhere not finding something

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -183,13 +183,17 @@ function VSX
 
     $versionSearchStr = "[$VS_VER.0," + ($VS_VER+1) + ".0)"
 
+    $ErrorActionPreference="SilentlyContinue"
     $VSInstallPath = & $VSWherePath -version $versionSearchStr -property installationPath $VS_PRE
+    $ErrorActionPreference="Stop"
     
     Write-Diagnostic "$($VS_OFFICIAL_VER)InstallPath: $VSInstallPath"
         
     if( -not $VSInstallPath -or -not (Test-Path $VSInstallPath))
     {
+        $ErrorActionPreference="SilentlyContinue"
         $VSInstallPath = & $VSwherePath -version $versionSearchStr -property installationPath $VS_PRE -products 'Microsoft.VisualStudio.Product.BuildTools'
+        $ErrorActionPreference="Stop"
 		Write-Diagnostic "BuildTools $($VS_OFFICIAL_VER)InstallPath: $VSInstallPath"
 
         if( -not $VSInstallPath -or -not (Test-Path $VSInstallPath))


### PR DESCRIPTION
By default vswhere returns a non-zero error code making our error handling fail

I don't remember if I am mis-remembering a line suppress error option in powershell but I couldn't find it, and I didn't want to try/catch this.