### PR TITLE
Update subset arch packaging dep removal from cef.redist->chromiumembeddedframework.runtime.win* naming

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -302,8 +302,8 @@ function Nupkg
                     }
                     else
                     {
-                        # Remove cef.redist dependency
-                        $depNode =  $NupkgXml.package.metadata.dependencies.group.dependency | Where-Object {$_.Attributes["id"].Value.Equals("cef.redist." + $a) };
+                        # Remove chromiumembeddedframework.runtime.win* dependency for arches we are not including
+                        $depNode =  $NupkgXml.package.metadata.dependencies.group.dependency | Where-Object {$_.Attributes["id"].Value.Equals("chromiumembeddedframework.runtime.win-" + $a) };
                         $depNode.ParentNode.RemoveChild($depNode) | Out-Null
                     }
                     


### PR DESCRIPTION
Clearly this high use automated build feature of single arch only gets used by ones of people. Only broken for 1.5 years?, sorry for the slow catch on this one:)  In my defense im guessing the last few solo arch build I just didn't take the time prior to figure out why it failed on the last build step and did it manually. 

Tested on 138 and works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the packaging process to remove a different set of dependencies from the NuGet package, ensuring only relevant architecture-specific dependencies are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->