### PR TITLE
CefSharp.Wpf.HwndHost support added to sample app and master solution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CefSharp.Wpf.HwndHost"]
+	path = CefSharp.Wpf.HwndHost
+	url = https://github.com/cefsharp/CefSharp.Wpf.HwndHost.git

--- a/CefSharp.Wpf.Example/App.xaml.cs
+++ b/CefSharp.Wpf.Example/App.xaml.cs
@@ -6,7 +6,9 @@ using System.Windows;
 using CefSharp.Example;
 using CefSharp.Example.Handlers;
 using CefSharp.Wpf.Example.Handlers;
-
+#if CEFSHARP_WPF_HWNDHOST
+using CefSharp.Wpf.HwndHost;
+#endif
 namespace CefSharp.Wpf.Example
 {
     public partial class App : Application

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
@@ -35,10 +35,12 @@
         <SelfContained Condition="'$(Configuration)' == 'Debug'">false</SelfContained>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'False'">
+      <DefineConstants>$(DefineConstants);CEFSHARP_WPF_HWNDHOST</DefineConstants>
+    </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\CefSharp.Core\CefSharp.Core.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
-        <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
         <PackageReference Include="chromiumembeddedframework.runtime" Version="129.0.11" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
@@ -49,6 +51,18 @@
         <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
     </ItemGroup>
 
+    <Choose>
+        <When Condition="$(DefineConstants.Contains(CEFSHARP_WPF_HWNDHOST))">
+            <ItemGroup>
+                <ProjectReference Include="..\CefSharp.Wpf.HwndHost\CefSharp.Wpf.HwndHost\CefSharp.Wpf.HwndHost.csproj" />
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup>
+                <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
     <ItemGroup>
         <None Include="crash_reporter.cfg">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/CefSharp.Wpf.Example/ChangeParentWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/ChangeParentWindow.xaml.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System.Windows;
+using CefSharp.Wpf.Example.Controls;
 
 namespace CefSharp.Wpf.Example
 {

--- a/CefSharp.Wpf.Example/Controls/ChromiumWebBrowserWithScreenshotSupport.cs
+++ b/CefSharp.Wpf.Example/Controls/ChromiumWebBrowserWithScreenshotSupport.cs
@@ -97,7 +97,7 @@ namespace CefSharp.Wpf.Example.Controls
 
             return screenshotTaskCompletionSource.Task;
         }
-
+#if ! CEFSHARP_WPF_HWNDHOST
         protected override CefSharp.Structs.Rect GetViewRect()
         {
             if (isTakingScreenshot)
@@ -161,7 +161,7 @@ namespace CefSharp.Wpf.Example.Controls
                 base.OnPaint(isPopup, dirtyRect, buffer, width, height);
             }
         }
-
+#endif
         private void TakeScreenshot()
         {
             var uiThreadTaskScheduler = TaskScheduler.FromCurrentSynchronizationContext();

--- a/CefSharp.Wpf.Example/Controls/NonReloadingTabControl.cs
+++ b/CefSharp.Wpf.Example/Controls/NonReloadingTabControl.cs
@@ -4,7 +4,9 @@ using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+#if ! CEFSHARP_WPF_HWNDHOST
 using TabControlAutomationPeer = CefSharp.Wpf.Experimental.Accessibility.TabControlAutomationPeer;
+#endif
 
 namespace CefSharp.Wpf.Example.Controls
 {

--- a/CefSharp.Wpf.Example/Controls/SampleChromiumWebBrowser.cs
+++ b/CefSharp.Wpf.Example/Controls/SampleChromiumWebBrowser.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+#if CEFSHARP_WPF_HWNDHOST
+using CefSharp.Wpf.HwndHost;
+#endif
+namespace CefSharp.Wpf.Example.Controls
+{
+    public class ChromiumWebBrowser :
+#if CEFSHARP_WPF_HWNDHOST
+        CefSharp.Wpf.HwndHost.ChromiumWebBrowser
+#else
+        CefSharp.Wpf.ChromiumWebBrowser
+#endif
+    {
+        public ChromiumWebBrowser(string initialAddress) : base(initialAddress){ }
+        public ChromiumWebBrowser() { }
+    }
+}

--- a/CefSharp.Wpf.Example/Handlers/DisplayHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/DisplayHandler.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using CefSharp.Wpf.Example.Controls;
 using CefSharp.Wpf.Example.Views;
 using System;
 using System.Windows;

--- a/CefSharp.Wpf.Example/Handlers/JsDialogHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/JsDialogHandler.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System.Windows;
+using CefSharp.Wpf.Example.Controls;
 
 namespace CefSharp.Wpf.Example.Handlers
 {

--- a/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/MenuHandler.cs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 using System;
+#if ! CEFSHARP_WPF_HWNDHOST
 using CefSharp.Wpf.Handler;
 
 namespace CefSharp.Wpf.Example.Handlers
@@ -46,3 +47,5 @@ namespace CefSharp.Wpf.Example.Handlers
         }
     }
 }
+
+#endif

--- a/CefSharp.Wpf.Example/JavascriptCallbackMainWindow.xaml
+++ b/CefSharp.Wpf.Example/JavascriptCallbackMainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="CefSharp.Wpf.Example.JavascriptCallbackMainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:wpf="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+        xmlns:wpf="clr-namespace:CefSharp.Wpf.Example.Controls"
         Title="JavascriptCallbackMainWindow" WindowState="Maximized">
     <Grid>
         <Grid.RowDefinitions>
@@ -12,10 +12,10 @@
         </Grid.RowDefinitions>
         <wpf:ChromiumWebBrowser Grid.Row="0"
                           x:Name="BrowserOne"
-                          Address="custom://cefsharp/JavascriptCallbackTest.html"  BorderBrush="Red" BorderThickness="1"/>
+                          Address="custom://cefsharp/JavascriptCallbackTest.html" />
         <wpf:ChromiumWebBrowser Grid.Row="1"
                           x:Name="BrowserTwo"
-                          Address="test://cefsharp/JavascriptCallbackTest.html" BorderBrush="Red" BorderThickness="1"/>
+                          Address="test://cefsharp/JavascriptCallbackTest.html"/>
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
             <Button Content="Execute Callback Immediately" Click="ExecuteCallbackImmediatelyClick" Margin="0, 0, 10, 0"/>
             <Button Content="Execute Callback In 3 Seconds" Click="ExecuteCallbackInThreeSeconds"/>

--- a/CefSharp.Wpf.Example/JavascriptCallbackMainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/JavascriptCallbackMainWindow.xaml.cs
@@ -15,7 +15,10 @@ namespace CefSharp.Wpf.Example
         public JavascriptCallbackMainWindow()
         {
             InitializeComponent();
-
+#if ! CEFSHARP_WPF_HWNDHOST
+            BrowserTwo.BorderBrush = BrowserOne.BorderBrush = System.Windows.Media.Brushes.Red;
+            BrowserTwo.BorderThickness = BrowserOne.BorderThickness = new Thickness(1);
+#endif
             boundObjectOne = new JavascriptCallbackBoundObject(BrowserOne);
             boundObjectTwo = new JavascriptCallbackBoundObject(BrowserTwo);
 

--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -133,8 +133,12 @@ namespace CefSharp.Wpf.Example
                 }
                 else if (param == "ToggleAudioMute")
                 {
+#if CEFSHARP_WPF_HWNDHOST
+                    throw new NotImplementedException();
+#else
                     var cmd = browserViewModel.WebBrowser.ToggleAudioMuteCommand;
                     cmd.Execute(null);
+#endif
                 }
                 else if (param == "ClearHttpAuthCredentials")
                 {

--- a/CefSharp.Wpf.Example/SimpleMainWindow.xaml
+++ b/CefSharp.Wpf.Example/SimpleMainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="CefSharp.Wpf.Example.SimpleMainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:wpf="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+        xmlns:wpf="clr-namespace:CefSharp.Wpf.Example.Controls"
         Title="SimpleMainWindow" WindowState="Maximized">
     <Grid>
         <Grid.RowDefinitions>

--- a/CefSharp.Wpf.Example/SpawnBrowsersWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/SpawnBrowsersWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using CefSharp.Wpf.Example.Controls;
 
 namespace CefSharp.Wpf.Example
 {

--- a/CefSharp.Wpf.Example/StandardTabControlWindow.xaml
+++ b/CefSharp.Wpf.Example/StandardTabControlWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="CefSharp.Wpf.Example.StandardTabControlWindow"
-        xmlns:cefSharp="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+        xmlns:cefSharp="clr-namespace:CefSharp.Wpf.Example.Controls"
         Title="TabControl Test Window" Height="594" Width="651">
     <Grid>
         <TabControl ItemsSource="{Binding Tabs}">

--- a/CefSharp.Wpf.Example/StandardTabControlWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/StandardTabControlWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using CefSharp.Wpf.Example.Controls;
 
 namespace CefSharp.Wpf.Example
 {

--- a/CefSharp.Wpf.Example/TouchKeyboardWin10MainWindow.xaml
+++ b/CefSharp.Wpf.Example/TouchKeyboardWin10MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="CefSharp.Wpf.Example.TouchKeyboardWin10MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:wpf="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+        xmlns:wpf="clr-namespace:CefSharp.Wpf.Example.Controls"
         Title="SimpleMainWindow" WindowState="Maximized">
     <Grid>
         <Grid.RowDefinitions>

--- a/CefSharp.Wpf.Example/TouchKeyboardWin10MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/TouchKeyboardWin10MainWindow.xaml.cs
@@ -5,7 +5,7 @@
 using System.Windows;
 using CefSharp.Enums;
 using Microsoft.Windows.Input.TouchKeyboard;
-
+#if ! CEFSHARP_WPF_HWNDHOST
 namespace CefSharp.Wpf.Example
 {
     /// <summary>
@@ -56,3 +56,5 @@ namespace CefSharp.Wpf.Example
         }
     }
 }
+
+#endif

--- a/CefSharp.Wpf.Example/ViewModels/BrowserTabViewModel.cs
+++ b/CefSharp.Wpf.Example/ViewModels/BrowserTabViewModel.cs
@@ -9,6 +9,9 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using CefSharp.Example;
+#if CEFSHARP_WPF_HWNDHOST
+using CefSharp.Wpf.HwndHost;
+#endif
 
 namespace CefSharp.Wpf.Example.ViewModels
 {

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-             xmlns:cefSharp="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+             xmlns:cefSharp="clr-namespace:CefSharp.Wpf.Example.Controls"
              xmlns:local="clr-namespace:CefSharp.Wpf.Example.ViewModels"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"

--- a/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
+++ b/CefSharp.Wpf.Example/Views/BrowserTabView.xaml.cs
@@ -16,8 +16,10 @@ using CefSharp.Example.PostMessage;
 using CefSharp.Fluent;
 using CefSharp.Wpf.Example.Handlers;
 using CefSharp.Wpf.Example.ViewModels;
+#if ! CEFSHARP_WPF_HWNDHOST
 using CefSharp.Wpf.Experimental;
 using CefSharp.Wpf.Experimental.Accessibility;
+#endif
 
 namespace CefSharp.Wpf.Example.Views
 {
@@ -31,9 +33,9 @@ namespace CefSharp.Wpf.Example.Views
             InitializeComponent();
 
             DataContextChanged += OnDataContextChanged;
-
+#if ! CEFSHARP_WPF_HWNDHOST
             browser.UsePopupMouseTransform();
-
+#endif
             //browser.BrowserSettings.BackgroundColor = Cef.ColorSetARGB(0, 255, 255, 255);
 
             //Please remove the comments below to use the Experimental WpfImeKeyboardHandler.
@@ -182,7 +184,7 @@ namespace CefSharp.Wpf.Example.Views
                     }
                 }).Build();
             */
-
+#if ! CEFSHARP_WPF_HWNDHOST
             browser.MenuHandler = new MenuHandler(addDevtoolsMenuItems:true);
 
             //Enable experimental Accessibility support 
@@ -195,7 +197,7 @@ namespace CefSharp.Wpf.Example.Views
                     //browser.GetBrowserHost().SetAccessibilityState(CefState.Enabled);
                 }
             };
-
+#endif
             browser.DownloadHandler = DownloadHandler
                 .Create()
                 .CanDownload((chromiumWebBrowser, browser, url, requestMethod) =>

--- a/CefSharp3.netcore.sln
+++ b/CefSharp3.netcore.sln
@@ -73,6 +73,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.Core.netcore", "Ce
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.Core.Runtime.RefAssembly.netcore", "CefSharp.Core.Runtime.RefAssembly\CefSharp.Core.Runtime.RefAssembly.netcore.csproj", "{A4AFD158-0B6F-4579-AE79-EC386C8BEA58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CefSharp.Wpf.HwndHost", "..\CefSharp.Wpf.HwndHost\CefSharp.Wpf.HwndHost\CefSharp.Wpf.HwndHost.csproj", "{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|arm64 = Debug|arm64
@@ -243,6 +245,18 @@ Global
 		{A4AFD158-0B6F-4579-AE79-EC386C8BEA58}.Release|x64.Build.0 = Release|Any CPU
 		{A4AFD158-0B6F-4579-AE79-EC386C8BEA58}.Release|x86.ActiveCfg = Release|Any CPU
 		{A4AFD158-0B6F-4579-AE79-EC386C8BEA58}.Release|x86.Build.0 = Release|Any CPU
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Debug|arm64.ActiveCfg = Debug|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Debug|arm64.Build.0 = Debug|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Debug|x64.ActiveCfg = Debug|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Debug|x64.Build.0 = Debug|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Debug|x86.ActiveCfg = Debug|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Debug|x86.Build.0 = Debug|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Release|arm64.ActiveCfg = Release|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Release|arm64.Build.0 = Release|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Release|x64.ActiveCfg = Release|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Release|x64.Build.0 = Release|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Release|x86.ActiveCfg = Release|x64
+		{94AF2E6A-6508-451F-BF4A-56B9C0AB1993}.Release|x86.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Enabled when compile time define of CEFSHARP_WPF_HWNDHOST is used

**Summary:** 
   - Given the larger divergence between CefSharp.Wpf.HwndHost and the normal Wpf library for what they support, expanding the test ability on HwndHost seems like a good idea.   Functionally this is a no-op unless #CEFSHARP_WPF_HWNDHOST compile time define is set.   Then it uses HwndHost rather than CefSharp.Wpf.   

**Changes:** [specify the structures changed] 
The biggest change of debate is ChromiumWebBrowser and xaml.     I wanted to minimize the changes but don't want things to lead to too much confusion.   Right now that is done by adding a new 
`ChromiumWebBrowser` class in the `CefSharp.Wpf.Example.Controls` namespace.  Originally I named it SampleChromiumWebBrowser but that results in further xaml changes.    I don't think possible to get it under the CefSharp.Wpf namespace without the xaml assembly reference when not using the HwndHost.

One option would be to add the fake ChromiumWebBrowser class under the CefSharp namespace in the sample app.  This would avoid all the additional includes of the example control namespace.  That could easily cause more confusion for users if they did copy the namespace given ChromiumWebBrowser is not under that namespace normally and its not obvious that is the issue.

So, in short right now you can copy the sample xaml and just have to add the proper namespace include at the top (which vs will auto suggest) but can't copy that part directly.
      
I moved to using the hwndhost on the sample for awhile now,  I feel most airspace issues can be worked around with regions and otherwise it seems HwndHost is fairly amazing.  Haven't quite been able to move over to using it for most apps as I work around some of the crashes I am able to run into but I am still hopeful for it.    Hopefully expanding the sample can get some others to see the lack of issues with HwndHost.

Should also make it easier for tickets without having to switch to WinForms for easier repro for Chrome style with extension support.

Aside from just the define it is possible to add another Configuration beyond Debug/Release (ie Debug Wpf.HwndHost) that would auto enable the define.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ x ] The formatting is consistent with the project (project supports .editorconfig)
