### PR TITLE
Implement AcceleratedPaintInfo

### DIFF
--- a/CefSharp.Core.Runtime/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core.Runtime/Internals/RenderClientAdapter.h
@@ -153,7 +153,10 @@ namespace CefSharp
             virtual DECL void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList& dirtyRects, const CefAcceleratedPaintInfo& info) override
             {
                 CefRect r = dirtyRects.front();
-                _renderWebBrowser->OnAcceleratedPaint((CefSharp::PaintElementType)type, CefSharp::Structs::Rect(r.x, r.y, r.width, r.height), nullptr);
+                AcceleratedPaintInfo^ api = gcnew AcceleratedPaintInfo();
+                api->SharedTextureHandle = (IntPtr)info.shared_texture_handle;
+                api->Format = (ColorType)info.format;
+                _renderWebBrowser->OnAcceleratedPaint((CefSharp::PaintElementType)type, CefSharp::Structs::Rect(r.x, r.y, r.width, r.height), api);
             }
 
             virtual DECL void OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList& dirtyRects,

--- a/CefSharp.Core.Runtime/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core.Runtime/Internals/RenderClientAdapter.h
@@ -153,9 +153,7 @@ namespace CefSharp
             virtual DECL void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList& dirtyRects, const CefAcceleratedPaintInfo& info) override
             {
                 CefRect r = dirtyRects.front();
-                AcceleratedPaintInfo^ api = gcnew AcceleratedPaintInfo();
-                api->SharedTextureHandle = (IntPtr)info.shared_texture_handle;
-                api->Format = (ColorType)info.format;
+                AcceleratedPaintInfo^ api = gcnew AcceleratedPaintInfo((IntPtr)info.shared_texture_handle, (ColorType)info.format);
                 _renderWebBrowser->OnAcceleratedPaint((CefSharp::PaintElementType)type, CefSharp::Structs::Rect(r.x, r.y, r.width, r.height), api);
             }
 

--- a/CefSharp/AcceleratedPaintInfo.cs
+++ b/CefSharp/AcceleratedPaintInfo.cs
@@ -8,11 +8,30 @@ using CefSharp.Enums;
 namespace CefSharp
 {
     /// <summary>
-    /// AcceleratedPaintInfo
+    /// Class representing accelerated paint info.
     /// </summary>
     public sealed class AcceleratedPaintInfo
     {
-        public IntPtr SharedTextureHandle;
-        public ColorType Format;
+        /// <summary>
+        /// Handle for the shared texture. The shared texture is instantiated
+        /// without a keyed mutex.
+        /// </summary>
+        public IntPtr SharedTextureHandle { get; }
+
+        /// <summary>
+        /// The pixel format of the texture.
+        /// </summary>
+        public ColorType Format { get; }
+
+        /// <summary>
+        /// AcceleratedPaintInfo
+        /// </summary>
+        /// <param name="sharedTextureHandle">Handle to the shared texture resource</param>
+        /// <param name="format">The pixel format of the shared texture resource</param>
+        public AcceleratedPaintInfo(IntPtr sharedTextureHandle, ColorType format)
+        {
+            SharedTextureHandle = sharedTextureHandle;
+            Format = format;
+        }
     }
 }

--- a/CefSharp/AcceleratedPaintInfo.cs
+++ b/CefSharp/AcceleratedPaintInfo.cs
@@ -2,6 +2,9 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System;
+using CefSharp.Enums;
+
 namespace CefSharp
 {
     /// <summary>
@@ -9,5 +12,7 @@ namespace CefSharp
     /// </summary>
     public sealed class AcceleratedPaintInfo
     {
+        public IntPtr SharedTextureHandle;
+        public ColorType Format;
     }
 }


### PR DESCRIPTION
Implement AcceleratedPaintInfo so the shared texture can be used for accelerated rendering in a custom IRenderHandler.
Code was successfully tested against Direct3D11.1 using SharpDX on Windows 11.
Use SharpDX.Direct3D11.Device1.OpenSharedResource1< Texture2D >(AcceleratedPaintInfo.SharedTextureHandle);
Then copy the contents of this resource to your own Texture2D before returning from OnAcceleratedPaint().