### PR TITLE
Javascript Binding - Add ability to limit access to JavaScript Bound objects to specific origins

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -173,6 +173,7 @@ namespace CefSharp
                     if (CefParseURL(frameUrl, frameUrlParts))
                     {
                         auto frameUrlOrigin = CefString(frameUrlParts.origin.str, frameUrlParts.origin.length);
+                        auto clrframeUrlOrigin = StringUtils::ToClr(frameUrlOrigin);
 
                         auto size = static_cast<int>(_jsBindingApiAllowOrigins->GetSize());
 
@@ -180,7 +181,11 @@ namespace CefSharp
                         {
                             auto origin = _jsBindingApiAllowOrigins->GetString(i);
 
-                            if (origin.compare(frameUrlOrigin))
+                            auto clrOrigin = StringUtils::ToClr(origin);
+
+                            auto originEqual = String::Compare(clrframeUrlOrigin, clrOrigin, StringComparison::InvariantCultureIgnoreCase);
+
+                            if (originEqual == 0)
                             {
                                 createObjects = true;
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -23,6 +23,7 @@
 #include "Wrapper\Browser.h"
 #include "..\CefSharp.Core.Runtime\Internals\Messaging\Messages.h"
 #include "..\CefSharp.Core.Runtime\Internals\Serialization\Primitives.h"
+#include <include/cef_parser.h>
 
 using namespace System;
 using namespace System::Diagnostics;
@@ -100,6 +101,16 @@ namespace CefSharp
                 }
 
                 _jsBindingApiEnabled = extraInfo->GetBool("JavascriptBindingApiEnabled");
+                _jsBindingApiHasAllowOrigins = extraInfo->GetBool("JavascriptBindingApiHasAllowOrigins");
+
+                if (_jsBindingApiHasAllowOrigins)
+                {
+                    auto allowOrigins = extraInfo->GetList("JavascriptBindingApiAllowOrigins");
+                    if (allowOrigins.get() && allowOrigins->IsValid())
+                    {
+                        _jsBindingApiAllowOrigins = allowOrigins->Copy();
+                    }
+                }
 
                 if (extraInfo->HasKey("JsBindingPropertyName") || extraInfo->HasKey("JsBindingPropertyNameCamelCase"))
                 {
@@ -149,50 +160,83 @@ namespace CefSharp
 
             if (_jsBindingApiEnabled)
             {
-                //TODO: Look at adding some sort of javascript mapping layer to reduce the code duplication
-                auto global = context->GetGlobal();
-                auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier());
-                auto processId = System::Diagnostics::Process::GetCurrentProcess()->Id;
+                auto createObjects = true;
 
-                //TODO: JSB: Split functions into their own classes
-                //Browser wrapper is only used for BindObjectAsync
-                auto bindObjAsyncFunction = CefV8Value::CreateFunction(kBindObjectAsync, new BindObjectAsyncHandler(_registerBoundObjectRegistry, _javascriptObjects, browserWrapper));
-                auto unBindObjFunction = CefV8Value::CreateFunction(kDeleteBoundObject, new RegisterBoundObjectHandler(_javascriptObjects));
-                auto removeObjectFromCacheFunction = CefV8Value::CreateFunction(kRemoveObjectFromCache, new RegisterBoundObjectHandler(_javascriptObjects));
-                auto isObjectCachedFunction = CefV8Value::CreateFunction(kIsObjectCached, new RegisterBoundObjectHandler(_javascriptObjects));
-                auto postMessageFunction = CefV8Value::CreateFunction(kPostMessage, new JavascriptPostMessageHandler(rootObject == nullptr ? nullptr : rootObject->CallbackRegistry));
-                auto promiseHandlerFunction = CefV8Value::CreateFunction(kSendEvalScriptResponse, new JavascriptPromiseHandler());
-
-                //By default We'll support both CefSharp and cefSharp, for those who prefer the JS style
-                auto createCefSharpObj = !_jsBindingPropertyName.empty();
-                auto createCefSharpObjCamelCase = !_jsBindingPropertyNameCamelCase.empty();
-
-                if (createCefSharpObj)
+                if (_jsBindingApiHasAllowOrigins)
                 {
-                    auto cefSharpObj = CefV8Value::CreateObject(nullptr, nullptr);
-                    cefSharpObj->SetValue(kBindObjectAsync, bindObjAsyncFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObj->SetValue(kDeleteBoundObject, unBindObjFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObj->SetValue(kRemoveObjectFromCache, removeObjectFromCacheFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObj->SetValue(kIsObjectCached, isObjectCachedFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObj->SetValue(kPostMessage, postMessageFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObj->SetValue(kSendEvalScriptResponse, promiseHandlerFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObj->SetValue(kRenderProcessId, CefV8Value::CreateInt(processId), CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                    createObjects = false;
 
-                    global->SetValue(_jsBindingPropertyName, cefSharpObj, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_READONLY);
+                    auto frameUrl = frame->GetURL();
+
+                    CefURLParts frameUrlParts;
+
+                    if (CefParseURL(frameUrl, frameUrlParts))
+                    {
+                        auto frameUrlOrigin = CefString(frameUrlParts.origin.str, frameUrlParts.origin.length);
+
+                        auto size = static_cast<int>(_jsBindingApiAllowOrigins->GetSize());
+
+                        for (int i = 0; i < size; i++)
+                        {
+                            auto origin = _jsBindingApiAllowOrigins->GetString(i);
+
+                            if (origin.compare(frameUrlOrigin))
+                            {
+                                createObjects = true;
+
+                                break;
+                            }
+                        }
+                    }
                 }
 
-                if (createCefSharpObjCamelCase)
+                if (createObjects)
                 {
-                    auto cefSharpObjCamelCase = CefV8Value::CreateObject(nullptr, nullptr);
-                    cefSharpObjCamelCase->SetValue(kBindObjectAsyncCamelCase, bindObjAsyncFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObjCamelCase->SetValue(kDeleteBoundObjectCamelCase, unBindObjFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObjCamelCase->SetValue(kRemoveObjectFromCacheCamelCase, removeObjectFromCacheFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObjCamelCase->SetValue(kIsObjectCachedCamelCase, isObjectCachedFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObjCamelCase->SetValue(kPostMessageCamelCase, postMessageFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObjCamelCase->SetValue(kSendEvalScriptResponseCamelCase, promiseHandlerFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
-                    cefSharpObjCamelCase->SetValue(kRenderProcessIdCamelCase, CefV8Value::CreateInt(processId), CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                    //TODO: Look at adding some sort of javascript mapping layer to reduce the code duplication
+                    auto global = context->GetGlobal();
+                    auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier());
+                    auto processId = System::Diagnostics::Process::GetCurrentProcess()->Id;
 
-                    global->SetValue(_jsBindingPropertyNameCamelCase, cefSharpObjCamelCase, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_READONLY);
+                    //TODO: JSB: Split functions into their own classes
+                    //Browser wrapper is only used for BindObjectAsync
+                    auto bindObjAsyncFunction = CefV8Value::CreateFunction(kBindObjectAsync, new BindObjectAsyncHandler(_registerBoundObjectRegistry, _javascriptObjects, browserWrapper));
+                    auto unBindObjFunction = CefV8Value::CreateFunction(kDeleteBoundObject, new RegisterBoundObjectHandler(_javascriptObjects));
+                    auto removeObjectFromCacheFunction = CefV8Value::CreateFunction(kRemoveObjectFromCache, new RegisterBoundObjectHandler(_javascriptObjects));
+                    auto isObjectCachedFunction = CefV8Value::CreateFunction(kIsObjectCached, new RegisterBoundObjectHandler(_javascriptObjects));
+                    auto postMessageFunction = CefV8Value::CreateFunction(kPostMessage, new JavascriptPostMessageHandler(rootObject == nullptr ? nullptr : rootObject->CallbackRegistry));
+                    auto promiseHandlerFunction = CefV8Value::CreateFunction(kSendEvalScriptResponse, new JavascriptPromiseHandler());
+
+                    //By default We'll support both CefSharp and cefSharp, for those who prefer the JS style
+                    auto createCefSharpObj = !_jsBindingPropertyName.empty();
+                    auto createCefSharpObjCamelCase = !_jsBindingPropertyNameCamelCase.empty();
+
+                    if (createCefSharpObj)
+                    {
+                        auto cefSharpObj = CefV8Value::CreateObject(nullptr, nullptr);
+                        cefSharpObj->SetValue(kBindObjectAsync, bindObjAsyncFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObj->SetValue(kDeleteBoundObject, unBindObjFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObj->SetValue(kRemoveObjectFromCache, removeObjectFromCacheFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObj->SetValue(kIsObjectCached, isObjectCachedFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObj->SetValue(kPostMessage, postMessageFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObj->SetValue(kSendEvalScriptResponse, promiseHandlerFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObj->SetValue(kRenderProcessId, CefV8Value::CreateInt(processId), CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+
+                        global->SetValue(_jsBindingPropertyName, cefSharpObj, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_READONLY);
+                    }
+
+                    if (createCefSharpObjCamelCase)
+                    {
+                        auto cefSharpObjCamelCase = CefV8Value::CreateObject(nullptr, nullptr);
+                        cefSharpObjCamelCase->SetValue(kBindObjectAsyncCamelCase, bindObjAsyncFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObjCamelCase->SetValue(kDeleteBoundObjectCamelCase, unBindObjFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObjCamelCase->SetValue(kRemoveObjectFromCacheCamelCase, removeObjectFromCacheFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObjCamelCase->SetValue(kIsObjectCachedCamelCase, isObjectCachedFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObjCamelCase->SetValue(kPostMessageCamelCase, postMessageFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObjCamelCase->SetValue(kSendEvalScriptResponseCamelCase, promiseHandlerFunction, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+                        cefSharpObjCamelCase->SetValue(kRenderProcessIdCamelCase, CefV8Value::CreateInt(processId), CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_NONE);
+
+                        global->SetValue(_jsBindingPropertyNameCamelCase, cefSharpObjCamelCase, CefV8Value::PropertyAttribute::V8_PROPERTY_ATTRIBUTE_READONLY);
+                    }
                 }
             }
 

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -29,6 +29,8 @@ namespace CefSharp
             bool _focusedNodeChangedEnabled;
             bool _legacyBindingEnabled;
             bool _jsBindingApiEnabled = true;
+            bool _jsBindingApiHasAllowOrigins = false;
+            CefRefPtr<CefListValue> _jsBindingApiAllowOrigins;
 
             // The property names used to call bound objects
             CefString _jsBindingPropertyName;
@@ -69,6 +71,8 @@ namespace CefSharp
                 }
                 delete _onBrowserCreated;
                 delete _onBrowserDestroyed;
+
+                _jsBindingApiAllowOrigins = nullptr;
             }
 
             CefBrowserWrapper^ FindBrowserWrapper(int browserId);

--- a/CefSharp.Core.Runtime/ManagedCefBrowserAdapter.cpp
+++ b/CefSharp.Core.Runtime/ManagedCefBrowserAdapter.cpp
@@ -84,6 +84,22 @@ namespace CefSharp
 
             extraInfo->SetBool("JavascriptBindingApiEnabled", objectRepositorySettings->JavascriptBindingApiEnabled);
 
+            auto hasJavascriptBindingApiAllowOrigins = objectRepositorySettings->HasJavascriptBindingApiAllowOrigins();
+
+            extraInfo->SetBool("JavascriptBindingApiHasAllowOrigins", hasJavascriptBindingApiAllowOrigins);
+
+            if (hasJavascriptBindingApiAllowOrigins)
+            {
+                auto allowOriginList = CefListValue::Create();
+
+                for (int i = 0; i < objectRepositorySettings->JavascriptBindingApiAllowOrigins->Length; i++)
+                {
+                    allowOriginList->SetString(i, StringUtils::ToNative(objectRepositorySettings->JavascriptBindingApiAllowOrigins[i]));
+                }
+
+                extraInfo->SetList("JavascriptBindingApiAllowOrigins", allowOriginList);
+            }
+
             CefRefPtr<CefRequestContext> requestCtx;
 
             if (requestContext != nullptr)

--- a/CefSharp.Test/CefSharpFixture.cs
+++ b/CefSharp.Test/CefSharpFixture.cs
@@ -64,6 +64,7 @@ namespace CefSharp.Test
                 settings.CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Tests\\Cache");
                 settings.RootCachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Tests");
                 //settings.CefCommandLineArgs.Add("renderer-startup-dialog");
+                //settings.CefCommandLineArgs.Add("disable-features=SpareRendererForSitePerProcess");
                 //settings.CefCommandLineArgs.Add("disable-site-isolation-trials");
                 settings.SetOffScreenRenderingBestPerformanceArgs();
 

--- a/CefSharp.Test/JavascriptBinding/JavascriptBindingTests.cs
+++ b/CefSharp.Test/JavascriptBinding/JavascriptBindingTests.cs
@@ -157,14 +157,16 @@ namespace CefSharp.Test.JavascriptBinding
             }
         }
 
-        [Fact]
-        public async Task ShouldEnableJsBindingApiForOrigin()
+        [Theory]
+        [InlineData(CefExample.BaseUrl + "/")]
+        [InlineData("someorigin", CefExample.BaseUrl + "/")]
+        public async Task ShouldEnableJsBindingApiForOrigin(params string[] origins)
         {
             using (var browser = new ChromiumWebBrowser(CefExample.BindingApiCustomObjectNameTestUrl, automaticallyCreateBrowser: false))
             {
                 var settings = browser.JavascriptObjectRepository.Settings;
                 settings.JavascriptBindingApiEnabled = true;
-                settings.JavascriptBindingApiAllowOrigins = new string[] { CefExample.ExampleDomain };
+                settings.JavascriptBindingApiAllowOrigins = origins;
 
                 //To modify the settings we need to defer browser creation slightly
                 browser.CreateBrowser();

--- a/CefSharp.Test/JavascriptBinding/JavascriptBindingTests.cs
+++ b/CefSharp.Test/JavascriptBinding/JavascriptBindingTests.cs
@@ -131,6 +131,58 @@ namespace CefSharp.Test.JavascriptBinding
         }
 
         [Fact]
+        public async Task ShouldDisableJsBindingApiForOrigin()
+        {
+            using (var browser = new ChromiumWebBrowser(CefExample.BindingApiCustomObjectNameTestUrl, automaticallyCreateBrowser: false))
+            {
+                var settings = browser.JavascriptObjectRepository.Settings;
+                settings.JavascriptBindingApiEnabled = true;
+                settings.JavascriptBindingApiAllowOrigins = new string[] { "notallowed" };
+
+                //To modify the settings we need to defer browser creation slightly
+                browser.CreateBrowser();
+
+                var loadResponse = await browser.WaitForInitialLoadAsync();
+
+                Assert.True(loadResponse.Success);
+
+                var response1 = await browser.EvaluateScriptAsync("typeof window.cefSharp === 'undefined'");
+                var response2 = await browser.EvaluateScriptAsync("typeof window.CefSharp === 'undefined'");
+
+                Assert.True(response1.Success);
+                Assert.True((bool)response1.Result);
+
+                Assert.True(response2.Success);
+                Assert.True((bool)response2.Result);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldEnableJsBindingApiForOrigin()
+        {
+            using (var browser = new ChromiumWebBrowser(CefExample.BindingApiCustomObjectNameTestUrl, automaticallyCreateBrowser: false))
+            {
+                var settings = browser.JavascriptObjectRepository.Settings;
+                settings.JavascriptBindingApiEnabled = true;
+                settings.JavascriptBindingApiAllowOrigins = new string[] { CefExample.ExampleDomain };
+
+                //To modify the settings we need to defer browser creation slightly
+                browser.CreateBrowser();
+
+                await browser.WaitForInitialLoadAsync();
+
+                var response1 = await browser.EvaluateScriptAsync("typeof window.cefSharp === 'undefined'");
+                var response2 = await browser.EvaluateScriptAsync("typeof window.CefSharp === 'undefined'");
+
+                Assert.True(response1.Success);
+                Assert.False((bool)response1.Result);
+
+                Assert.True(response2.Success);
+                Assert.False((bool)response2.Result);
+            }
+        }
+
+        [Fact]
         public async Task ShouldEnableJsBindingApi()
         {
             using (var browser = new ChromiumWebBrowser(CefExample.BindingApiCustomObjectNameTestUrl, automaticallyCreateBrowser: false))

--- a/CefSharp/JavascriptBinding/JavascriptBindingSettings.cs
+++ b/CefSharp/JavascriptBinding/JavascriptBindingSettings.cs
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+using System.Collections.Generic;
 using CefSharp.Internals;
 
 namespace CefSharp.JavascriptBinding
@@ -15,6 +16,7 @@ namespace CefSharp.JavascriptBinding
         private bool legacyBindingEnabled;
         private string jsBindingGlobalObjectName;
         private bool jsBindingApiEnabled = true;
+        private string[] javascriptBindingApiAllowOrigins;
 
         /// <summary>
         /// The Javascript methods that CefSharp provides in relation to JavaScript Binding are
@@ -30,6 +32,24 @@ namespace CefSharp.JavascriptBinding
                 ThrowIfFrozen();
 
                 jsBindingApiEnabled = value;
+            }
+        }
+
+        /// <summary>
+        /// When <see cref="JavascriptBindingApiEnabled"/> is set to true, set a collection
+        /// of origins to limit which origins CefSharp will create it's global (window) object.
+        /// </summary>
+        /// <remarks>
+        /// If you wish to create the CefSharp object for a limited set of origins then set this property
+        /// </remarks>
+        public string[] JavascriptBindingApiAllowOrigins
+        {
+            get { return javascriptBindingApiAllowOrigins; }
+            set
+            {
+                ThrowIfFrozen();
+
+                javascriptBindingApiAllowOrigins = value;
             }
         }
 
@@ -94,6 +114,18 @@ namespace CefSharp.JavascriptBinding
 
                 alwaysInterceptAsynchronously = value;
             }
+        }
+
+        /// <summary>
+        /// HasJavascriptBindingApiAllowOrigins 
+        /// </summary>
+        /// <returns>bool true if <see cref="JavascriptBindingApiAllowOrigins"/> is non empty collection.</returns>
+        public bool HasJavascriptBindingApiAllowOrigins()
+        {
+            if (javascriptBindingApiAllowOrigins == null)
+                return false;
+
+            return javascriptBindingApiAllowOrigins.Length > 0;
         }
     }
 }


### PR DESCRIPTION
**Fixes:** 
#5001

**Summary:** 
   - Add new JavascriptBindingSettings.JavascriptBindingApiAllowOrigins property

**Changes:** 
   - Don't create CefSharp objects when non matching origin
   - Doesn't currently impact Legacy binding 
   - Added xunit tests
      
**How Has This Been Tested?**  
  - New xUnit tests have been added

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support to restrict the creation of global JavaScript binding objects to specified allowed origins. When enabled, the JavaScript binding API will only be available on origins explicitly listed in the settings.
- **Tests**
  - Introduced new tests to verify JavaScript binding API availability based on allowed origins.
- **Chores**
  - Added internal settings and cleanup related to allowed origins for JavaScript binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->