### PR TITLE
Avoid ObjectDisposedException when host got disposed in InitialLoad

### DIFF
--- a/CefSharp/Internals/Partial/ChromiumWebBrowser.Partial.cs
+++ b/CefSharp/Internals/Partial/ChromiumWebBrowser.Partial.cs
@@ -449,11 +449,21 @@ namespace CefSharp.WinForms
 
                 initialLoadAction = null;
 
-                var host = browser?.GetHost();
+                int statusCode = 0;
 
-                var navEntry = host?.GetVisibleNavigationEntry();
+                try
+                {
+                    var host = browser?.GetHost();
 
-                int statusCode = navEntry?.HttpStatusCode ?? -1;
+                    var navEntry = host?.GetVisibleNavigationEntry();
+
+                    statusCode = navEntry?.HttpStatusCode ?? -1;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The host might got disposed
+                    // https://github.com/cefsharp/CefSharp/issues/5002
+                }
 
                 //By default 0 is some sort of error, we map that to -1
                 //so that it's clearer that something failed.


### PR DESCRIPTION
**Fixes:** https://github.com/cefsharp/CefSharp/issues/5002

**Summary:**
   - Added try catch to avoid `ObjectDisposedException` in `InitialLoad`

**Changes:**
   - Added try catch to avoid `ObjectDisposedException` in `InitialLoad`
      
**How Has This Been Tested?**  
Not tested.

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [X] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)
