### PR TITLE
WPF/OffScreen - Avoid ObjectDisposedException when browser is already disposed

### DIFF
--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -291,7 +291,10 @@ namespace CefSharp.OffScreen
                 //Stop rendering immediately so later on when we dispose of the
                 //RenderHandler no further OnPaint calls take place
                 //Check browser not null as it's possible to call Dispose before it's created
-                browser?.GetHost().WasHidden(true);
+                if (browser?.IsDisposed == false)
+                {
+                    browser?.GetHost().WasHidden(true);
+                }
 
                 // Don't reference event listeners any longer:
                 AddressChanged = null;

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -671,7 +671,10 @@ namespace CefSharp.Wpf
                 //Stop rendering immediately so later on when we dispose of the
                 //RenderHandler no further OnPaint calls take place
                 //Check browser not null as it's possible to call Dispose before it's created
-                browser?.GetHost().WasHidden(true);
+                if (browser?.IsDisposed == false)
+                {
+                    browser?.GetHost().WasHidden(true);
+                }
 
                 UiThreadRunAsync(() =>
                 {


### PR DESCRIPTION
**Summary:** 
   - When opening popups which close themself (e.g. with `window.close()`) it can happen that the `IBrowser` is already disposed but not the `ChromiumWebBrowser`, which can lead to `ObjectDisposedException` in dispose.

**Changes:**
   - Added a check for `IBrowser.IsDisposed` before accessing it.
      
**How Has This Been Tested?**  
Manually. Unfortunately I wasn't able to create a test for it yet.

**Screenshots (if appropriate):**
![image](https://github.com/user-attachments/assets/ac21ddf6-873a-4448-8035-6cef732a56fb)
<img width="718" alt="image" src="https://github.com/user-attachments/assets/92811ea6-5c25-44ce-8d73-264a5802cbb3">


**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
