### PR TITLE
Test - Use TaskCreationOptions instead of TaskContinuationOptions for TaskCompletionSource

### DIFF
--- a/CefSharp.Test/OffScreen/DownloadHandlerTests.cs
+++ b/CefSharp.Test/OffScreen/DownloadHandlerTests.cs
@@ -26,7 +26,7 @@ namespace CefSharp.Test.OffScreen
         [InlineData("https://code.jquery.com/jquery-3.4.1.min.js")]
         public async Task ShouldWorkWithoutAskingUser(string url)
         {
-            var tcs = new TaskCompletionSource<string>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var chromiumWebBrowser = new ChromiumWebBrowser(url, useLegacyRenderHandler: false))
             {


### PR DESCRIPTION
Using `TaskCreationOptions` instead of `TaskContinuationOptions` for `TaskCompletionSource` in test. This was the only place where it was wrong.