### PR TITLE
fix: take latest vs install if multiple instances exist with vswhere.exe

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -184,7 +184,7 @@ function VSX
     $versionSearchStr = "[$VS_VER.0," + ($VS_VER+1) + ".0)"
 
     $ErrorActionPreference="SilentlyContinue"
-    $VSInstallPath = & $VSWherePath -version $versionSearchStr -property installationPath $VS_PRE
+    $VSInstallPath = & $VSWherePath -version $versionSearchStr -latest -property installationPath $VS_PRE
     $ErrorActionPreference="Stop"
     
     Write-Diagnostic "$($VS_OFFICIAL_VER)InstallPath: $VSInstallPath"


### PR DESCRIPTION
**Fixes:** #4938
<!-- e.g Fixes: #2345 -->

**Summary:** [summary of the change and which issue is fixed here]
Specifying latest gives us the last installed version and is a quick fix without adding more parameters.

**Changes:** [specify the structures changed] 
Should have 0 effect for where build.ps1 was working and fix where it broke with multiple installs
      
**How Has This Been Tested?**  
I ran it ;)

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [  x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ x ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ x ] The formatting is consistent with the project (project supports .editorconfig)

I think this would happen if you have vs 2022 and preview installed, certainly if you had community and another version installed.