### PR TITLE
editorconfig - Enable CA2247 to error on build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -156,3 +156,5 @@ csharp_space_between_square_brackets                                           =
 # Modifier order
 csharp_preferred_modifier_order                                                = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async : error
 
+# CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+dotnet_diagnostic.CA2247.severity = error

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -905,7 +905,7 @@ namespace CefSharp.OffScreen
             return RenderHandler?.GetScreenPoint(viewX, viewY, out screenX, out screenY) ?? false;
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderWebBrowser.OnAcceleratedPaint(PaintElementType type, Rect dirtyRect, AcceleratedPaintInfo acceleratedPaintInfo)
         {
             RenderHandler?.OnAcceleratedPaint(type, dirtyRect, acceleratedPaintInfo);

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -981,7 +981,7 @@ namespace CefSharp.Wpf
         /// client application. The contents of <paramref name="acceleratedPaintInfo"/>acceleratedPaintInfo
         /// will be released back to the pool after this callback returns.
         /// </summary>
-        /// <param name="type">indicates whether the element is the view or the popup widget.</param>
+        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
         /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
         /// <param name="acceleratedPaintInfo">contains the shared handle; on Windows it is a
         /// HANDLE to a texture that can be opened with D3D11 OpenSharedResource.</param>

--- a/CefSharp.Wpf/IRenderHandler.cs
+++ b/CefSharp.Wpf/IRenderHandler.cs
@@ -27,7 +27,7 @@ namespace CefSharp.Wpf
         /// client application. The contents of <paramref name="acceleratedPaintInfo"/>acceleratedPaintInfo
         /// will be released back to the pool after this callback returns.
         /// </summary>
-        /// <param name="type">indicates whether the element is the view or the popup widget.</param>
+        /// <param name="isPopup">indicates whether the element is the view or the popup widget.</param>
         /// <param name="dirtyRect">contains the set of rectangles in pixel coordinates that need to be repainted</param>
         /// <param name="acceleratedPaintInfo">contains the shared handle; on Windows it is a
         /// HANDLE to a texture that can be opened with D3D11 OpenSharedResource.</param>

--- a/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AbstractRenderHandler.cs
@@ -98,7 +98,7 @@ namespace CefSharp.Wpf.Rendering
             }
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         public virtual void OnAcceleratedPaint(bool isPopup, Rect dirtyRect, AcceleratedPaintInfo acceleratedPaintInfo)
         {
             // NOT USED

--- a/CefSharp.Wpf/Rendering/AllocHGlobalWritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/AllocHGlobalWritableBitmapRenderHandler.cs
@@ -96,7 +96,7 @@ namespace CefSharp.Wpf.Rendering
             }
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, AcceleratedPaintInfo acceleratedPaintInfo)
         {
             //NOT USED

--- a/CefSharp.Wpf/Rendering/DirectWritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/DirectWritableBitmapRenderHandler.cs
@@ -42,19 +42,19 @@ namespace CefSharp.Wpf.Rendering
             this.invalidateDirtyRect = invalidateDirtyRect;
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IDisposable.Dispose()
         {
 
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, AcceleratedPaintInfo acceleratedPaintInfo)
         {
             throw new NotImplementedException();
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderHandler.OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
         {
             var writeableBitmap = image.Source as WriteableBitmap;

--- a/CefSharp.Wpf/Rendering/Experimental/ByteArrayWritableBitmapRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/Experimental/ByteArrayWritableBitmapRenderHandler.cs
@@ -42,7 +42,7 @@ namespace CefSharp.Wpf.Rendering.Experimental
             this.dispatcherPriority = dispatcherPriority;
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, AcceleratedPaintInfo acceleratedPaintInfo)
         {
             //NOT USED

--- a/CefSharp.Wpf/Rendering/Experimental/CompositionTargetRenderHandler.cs
+++ b/CefSharp.Wpf/Rendering/Experimental/CompositionTargetRenderHandler.cs
@@ -59,7 +59,7 @@ namespace CefSharp.Wpf.Rendering.Experimental
             }
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IDisposable.Dispose()
         {
             CompositionTarget.Rendering -= OnRendering;
@@ -79,13 +79,13 @@ namespace CefSharp.Wpf.Rendering.Experimental
             }
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderHandler.OnAcceleratedPaint(bool isPopup, Rect dirtyRect, AcceleratedPaintInfo acceleratedPaintInfo)
         {
             throw new NotImplementedException();
         }
 
-        /// </<inheritdoc/>
+        /// <inheritdoc/>
         void IRenderHandler.OnPaint(bool isPopup, Rect dirtyRect, IntPtr buffer, int width, int height, Image image)
         {
             if (image.Dispatcher.HasShutdownStarted)

--- a/CefSharp/IWindowInfo.cs
+++ b/CefSharp/IWindowInfo.cs
@@ -73,7 +73,7 @@ namespace CefSharp
 
         /// <summary>
         /// Optionally change the runtime style. Alloy style will always be used if
-        /// <see cref="WindowlessRenderingEnabled"> is true. See <see cref="CefRuntimeStyle"/>
+        /// <see cref="WindowlessRenderingEnabled"/> is true. See <see cref="CefRuntimeStyle"/>
         /// documentation for details.
         /// </summary>
         CefRuntimeStyle RuntimeStyle { get; set; }


### PR DESCRIPTION
**Fixes:**
See https://github.com/cefsharp/CefSharp/pull/4942#issuecomment-2380104532

**Summary:**
   - Enable CA2247 rule in editorconfig and set it to `error` on build

**Changes:**
   - Enable CA2247
   - Fix some XML doc comments
      
**How Has This Been Tested?**  
Manual build.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
