### PR TITLE
Nuget - Prefer APPVEYOR_REPO_BRANCH

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-#requires -Version 5
+﻿#requires -Version 5
 
 param(
     [ValidateSet("vs2022","vs2019", "nupkg-only", "update-build-version")]
@@ -271,6 +271,11 @@ function Nupkg
 
     $gitBranch = git rev-parse --abbrev-ref HEAD
     $gitCommit = git rev-parse HEAD
+
+    if (Test-Path Env:\APPVEYOR_REPO_BRANCH) # https://github.com/appveyor/ci/issues/1606
+    {
+        $gitBranch = $env:APPVEYOR_REPO_BRANCH
+    }
 
     Write-Diagnostic "Building nuget package for $gitCommit on $gitBranch"
 


### PR DESCRIPTION
**Summary:**
After https://github.com/cefsharp/CefSharp/pull/4763 was merged I have seen in https://ci.appveyor.com/project/cefsharp/cefsharp/builds/49434312/artifacts that the branch name was `HEAD` instead of `master`. Looks like AppVeyor does checkout the commit rather than the branch: https://github.com/appveyor/ci/issues/1606

**Changes:** 
   - Added check for `APPVEYOR_REPO_BRANCH` and prefer it over the branch name we get from git.
      
**How Has This Been Tested?**  
Manually

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
