### PR TITLE
FolderSchemeHandlerFactory Handle URL encoded paths only in absolute path

### DIFF
--- a/CefSharp/SchemeHandler/FolderSchemeHandlerFactory.cs
+++ b/CefSharp/SchemeHandler/FolderSchemeHandlerFactory.cs
@@ -109,7 +109,7 @@ namespace CefSharp.SchemeHandler
                 asbolutePath = defaultPage;
             }
 
-            var filePath = WebUtility.UrlDecode(Path.GetFullPath(Path.Combine(rootFolder, asbolutePath)));
+            var filePath = Path.GetFullPath(Path.Combine(rootFolder, WebUtility.UrlDecode(asbolutePath)));
 
             //Check the file requested is within the specified path and that the file exists
             if (filePath.StartsWith(rootFolder, StringComparison.OrdinalIgnoreCase) && File.Exists(filePath))


### PR DESCRIPTION
Related to pull request https://github.com/cefsharp/CefSharp/pull/2364

**Summary:**
The original fix can potentially lead to non-existing root path. This PR fixes the issue when the `rootFolder` has "escaped" URL characters even thought that's how the folder is named (e.g. `hello%2Fworld` folder would try to lookup `hello/world` folder which doesn't exist).

**Changes:**
- Moved `WebUtility.UrlDecode` from the full path to absolute path only.
      
**How Has This Been Tested?**  
1. I've used CefSharp.Wpf.Example.netcore project, where I've added new custom scheme with `FolderSchemeHandlerFactory`, with the following parameters:
   - rootFolder: `"escaped%2Fslash"`
   - schemeName: `"app"`
   - hostName: `"test"`
2. Then I've created folder `escaped%2Fslash` in the output directory and created two simple HTML files, one called `index.html` and the other `file with spaces.html`.
3. Run the project and navigate to `app://test/index.html` and `app://test/file%20with%20spaces.html`. Both files have been loaded correctly.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
