### PR TITLE
WPF - Ensure only single drag operation is emit on DragSourceEndedAt

### DIFF
--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -920,7 +920,7 @@ namespace CefSharp.Wpf
             {
                 if (browser != null)
                 {
-                    //DoDragDrop will fire DragEnter event
+                    // DoDragDrop will fire DragEnter event
                     var result = DragDrop.DoDragDrop(this, dataObject, allowedOps.GetDragEffects());
                     var dragEffects = currentDragDropEffects.HasValue ? currentDragDropEffects.Value : DragDropEffects.None;
 
@@ -932,10 +932,12 @@ namespace CefSharp.Wpf
                     // just default to copy, as that reflects the defaulting behavior of GetDragEffects.
                     var finalSingleEffect = finalEffectMask.HasFlag(DragOperationsMask.Every) ? DragOperationsMask.Copy : finalEffectMask;
 
-                    //DragData was stored so when DoDragDrop fires DragEnter we reuse a clone of the IDragData provided here
+                    // DragData was stored so when DoDragDrop fires DragEnter we reuse a clone of the IDragData provided here
                     currentDragData = null;
                     currentDragDropEffects = null;
 
+                    // If result or the last recorded drag drop effect were DragDropEffects.None
+                    // then we'll send DragOperationsMask.None, effectively cancelling the drag operation
                     browser.GetHost().DragSourceEndedAt(x, y, finalSingleEffect);
                     browser.GetHost().DragSourceSystemDragEnded();
                 }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -133,7 +134,7 @@ namespace CefSharp.Wpf
         /// <summary>
         /// Keep the current drag&amp;drop effects to return the appropriate effects on drag over.
         /// </summary>
-        private DragDropEffects currentDragDropEffects;
+        private DragDropEffects? currentDragDropEffects;
         /// <summary>
         /// A flag that indicates whether or not the designer is active
         /// NOTE: Needs to be static for OnApplicationExit
@@ -921,13 +922,21 @@ namespace CefSharp.Wpf
                 {
                     //DoDragDrop will fire DragEnter event
                     var result = DragDrop.DoDragDrop(this, dataObject, allowedOps.GetDragEffects());
+                    var dragEffects = currentDragDropEffects.HasValue ? currentDragDropEffects.Value : DragDropEffects.None;
+
+                    // Ensure the drag and drop operation wasn't cancelled
+                    var finalEffectMask = dragEffects.GetDragOperationsMask() & result.GetDragOperationsMask();
+
+                    // We shouldn't have an instance where finalEffectMask signfies multiple effects, as the operation
+                    // set by UpdateDragCursor should only ever be none, move, copy, or link. However, if it does, we'll
+                    // just default to copy, as that reflects the defaulting behavior of GetDragEffects.
+                    var finalSingleEffect = finalEffectMask.HasFlag(DragOperationsMask.Every) ? DragOperationsMask.Copy : finalEffectMask;
 
                     //DragData was stored so when DoDragDrop fires DragEnter we reuse a clone of the IDragData provided here
                     currentDragData = null;
+                    currentDragDropEffects = null;
 
-                    //If result == DragDropEffects.None then we'll send DragOperationsMask.None
-                    //effectively cancelling the drag operation
-                    browser.GetHost().DragSourceEndedAt(x, y, result.GetDragOperationsMask());
+                    browser.GetHost().DragSourceEndedAt(x, y, finalSingleEffect);
                     browser.GetHost().DragSourceSystemDragEnded();
                 }
             });
@@ -945,9 +954,13 @@ namespace CefSharp.Wpf
         /// Called when the web view wants to update the mouse cursor during a drag &amp; drop operation.
         /// </summary>
         /// <param name="operation">describes the allowed operation (none, move, copy, link). </param>
+        List<DragOperationsMask> pretransformEffectsRaised = new List<DragOperationsMask>();
+        List<DragDropEffects> effectsRaised = new List<DragDropEffects>();
         protected virtual void UpdateDragCursor(DragOperationsMask operation)
         {
             currentDragDropEffects = operation.GetDragEffects();
+            pretransformEffectsRaised.Add(operation);
+            effectsRaised.Add(currentDragDropEffects.Value);
         }
 
         /// <inheritdoc />
@@ -1683,7 +1696,6 @@ namespace CefSharp.Wpf
             {
                 var mouseEvent = GetMouseEvent(e);
                 var effect = e.AllowedEffects.GetDragOperationsMask();
-
                 browser.GetHost().DragTargetDragOver(mouseEvent, effect);
                 browser.GetHost().DragTargetDragDrop(mouseEvent);
             }
@@ -1713,7 +1725,7 @@ namespace CefSharp.Wpf
             {
                 browser.GetHost().DragTargetDragOver(GetMouseEvent(e), e.AllowedEffects.GetDragOperationsMask());
             }
-            e.Effects = currentDragDropEffects;
+            e.Effects = currentDragDropEffects.HasValue ? currentDragDropEffects.Value : DragDropEffects.None;
             e.Handled = true;
         }
 
@@ -1731,6 +1743,7 @@ namespace CefSharp.Wpf
 
                 //DoDragDrop will fire this handler for internally sourced Drag/Drop operations
                 //we use the existing IDragData (cloned copy)
+
                 var dragData = currentDragData ?? e.GetDragData();
 
                 browser.GetHost().DragTargetDragEnter(dragData, mouseEvent, effect);
@@ -2323,7 +2336,7 @@ namespace CefSharp.Wpf
                     deltaX: isShiftKeyDown ? e.Delta : 0,
                     deltaY: !isShiftKeyDown ? e.Delta : 0,
                     modifiers: modifiers);
-                
+
                 e.Handled = true;
             }
 
@@ -2469,7 +2482,7 @@ namespace CefSharp.Wpf
                     {
                         clickCount = 1;
                     }
-                    
+
                     MousePositionTransform.TransformMousePoint(ref point);
                     browser.GetHost().SendMouseClickEvent((int)point.X, (int)point.Y, (MouseButtonType)e.ChangedButton, mouseUp, clickCount, modifiers);
                 }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -954,13 +954,9 @@ namespace CefSharp.Wpf
         /// Called when the web view wants to update the mouse cursor during a drag &amp; drop operation.
         /// </summary>
         /// <param name="operation">describes the allowed operation (none, move, copy, link). </param>
-        List<DragOperationsMask> pretransformEffectsRaised = new List<DragOperationsMask>();
-        List<DragDropEffects> effectsRaised = new List<DragDropEffects>();
         protected virtual void UpdateDragCursor(DragOperationsMask operation)
         {
             currentDragDropEffects = operation.GetDragEffects();
-            pretransformEffectsRaised.Add(operation);
-            effectsRaised.Add(currentDragDropEffects.Value);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
**Fixes:** #4801 
<!-- e.g Fixes: #2345 -->

**Summary:** 
   - This change ensures that only `none`, `move`, `copy`, or `link` can be passed the the browser host to signify a DragEnd event. Specifying multiple flags on the bitmask seems to prevent the event from firing, and therefore the result that is returned from DragDrop.DoDragDrop is compared to the last drag drop effect we have on record.
   - When doing further testing after creating the issue, I noticed that the dragEnd event *was* emit when I cancelled the drag drop. Beyond this, when testing and manually specifying the flag, I noticed the event was emit when using the `none`, `move`, `copy`, or `link` flags by themselves in the bitmask, and seemed to correlate with the event's `dataTransfer.dropEvent` field. Given the API specifies that can only be one of those four values (and not a mixture of [them](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer)), that seemed reasonable. Furthermore, it seemed that the `DoDragDrop` function used within the `StartDragging` function would consistently return the mask with more than one value set.
  
**Changes:** 
   - I have modified the implementation of the CefSharp.Wpf ChromiumWebBrowser's StartDragging method, but no significant changes were made to the structure of the code.
      
**How Has This Been Tested?**  

This has been tested by going through the same process detailed in the issue [here](https://github.com/cefsharp/CefSharp/issues/4801#issue-2293862100). This was done on Windows 11, with an x64 architecture, .NET Version 4.7.2, and the WPF implementation.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [X] Commented my code
- [ ] Changed the documentation(if applicable) N/A
- [X] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
