### PR TITLE
SerializeV8SimpleObject support for ExpandoObjects

### DIFF
--- a/CefSharp.Core.Runtime/Internals/Serialization/V8Serialization.cpp
+++ b/CefSharp.Core.Runtime/Internals/Serialization/V8Serialization.cpp
@@ -140,6 +140,18 @@ namespace CefSharp
                         list->SetString(index, StringUtils::ToNative(Convert::ToString(obj)));
                     }
                 }
+                // ExpandoObject only implements IDictionary<string,object> not the non-generic System.Collection.IDictionary like Dictionary does
+                else if (type == System::Dynamic::ExpandoObject::typeid)
+                {
+                    auto subDict = CefDictionaryValue::Create();
+                    auto dict = (System::Collections::Generic::IDictionary<String^, Object^>^) obj;
+                    for each (auto kvp in dict)
+                    {
+                        auto fieldName = StringUtils::ToNative(Convert::ToString(kvp.Key));
+                        SerializeV8SimpleObject(subDict, fieldName, kvp.Value, ancestors, nameConverter);
+                    }
+                    list->SetDictionary(index, subDict);
+                }
                 // Serialize dictionary to CefDictionary (key,value pairs)
                 else if (System::Collections::IDictionary::typeid->IsAssignableFrom(type))
                 {


### PR DESCRIPTION
**Fixes:** #4958

**Summary:**
   This adds ExpandoObject support to the SerializeV8SimpleObject path.   We could add support for testing if it is assignable to a idictionary<string,object> which might allow a few more things to work but im not aware off hand what they would be.  Maybe we could add support for any templated IDictionary but that is beyond my CLR c++ knowledge. 
We could eliminate some code potentially merging this and the dictionary function into one.  If the item is an expandoObject we could use the IDictionary constructor of Dictionary to create a Dictionary<string,object> and then use the rest of the IDictionary support that is there.   Let me know if you want me to revise it to that.

**Changes:**
Added specific case for ExpandoObject so should have minimal impact
      
**How Has This Been Tested?**  
Ran it once, cow was still standing after, clearly bulletproof.

**Screenshots (if appropriate):**
![image](https://github.com/user-attachments/assets/c7a1d72e-868a-4629-aa14-c4dfa710b9de)

**Types of changes**
Default behavior created nodes with literal "Key": <expandoItemKey>, "Value":<expandoItemValue>, i doubt something replied on that.

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ x] Changed the documentation(if applicable)
- [ x] New files have a license disclaimer
- [x ] The formatting is consistent with the project (project supports .editorconfig)
