### PR TITLE
Handle case where IPostDataElement.Bytes is null

### DIFF
--- a/CefSharp/PostDataExtensions.cs
+++ b/CefSharp/PostDataExtensions.cs
@@ -81,7 +81,7 @@ namespace CefSharp
         public static string GetBody(this IPostDataElement postDataElement, string charSet = null)
         {
             var bytes = postDataElement.Bytes;
-            if (bytes.Length == 0)
+            if (bytes is null || bytes.Length == 0)
             {
                 return null;
             }


### PR DESCRIPTION
**Summary:** [summary of the change and which issue is fixed here]
   - We noticed that we had to check the IPostDataElement.Bytes array for null ourselves before calling .GetBody(). This felt a bit weird, so I think it makes sense to handle this in CefSharp code like I did here.

**Changes:** [specify the structures changed] 
   - Added null check for Bytes of IPostDataElement object
      
**How Has This Been Tested?**  
By calling .GetBody() on a IPostDataElement object with PostDataType.Empty and Bytes = null.


**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x]  The formatting is consistent with the project (project supports .editorconfig)
