### PR TITLE
Change Frame identifier from Int64 to String

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/BindObjectAsyncHandler.h
+++ b/CefSharp.BrowserSubprocess.Core/BindObjectAsyncHandler.h
@@ -151,14 +151,14 @@ namespace CefSharp
                                     auto rootObjectWrappers = _browserWrapper->JavascriptRootObjectWrappers;
 
                                     JavascriptRootObjectWrapper^ rootObject;
-                                    if (!rootObjectWrappers->TryGetValue(frame->GetIdentifier(), rootObject))
+                                    if (!rootObjectWrappers->TryGetValue(StringUtils::ToClr(frame->GetIdentifier()), rootObject))
                                     {
 #ifdef NETCOREAPP
                                         rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier());
 #else
                                         rootObject = gcnew JavascriptRootObjectWrapper(browser->GetIdentifier(), _browserWrapper->BrowserProcess);
 #endif
-                                        rootObjectWrappers->TryAdd(frame->GetIdentifier(), rootObject);
+                                        rootObjectWrappers->TryAdd(StringUtils::ToClr(frame->GetIdentifier()), rootObject);
                                     }
 
                                     //Cached objects only contains a list of objects not already bound

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -72,7 +72,7 @@ namespace CefSharp
             }
 
             CefBrowserWrapper^ FindBrowserWrapper(int browserId);
-            JavascriptRootObjectWrapper^ GetJsRootObjectWrapper(int browserId, int64_t frameId);
+            JavascriptRootObjectWrapper^ GetJsRootObjectWrapper(int browserId, CefString& frameId);
 
             virtual DECL CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override;
             virtual DECL void OnBrowserCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDictionaryValue> extraInfo) override;

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -31,7 +31,7 @@ namespace CefSharp
 
         internal:
             //Frame Identifier is used as Key
-            property ConcurrentDictionary<int64_t, JavascriptRootObjectWrapper^>^ JavascriptRootObjectWrappers;
+            property ConcurrentDictionary<String^, JavascriptRootObjectWrapper^>^ JavascriptRootObjectWrappers;
 
         public:
             CefBrowserWrapper(CefRefPtr<CefBrowser> cefBrowser)
@@ -40,7 +40,7 @@ namespace CefSharp
                 BrowserId = cefBrowser->GetIdentifier();
                 IsPopup = cefBrowser->IsPopup();
 
-                JavascriptRootObjectWrappers = gcnew ConcurrentDictionary<int64_t, JavascriptRootObjectWrapper^>();
+                JavascriptRootObjectWrappers = gcnew ConcurrentDictionary<String^, JavascriptRootObjectWrapper^>();
             }
 
             !CefBrowserWrapper()
@@ -54,7 +54,7 @@ namespace CefSharp
 
                 if (JavascriptRootObjectWrappers != nullptr)
                 {
-                    for each (KeyValuePair<int64_t, JavascriptRootObjectWrapper^> entry in JavascriptRootObjectWrappers)
+                    for each (KeyValuePair<String^, JavascriptRootObjectWrapper^> entry in JavascriptRootObjectWrappers)
                     {
                         delete entry.Value;
                     }

--- a/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptCallbackRegistry.cpp
@@ -21,7 +21,7 @@ namespace CefSharp
             auto result = gcnew JavascriptCallback();
             result->Id = newId;
             result->BrowserId = _browserId;
-            result->FrameId = context->GetFrame()->GetIdentifier();
+            result->FrameId = StringUtils::ToClr(context->GetFrame()->GetIdentifier());
             return result;
         }
 

--- a/CefSharp.BrowserSubprocess.Core/Wrapper/Browser.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Wrapper/Browser.cpp
@@ -155,9 +155,9 @@ IFrame^ Browser::FocusedFrame::get()
 // Returns the frame with the specified identifier, or NULL if not found.
 ///
 /*--cef(capi_name=get_frame_byident)--*/
-IFrame^ Browser::GetFrame(Int64 identifier)
+IFrame^ Browser::GetFrameByIdentifier(String^ identifier)
 {
-    auto frame = _browser->GetFrame(identifier);
+    auto frame = _browser->GetFrameByIdentifier(StringUtils::ToNative(identifier));
 
     if (frame.get())
     {
@@ -171,9 +171,9 @@ IFrame^ Browser::GetFrame(Int64 identifier)
 // Returns the frame with the specified name, or NULL if not found.
 ///
 /*--cef(optional_param=name)--*/
-IFrame^ Browser::GetFrame(String^ name)
+IFrame^ Browser::GetFrameByName(String^ name)
 {
-    auto frame = _browser->GetFrame(StringUtils::ToNative(name));
+    auto frame = _browser->GetFrameByName(StringUtils::ToNative(name));
 
     if (frame.get())
     {
@@ -196,14 +196,14 @@ int Browser::GetFrameCount()
 // Returns the identifiers of all existing frames.
 ///
 /*--cef(count_func=identifiers:GetFrameCount)--*/
-List<Int64>^ Browser::GetFrameIdentifiers()
+List<String^>^ Browser::GetFrameIdentifiers()
 {
-    std::vector<Int64> identifiers;
+    std::vector<CefString> identifiers;
     _browser->GetFrameIdentifiers(identifiers);
-    List<Int64>^ results = gcnew List<Int64>(static_cast<int>(identifiers.size()));
+    List<String^>^ results = gcnew List<String^>(static_cast<int>(identifiers.size()));
     for (UINT i = 0; i < identifiers.size(); i++)
     {
-        results->Add(identifiers[i]);
+        results->Add(StringUtils::ToClr(identifiers[i]));
     }
     return results;
 }

--- a/CefSharp.BrowserSubprocess.Core/Wrapper/Browser.h
+++ b/CefSharp.BrowserSubprocess.Core/Wrapper/Browser.h
@@ -158,13 +158,13 @@ namespace CefSharp
             // Returns the frame with the specified identifier, or NULL if not found.
             ///
             /*--cef(capi_name=get_frame_byident)--*/
-            virtual IFrame^ GetFrame(Int64 identifier);
+            virtual IFrame^ GetFrameByIdentifier(String^ identifier);
 
             ///
             // Returns the frame with the specified name, or NULL if not found.
             ///
             /*--cef(optional_param=name)--*/
-            virtual IFrame^ GetFrame(String^ name);
+            virtual IFrame^ GetFrameByName(String^ name);
 
             ///
             // Returns the number of frames that currently exist.
@@ -176,7 +176,7 @@ namespace CefSharp
             // Returns the identifiers of all existing frames.
             ///
             /*--cef(count_func=identifiers:GetFrameCount)--*/
-            virtual List<Int64>^ GetFrameIdentifiers();
+            virtual List<String^>^ GetFrameIdentifiers();
 
             ///
             // Returns the names of all existing frames.

--- a/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.cpp
+++ b/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.cpp
@@ -205,9 +205,9 @@ String^ Frame::Name::get()
 // Returns the globally unique identifier for this frame.
 ///
 /*--cef()--*/
-Int64 Frame::Identifier::get()
+String^ Frame::Identifier::get()
 {
-    return _frame->GetIdentifier();
+    return StringUtils::ToClr(_frame->GetIdentifier());
 }
 
 ///

--- a/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.h
+++ b/CefSharp.BrowserSubprocess.Core/Wrapper/Frame.h
@@ -201,9 +201,9 @@ namespace CefSharp
             // Returns the globally unique identifier for this frame.
             ///
             /*--cef()--*/
-            virtual property Int64 Identifier
+            virtual property String^ Identifier
             {
-                Int64 get();
+                String^ get();
             }
 
             ///

--- a/CefSharp.Core.Runtime/Internals/CefBrowserWrapper.cpp
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserWrapper.cpp
@@ -192,11 +192,11 @@ IFrame^ CefBrowserWrapper::FocusedFrame::get()
 // Returns the frame with the specified identifier, or NULL if not found.
 ///
 /*--cef(capi_name=get_frame_byident)--*/
-IFrame^ CefBrowserWrapper::GetFrame(Int64 identifier)
+IFrame^ CefBrowserWrapper::GetFrameByIdentifier(String^ identifier)
 {
     ThrowIfDisposed();
 
-    auto frame = _browser->GetFrame(identifier);
+    auto frame = _browser->GetFrameByIdentifier(StringUtils::ToNative(identifier));
 
     if (frame.get())
     {
@@ -210,11 +210,11 @@ IFrame^ CefBrowserWrapper::GetFrame(Int64 identifier)
 // Returns the frame with the specified name, or NULL if not found.
 ///
 /*--cef(optional_param=name)--*/
-IFrame^ CefBrowserWrapper::GetFrame(String^ name)
+IFrame^ CefBrowserWrapper::GetFrameByName(String^ name)
 {
     ThrowIfDisposed();
 
-    auto frame = _browser->GetFrame(StringUtils::ToNative(name));
+    auto frame = _browser->GetFrameByName(StringUtils::ToNative(name));
 
     if (frame.get())
     {
@@ -238,16 +238,16 @@ int CefBrowserWrapper::GetFrameCount()
 // Returns the identifiers of all existing frames.
 ///
 /*--cef(count_func=identifiers:GetFrameCount)--*/
-List<Int64>^ CefBrowserWrapper::GetFrameIdentifiers()
+List<String^>^ CefBrowserWrapper::GetFrameIdentifiers()
 {
     ThrowIfDisposed();
 
-    std::vector<Int64> identifiers;
+    std::vector<CefString> identifiers;
     _browser->GetFrameIdentifiers(identifiers);
-    List<Int64>^ results = gcnew List<Int64>(static_cast<int>(identifiers.size()));
+    List<String^>^ results = gcnew List<String^>(static_cast<int>(identifiers.size()));
     for (UINT i = 0; i < identifiers.size(); i++)
     {
-        results->Add(identifiers[i]);
+        results->Add(StringUtils::ToClr(identifiers[i]));
     }
     return results;
 }

--- a/CefSharp.Core.Runtime/Internals/CefBrowserWrapper.h
+++ b/CefSharp.Core.Runtime/Internals/CefBrowserWrapper.h
@@ -166,13 +166,13 @@ namespace CefSharp
             // Returns the frame with the specified identifier, or NULL if not found.
             ///
             /*--cef(capi_name=get_frame_byident)--*/
-            virtual IFrame^ GetFrame(Int64 identifier);
+            virtual IFrame^ GetFrameByIdentifier(String^ identifier);
 
             ///
             // Returns the frame with the specified name, or NULL if not found.
             ///
             /*--cef(optional_param=name)--*/
-            virtual IFrame^ GetFrame(String^ name);
+            virtual IFrame^ GetFrameByName(String^ name);
 
             ///
             // Returns the number of frames that currently exist.
@@ -184,7 +184,7 @@ namespace CefSharp
             // Returns the identifiers of all existing frames.
             ///
             /*--cef(count_func=identifiers:GetFrameCount)--*/
-            virtual List<Int64>^ GetFrameIdentifiers();
+            virtual List<String^>^ GetFrameIdentifiers();
 
             ///
             // Returns the names of all existing frames.

--- a/CefSharp.Core.Runtime/Internals/CefFrameWrapper.cpp
+++ b/CefSharp.Core.Runtime/Internals/CefFrameWrapper.cpp
@@ -307,11 +307,11 @@ String^ CefFrameWrapper::Name::get()
 // Returns the globally unique identifier for this frame.
 ///
 /*--cef()--*/
-Int64 CefFrameWrapper::Identifier::get()
+String^ CefFrameWrapper::Identifier::get()
 {
     ThrowIfDisposed();
 
-    return _frame->GetIdentifier();
+    return StringUtils::ToClr(_frame->GetIdentifier());
 }
 
 ///

--- a/CefSharp.Core.Runtime/Internals/CefFrameWrapper.h
+++ b/CefSharp.Core.Runtime/Internals/CefFrameWrapper.h
@@ -202,9 +202,9 @@ namespace CefSharp
             // Returns the globally unique identifier for this frame.
             ///
             /*--cef()--*/
-            virtual property Int64 Identifier
+            virtual property String^ Identifier
             {
-                Int64 get();
+                String^ get();
             }
 
             ///

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
@@ -1351,7 +1351,7 @@ namespace CefSharp
                 {
                     if (frame->IsMain())
                     {
-                        _browserControl->SetCanExecuteJavascriptOnMainFrame(frame->GetIdentifier(), true);
+                        _browserControl->SetCanExecuteJavascriptOnMainFrame(StringUtils::ToClr(frame->GetIdentifier()), true);
                     }
 
                     auto handler = _browserControl->RenderProcessMessageHandler;
@@ -1375,7 +1375,7 @@ namespace CefSharp
                 {
                     if (frame->IsMain())
                     {
-                        _browserControl->SetCanExecuteJavascriptOnMainFrame(frame->GetIdentifier(), false);
+                        _browserControl->SetCanExecuteJavascriptOnMainFrame(StringUtils::ToClr(frame->GetIdentifier()), false);
                     }
 
                     auto handler = _browserControl->RenderProcessMessageHandler;
@@ -1513,7 +1513,7 @@ namespace CefSharp
                     return true;
                 }
 
-                auto frameId = frame->GetIdentifier();
+                auto frameId = StringUtils::ToClr(frame->GetIdentifier());
                 auto objectId = GetInt64(argList, 0);
                 auto callbackId = GetInt64(argList, 1);
                 auto methodName = StringUtils::ToClr(argList->GetString(2));
@@ -1576,7 +1576,7 @@ namespace CefSharp
 
                 if (cefBrowser.get())
                 {
-                    auto frame = cefBrowser->GetFrame(result->FrameId);
+                    auto frame = cefBrowser->GetFrameByIdentifier(StringUtils::ToNative(result->FrameId));
 
                     if (frame.get() && frame->IsValid())
                     {

--- a/CefSharp.Core.Runtime/Internals/JavascriptCallbackProxy.cpp
+++ b/CefSharp.Core.Runtime/Internals/JavascriptCallbackProxy.cpp
@@ -47,7 +47,7 @@ namespace CefSharp
             }
             argList->SetList(2, paramList);
 
-            auto frame = browserWrapper->Browser->GetFrame(_callback->FrameId);
+            auto frame = browserWrapper->Browser->GetFrameByIdentifier(StringUtils::ToNative(_callback->FrameId));
 
             if (frame.get() && frame->IsValid())
             {
@@ -126,7 +126,7 @@ namespace CefSharp
             }
 
             //If the frame Id is still valid then we can attemp to execute the callback
-            auto frame = browser->GetFrame(_callback->FrameId);
+            auto frame = browser->GetFrameByIdentifier(_callback->FrameId);
             if (frame == nullptr)
             {
                 return false;

--- a/CefSharp.Core.Runtime/Internals/JavascriptCallbackProxy.h
+++ b/CefSharp.Core.Runtime/Internals/JavascriptCallbackProxy.h
@@ -48,7 +48,7 @@ namespace CefSharp
                 if (browser != nullptr && !browser->IsDisposed)
                 {
                     auto browserWrapper = static_cast<CefBrowserWrapper^>(browser)->Browser;
-                    auto frame = browserWrapper->GetFrame(_callback->FrameId);
+                    auto frame = browserWrapper->GetFrameByIdentifier(StringUtils::ToNative(_callback->FrameId));
                     if (frame.get() && frame->IsValid())
                     {
                         frame->SendProcessMessage(CefProcessId::PID_RENDERER, CreateDestroyMessage());

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -35,6 +35,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+        <PackageReference Include="Bogus" Version="35.4.1" />
         <PackageReference Include="chromiumembeddedframework.runtime" Version="122.1.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 
@@ -43,6 +44,7 @@
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+        <PackageReference Include="Xunit.Repeat" Version="1.1.26" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.Test/CefSharp.Test.netcore.csproj
+++ b/CefSharp.Test/CefSharp.Test.netcore.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\CefSharp.WinForms\CefSharp.WinForms.netcore.csproj" />
     <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
     <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
+    <PackageReference Include="Bogus" Version="35.4.1" />
     <PackageReference Include="chromiumembeddedframework.runtime" Version="122.1.9" />
   </ItemGroup>
 
@@ -43,6 +44,7 @@
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="Xunit.Repeat" Version="1.1.26" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
 	<PackageReference Include="Titanium.Web.Proxy" version="3.1.1301" />

--- a/CefSharp.Test/Framework/ConcurrentMethodRunnerQueueTest.cs
+++ b/CefSharp.Test/Framework/ConcurrentMethodRunnerQueueTest.cs
@@ -70,7 +70,7 @@ namespace CefSharp.Test.Framework
         [Fact]
         public void ShouldWorkWhenEnqueueCalledAfterDispose()
         {
-            var methodInvocation = new MethodInvocation(1, 1, 1, "Testing", 1);
+            var methodInvocation = new MethodInvocation(1, "1", 1, "Testing", 1);
             methodInvocation.Parameters.Add("Echo Me!");
 
             var objectRepository = new JavascriptObjectRepository
@@ -102,7 +102,7 @@ namespace CefSharp.Test.Framework
 #else
             objectRepository.Register("testObject", boundObject, true, BindingOptions.DefaultBinder);
 #endif
-            var methodInvocation = new MethodInvocation(1, 1, 1, nameof(boundObject.AsyncWaitTwoSeconds), 1);
+            var methodInvocation = new MethodInvocation(1, "1", 1, nameof(boundObject.AsyncWaitTwoSeconds), 1);
             methodInvocation.Parameters.Add("Echo Me!");
             var methodRunnerQueue = new ConcurrentMethodRunnerQueue(objectRepository);
 
@@ -124,7 +124,7 @@ namespace CefSharp.Test.Framework
 
             var mockObjectRepository = new Mock<IJavascriptObjectRepositoryInternal>();
             mockObjectRepository.Setup(x => x.TryCallMethodAsync(1, methodName, It.IsAny<object[]>())).ReturnsAsync(new TryCallMethodResult(true, expected, string.Empty));
-            var methodInvocation = new MethodInvocation(1, 1, 1, methodName, 1);
+            var methodInvocation = new MethodInvocation(1, "1", 1, methodName, 1);
             methodInvocation.Parameters.Add(expected);
 
             using var methodRunnerQueue = new ConcurrentMethodRunnerQueue(mockObjectRepository.Object);

--- a/CefSharp.Test/Framework/JavascritpCallbackConversionTests.cs
+++ b/CefSharp.Test/Framework/JavascritpCallbackConversionTests.cs
@@ -1,0 +1,30 @@
+using Bogus;
+using Bogus.Extensions;
+using CefSharp.Internals;
+using Xunit;
+using Xunit.Repeat;
+
+namespace CefSharp.Test.Framework
+{
+    public class JavascritpCallbackConversionTests
+    {
+        [Theory]
+        [Repeat(1000)]
+        public void CanConvertToAndFromBinary(int iteration)
+        {
+            var calbackFactory = new Faker<JavascriptCallback>()
+                .RuleFor(o => o.Id, f => f.Random.Long(1, long.MaxValue))
+                .RuleFor(o => o.BrowserId, f => f.Random.Number(1, int.MaxValue))
+                .RuleFor(o => o.FrameId, f => f.Random.AlphaNumeric(120).ClampLength(120, 160));
+
+            var exepected = calbackFactory.Generate();
+
+            var actual = JavascriptCallback.FromBytes(exepected.ToByteArray(1));
+
+            Assert.Equal(exepected.Id, actual.Id);
+            Assert.Equal(exepected.BrowserId, actual.BrowserId);
+            Assert.Equal(exepected.FrameId, actual.FrameId);
+
+        }
+    }
+}

--- a/CefSharp.Test/Framework/MethodRunnerQueueTests.cs
+++ b/CefSharp.Test/Framework/MethodRunnerQueueTests.cs
@@ -12,7 +12,7 @@ namespace CefSharp.Test.Framework
         [Fact]
         public void DisposeQueueThenEnqueueMethodInvocation()
         {
-            var methodInvocation = new MethodInvocation(1, 1, 1, "Testing", 1);
+            var methodInvocation = new MethodInvocation(1, "1", 1, "Testing", 1);
             methodInvocation.Parameters.Add("Echo Me!");
 
             var objectRepository = new JavascriptObjectRepository

--- a/CefSharp/Handler/FrameHandler.cs
+++ b/CefSharp/Handler/FrameHandler.cs
@@ -12,7 +12,7 @@ namespace CefSharp.Handler
     /// </summary>
     public class FrameHandler : IFrameHandler
     {
-        private Dictionary<long, IFrame> frames = new Dictionary<long, IFrame>();
+        private Dictionary<string, IFrame> frames = new Dictionary<string, IFrame>();
 
         /// <inheritdoc/>
         void IFrameHandler.OnFrameAttached(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, bool reattached)
@@ -119,7 +119,7 @@ namespace CefSharp.Handler
 
         }
 
-        private IFrame GetFrameById(long frameId)
+        private IFrame GetFrameById(string frameId)
         {
             if(frames.TryGetValue(frameId, out var frame))
             {

--- a/CefSharp/IBrowser.cs
+++ b/CefSharp/IBrowser.cs
@@ -113,14 +113,14 @@ namespace CefSharp
         /// </summary>
         /// <param name="identifier">identifier</param>
         /// <returns>frame or null</returns>
-        IFrame GetFrame(Int64 identifier);
+        IFrame GetFrameByIdentifier(string identifier);
 
         /// <summary>
         /// Returns the frame with the specified name, or NULL if not found.
         /// </summary>
         /// <param name="name">name of frame</param>
         /// <returns>frame or null</returns>
-        IFrame GetFrame(string name);
+        IFrame GetFrameByName(string name);
 
         /// <summary>
         /// Returns the number of frames that currently exist.
@@ -132,7 +132,7 @@ namespace CefSharp
         /// Returns the identifiers of all existing frames.
         /// </summary>
         /// <returns>list of frame identifiers</returns>
-        List<Int64> GetFrameIdentifiers();
+        List<string> GetFrameIdentifiers();
 
         /// <summary>
         /// Returns the names of all existing frames.

--- a/CefSharp/IFrame.cs
+++ b/CefSharp/IFrame.cs
@@ -148,9 +148,10 @@ namespace CefSharp
         string Name { get; }
 
         /// <summary>
-        /// Returns the globally unique identifier for this frame or &lt; 0 if the underlying frame does not yet exist.
+        /// Returns the globally unique identifier for this frame or empty if the
+        /// underlying frame does not yet exist.
         /// </summary>
-        Int64 Identifier { get; }
+        string Identifier { get; }
 
         /// <summary>
         /// Returns the parent of this frame or NULL if this is the main (top-level) frame.

--- a/CefSharp/Internals/IWebBrowserInternal.cs
+++ b/CefSharp/Internals/IWebBrowserInternal.cs
@@ -18,7 +18,7 @@ namespace CefSharp.Internals
         void SetLoadingStateChange(LoadingStateChangedEventArgs args);
         void SetTitle(TitleChangedEventArgs args);
         void SetTooltipText(string tooltipText);
-        void SetCanExecuteJavascriptOnMainFrame(long frameId, bool canExecute);
+        void SetCanExecuteJavascriptOnMainFrame(string frameId, bool canExecute);
         void SetJavascriptMessageReceived(JavascriptMessageReceivedEventArgs args);
 
         void OnFrameLoadStart(FrameLoadStartEventArgs args);

--- a/CefSharp/Internals/MethodInvocation.cs
+++ b/CefSharp/Internals/MethodInvocation.cs
@@ -12,7 +12,7 @@ namespace CefSharp.Internals
 
         public int BrowserId { get; private set; }
 
-        public long FrameId { get; private set; }
+        public string FrameId { get; private set; }
 
         public long? CallbackId { get; private set; }
 
@@ -25,7 +25,7 @@ namespace CefSharp.Internals
             get { return parameters; }
         }
 
-        public MethodInvocation(int browserId, long frameId, long objectId, string methodName, long? callbackId)
+        public MethodInvocation(int browserId, string frameId, long objectId, string methodName, long? callbackId)
         {
             BrowserId = browserId;
             FrameId = frameId;

--- a/CefSharp/Internals/MethodInvocationResult.cs
+++ b/CefSharp/Internals/MethodInvocationResult.cs
@@ -12,7 +12,7 @@ namespace CefSharp.Internals
 
         public long? CallbackId { get; set; }
 
-        public long FrameId { get; set; }
+        public string FrameId { get; set; }
 
         public string Message { get; set; }
 

--- a/CefSharp/Internals/Partial/ChromiumWebBrowser.Partial.cs
+++ b/CefSharp/Internals/Partial/ChromiumWebBrowser.Partial.cs
@@ -31,7 +31,7 @@ namespace CefSharp.WinForms
         /// <summary>
         /// Used as workaround for issue https://github.com/cefsharp/CefSharp/issues/3021
         /// </summary>
-        private BigInteger canExecuteJavascriptInMainFrameId;
+        private int canExecuteJavascriptInMainFrameChildProcessId;
 
         /// <summary>
         /// The browser initialized - boolean represented as 0 (false) and 1(true) as we use Interlocker to increment/reset
@@ -257,14 +257,14 @@ namespace CefSharp.WinForms
             //incorrectly overrides the value
             //https://github.com/cefsharp/CefSharp/issues/3021
 
-            var frameIdBigInt = BigInteger.Parse(frameId);
+            var chromiumChildProcessId = GetChromiumChildProcessId(frameId);
 
-            if (frameIdBigInt > canExecuteJavascriptInMainFrameId && !canExecute)
+            if (chromiumChildProcessId > canExecuteJavascriptInMainFrameChildProcessId && !canExecute)
             {
                 return;
             }
 
-            canExecuteJavascriptInMainFrameId = frameIdBigInt;
+            canExecuteJavascriptInMainFrameChildProcessId = chromiumChildProcessId;
             CanExecuteJavascriptInMainFrame = canExecute;
         }
 
@@ -430,7 +430,7 @@ namespace CefSharp.WinForms
 
         private void InitialLoad(bool? isLoading, CefErrorCode? errorCode)
         {
-            if(IsDisposed)
+            if (IsDisposed)
             {
                 initialLoadAction = null;
 
@@ -539,6 +539,23 @@ namespace CefSharp.WinForms
             {
                 throw new ObjectDisposedException("ChromiumWebBrowser");
             }
+        }
+
+        private int GetChromiumChildProcessId(string frameIdentifier)
+        {
+            try
+            {
+                var parts = frameIdentifier.Split('-');
+
+                if (int.TryParse(parts[0], out var childProcessId))
+                    return childProcessId;
+            }
+            catch
+            {
+
+            }
+
+            return -1;
         }
     }
 }

--- a/CefSharp/Internals/Partial/ChromiumWebBrowser.Partial.cs
+++ b/CefSharp/Internals/Partial/ChromiumWebBrowser.Partial.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using CefSharp.Internals;
@@ -30,7 +31,7 @@ namespace CefSharp.WinForms
         /// <summary>
         /// Used as workaround for issue https://github.com/cefsharp/CefSharp/issues/3021
         /// </summary>
-        private long canExecuteJavascriptInMainFrameId;
+        private BigInteger canExecuteJavascriptInMainFrameId;
 
         /// <summary>
         /// The browser initialized - boolean represented as 0 (false) and 1(true) as we use Interlocker to increment/reset
@@ -247,7 +248,7 @@ namespace CefSharp.WinForms
             get { return InternalIsBrowserInitialized(); }
         }
 
-        void IWebBrowserInternal.SetCanExecuteJavascriptOnMainFrame(long frameId, bool canExecute)
+        void IWebBrowserInternal.SetCanExecuteJavascriptOnMainFrame(string frameId, bool canExecute)
         {
             //When loading pages of a different origin the frameId changes
             //For the first loading of a new origin the messages from the render process
@@ -256,12 +257,14 @@ namespace CefSharp.WinForms
             //incorrectly overrides the value
             //https://github.com/cefsharp/CefSharp/issues/3021
 
-            if (frameId > canExecuteJavascriptInMainFrameId && !canExecute)
+            var frameIdBigInt = BigInteger.Parse(frameId);
+
+            if (frameIdBigInt > canExecuteJavascriptInMainFrameId && !canExecute)
             {
                 return;
             }
 
-            canExecuteJavascriptInMainFrameId = frameId;
+            canExecuteJavascriptInMainFrameId = frameIdBigInt;
             CanExecuteJavascriptInMainFrame = canExecute;
         }
 


### PR DESCRIPTION
**Fixes:** #4737

**Summary:** 
Migrate from Int64 to String for frame identifier

**Changes:** 
-       
**How Has This Been Tested?**  
- New tests added for `JavascriptCallback` conversion
- Existing tests are passing.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)