### PR TITLE
Update some leftover .net core 3.1 references to .net 6

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -26,8 +26,8 @@
     "Microsoft.VisualStudio.Component.VC.CLI.Support",
     "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
-	"Microsoft.NetCore.Component.DevelopmentTools",
-    "Microsoft.NetCore.Component.Runtime.3.1",
+    "Microsoft.NetCore.Component.DevelopmentTools",
+    "Microsoft.NetCore.Component.Runtime.6.0",
     "Microsoft.NetCore.Component.SDK"
   ]
 }

--- a/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj
+++ b/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj
@@ -25,7 +25,7 @@
         <!-- Explicitly set the PlatformTarget for arm64, see: https://github.com/dotnet/sdk/issues/15434 -->
         <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
         <!--
-        Run on a newer version of .Net if the specified version (.Net Core 3.1) is not installed
+        Run on a newer version of .Net if the specified version (.Net 6) is not installed
         https://github.com/dotnet/docs/issues/12237
         -->
         <RollForward>Major</RollForward>

--- a/CefSharp.BrowserSubprocess/Program.netcore.cs
+++ b/CefSharp.BrowserSubprocess/Program.netcore.cs
@@ -9,7 +9,7 @@ namespace CefSharp.BrowserSubprocess
 {
     /// <summary>
     /// When implementing your own BrowserSubprocess
-    /// - For .Net Core use <see cref="BrowserSubprocessExecutable"/> (No WCF Support)
+    /// - For .Net use <see cref="BrowserSubprocessExecutable"/> (No WCF Support)
     /// - Include an app.manifest with the dpi/compatability sections, this is required (this project contains the relevant).
     /// - If you are targeting x86/Win32 then you should set /LargeAddressAware (https://docs.microsoft.com/en-us/cpp/build/reference/largeaddressaware?view=vs-2017)
     /// </summary>

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -165,7 +165,7 @@ namespace CefSharp.Example
             {
                 var architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
 #if NETCOREAPP
-                settings.BrowserSubprocessPath = Path.GetFullPath("..\\..\\..\\..\\..\\..\\CefSharp.BrowserSubprocess\\bin.netcore\\" + architecture + "\\Debug\\netcoreapp3.1\\CefSharp.BrowserSubprocess.exe");
+                settings.BrowserSubprocessPath = Path.GetFullPath("..\\..\\..\\..\\..\\..\\CefSharp.BrowserSubprocess\\bin.netcore\\" + architecture + "\\Debug\\net6.0-windows\\CefSharp.BrowserSubprocess.exe");
 #else
                 settings.BrowserSubprocessPath = Path.GetFullPath("..\\..\\..\\..\\CefSharp.BrowserSubprocess\\bin\\" + architecture + "\\Debug\\CefSharp.BrowserSubprocess.exe");
 #endif

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.netcore.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.netcore.csproj
@@ -22,7 +22,7 @@
         <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
         <StartupObject>CefSharp.OffScreen.Example.Program</StartupObject>
         <!--
-        Run on a newer version of .Net if the specified version (.Net Core 3.1) is not installed
+        Run on a newer version of .Net if the specified version (.Net 6) is not installed
         https://github.com/dotnet/docs/issues/12237
         -->
         <RollForward>Major</RollForward>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.netcore.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.netcore.csproj
@@ -22,7 +22,7 @@
         <!-- Explicitly set the PlatformTarget for arm64, see: https://github.com/dotnet/sdk/issues/15434 -->
         <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
         <!--
-        Run on a newer version of .Net if the specified version (.Net Core 3.1) is not installed
+        Run on a newer version of .Net if the specified version (.Net 6) is not installed
         https://github.com/dotnet/docs/issues/12237
         -->
         <RollForward>Major</RollForward>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
@@ -23,7 +23,7 @@
         <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
         <StartupObject>CefSharp.Wpf.Example.Program</StartupObject>
         <!--
-        Run on a newer version of .Net if the specified version (.Net Core 3.1) is not installed
+        Run on a newer version of .Net if the specified version (.Net 6) is not installed
         https://github.com/dotnet/docs/issues/12237
         -->
         <RollForward>Major</RollForward>

--- a/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.netcore.csproj
+++ b/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.netcore.csproj
@@ -24,7 +24,7 @@
         <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
         <StartupObject>CefSharp.Wpf.HwndHost.Example.App</StartupObject>
         <!--
-        Run on a newer version of .Net if the specified version (.Net Core 3.1) is not installed
+        Run on a newer version of .Net if the specified version (.Net 6) is not installed
         https://github.com/dotnet/docs/issues/12237
         -->
         <RollForward>Major</RollForward>

--- a/CefSharp/IJavascriptObjectRepository.cs
+++ b/CefSharp/IJavascriptObjectRepository.cs
@@ -41,7 +41,7 @@ namespace CefSharp
         /// This method is newer and recommended for everyone starting out as it is faster and more reliable.
         /// If false then methods and properties will be registered, this method relies on a WCF service to communicate,
         /// which is only available when targeting the .NET Framework.
-        /// This parameter is not available when targeting .NET Core or .NET 5+, where only async binding is supported.
+        /// This parameter is not available when targeting .NET 6+, where only async binding is supported.
         /// </param>
 #endif
         /// <param name="options">binding options, by default method/property names are camelCased, you can control this

--- a/CefSharp/WebBrowserExtensions.cs
+++ b/CefSharp/WebBrowserExtensions.cs
@@ -445,7 +445,7 @@ namespace CefSharp
                 chromiumWebBrowser.LoadingStateChanged -= loadingStateChangeHandler;
 
                 //Ensure our continuation is executed on the ThreadPool
-                //For the .Net Core implementation we could use
+                //For the .Net implementation we could use
                 //TaskCreationOptions.RunContinuationsAsynchronously
                 tcs.TrySetResult(new LoadUrlAsyncResponse(args.ErrorCode, -1));
             };
@@ -476,7 +476,7 @@ namespace CefSharp
                     }
 
                     //Ensure our continuation is executed on the ThreadPool
-                    //For the .Net Core implementation we could use
+                    //For the .Net implementation we could use
                     //TaskCreationOptions.RunContinuationsAsynchronously
                     tcs.TrySetResult(new LoadUrlAsyncResponse(statusCode == -1 ? CefErrorCode.Failed : CefErrorCode.None, statusCode));
                 }
@@ -541,7 +541,7 @@ namespace CefSharp
                 chromiumWebBrowser.LoadingStateChanged -= loadingStateChangeHandler;
 
                 //Ensure our continuation is executed on the ThreadPool
-                //For the .Net Core implementation we could use
+                //For the .Net implementation we could use
                 //TaskCreationOptions.RunContinuationsAsynchronously
                 tcs.TrySetResult(new WaitForNavigationAsyncResponse(args.ErrorCode, -1));
             };
@@ -572,7 +572,7 @@ namespace CefSharp
                     }
 
                     //Ensure our continuation is executed on the ThreadPool
-                    //For the .Net Core implementation we could use
+                    //For the .Net implementation we could use
                     //TaskCreationOptions.RunContinuationsAsynchronously
                     tcs.TrySetResult(new WaitForNavigationAsyncResponse(statusCode == -1 ? CefErrorCode.Failed : CefErrorCode.None, statusCode));
                 }

--- a/NuGet/PackageReference/Readme.txt
+++ b/NuGet/PackageReference/Readme.txt
@@ -1,4 +1,4 @@
-CefSharp .Net Core/.Net 5.0+ Nuget Package
+CefSharp .Net Core/.Net 6.0+ Nuget Package
 
 Background:
   CefSharp is a .Net wrapping library for CEF (Chromium Embedded Framework) https://bitbucket.org/chromiumembedded/cef
@@ -12,25 +12,25 @@ Post Installation:
   - Read the `Need to know/limitations` section of the General usage guide (https://github.com/cefsharp/CefSharp/wiki/General-Usage#need-to-knowlimitations)
   - Check your output `\bin` directory to make sure the appropriate references have been copied.
   - Add an app.manifest to your exe if you don't already have one, it's required for Windows 10 compatability, HighDPI support and tooltips. The https://github.com/cefsharp/CefSharp.MinimalExample project contains an example app.manifest file in the root of the WPF/WinForms/OffScreen examples. 
-  
+
 Deployment:
-  - Make sure a minimum of `Visual C++ 2019` is installed (`x86`, `x64` or `arm64` depending on your build) or package the runtime dlls with your application, see the FAQ for details.
-  
+  - Make sure a minimum of `Visual C++ 2022` is installed (`x86`, `x64` or `arm64` depending on your build) or package the runtime dlls with your application, see the FAQ for details.
+
 What's New:
   See https://github.com/cefsharp/CefSharp/releases
 
 Basic Troubleshooting:
-  - Minimum of .Net Core 3.1 (.Net 5.0 and greater are also supported)
-  - Minimum of `Visual C++ 2019 Redist` is installed (either `x86`, `x64` or `arm64` depending on your application).
+  - Minimum of .Net 6
+  - Minimum of `Visual C++ 2022 Redist` is installed (either `x86`, `x64` or `arm64` depending on your application).
   - Please ensure your output directory contains these required dependencies:
     * libcef.dll (Chromium Embedded Framework Core library)
     * icudtl.dat (Unicode Support data)
-	* chrome_elf.dll(Crash reporting library)
-	* v8_context_snapshot.bin (V8 snapshot data)
-	* locales\en-US.pak, chrome_100_percent.pak, chrome_200_percent.pak, resources.pak, d3dcompiler_47.dll, libEGL.dll, libGLESv2.dll
-	  - Whilst these are technically listed as optional, the browser is unlikely to function without these files.
-	  - See https://github.com/cefsharp/CefSharp/wiki/Output-files-description-table-%28Redistribution%29 for details
-	* Ijwhost.dll (To support C++/CLI libraries in .NET Core/.Net 5.0, ijwhost was created as a shim for finding and loading the runtime.)
+    * chrome_elf.dll(Crash reporting library)
+    * v8_context_snapshot.bin (V8 snapshot data)
+    * locales\en-US.pak, chrome_100_percent.pak, chrome_200_percent.pak, resources.pak, d3dcompiler_47.dll, libEGL.dll, libGLESv2.dll
+      - Whilst these are technically listed as optional, the browser is unlikely to function without these files.
+      - See https://github.com/cefsharp/CefSharp/wiki/Output-files-description-table-%28Redistribution%29 for details
+    * Ijwhost.dll (To support C++/CLI libraries in .NET Core/.Net 5.0, ijwhost was created as a shim for finding and loading the runtime.)
     * CefSharp.Core.dll, CefSharp.dll, CefSharp.Core.Runtime.dll
       CefSharp.BrowserSubprocess.exe, CefSharp.BrowserSubprocess.dll, CefSharp.BrowserSubProcess.Core.dll
         - These are required CefSharp binaries that are the common core logic binaries of CefSharp.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ With each release a new branch is created, for example the `92.0.260` release co
 If you're new to `CefSharp` and are downloading the source to check it out, please use a **Release** branch.
 
 **&ast;** VC++ 2022 is required starting with version 138<br/>
-**&ast;&ast;** For .Net Core Packages 6 or greater is required. 
+**&ast;&ast;** For .Net Packages 6 or greater is required. 
 
 | Branch                                                                | CEF Version  | VC++ Version | .Net Version | Status |
 |-----------------------------------------------------------------------|------|-------|---------|-----------------|
@@ -169,7 +169,7 @@ If you're new to `CefSharp` and are downloading the source to check it out, plea
 | [cefsharp/37](https://github.com/cefsharp/CefSharp/tree/cefsharp/37)  | 2062 | 2012  | 4.0     | Unsupported     |
 
 **&ast;** VC++ 2022 is required starting with version 138<br/>
-**&ast;&ast;** For .Net Core Packages .Net 6.0 or greater is required. 
+**&ast;&ast;** For .Net Packages .Net 6 or greater is required. 
 
 ## Financial Support
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-#requires -Version 5
+﻿#requires -Version 5
 
 param(
     [ValidateSet("vs2022","vs2019", "nupkg-only", "update-build-version")]
@@ -9,7 +9,7 @@ param(
     [Parameter(Position = 2)]
     [string] $AssemblyVersion = "138.0.170",
     [Parameter(Position = 3)]
-    [ValidateSet("NetFramework", "NetCore", "NetFramework462", "NetCore31")]
+    [ValidateSet("NetFramework", "NetCore")]
     [string] $TargetFramework = "NetFramework",
     [Parameter(Position = 4)]
     [string] $BuildArches = "x86 x64 arm64"
@@ -34,21 +34,21 @@ function Invoke-BatchFile
 {
    param(
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-        [string]$Path, 
+        [string]$Path,
         [Parameter(Position = 1, Mandatory = $true, ValueFromPipeline = $true)]
         [string]$Parameters
    )
 
-   $tempFile = [IO.Path]::GetTempFileName()  
+   $tempFile = [IO.Path]::GetTempFileName()
 
-   cmd.exe /c " `"$Path`" $Parameters && set > `"$tempFile`" " 
+   cmd.exe /c " `"$Path`" $Parameters && set > `"$tempFile`" "
 
-   Get-Content $tempFile | Foreach-Object {   
-       if ($_ -match "^(.*?)=(.*)$")  
-       { 
-           Set-Content "env:\$($matches[1])" $matches[2]  
-       } 
-   }  
+   Get-Content $tempFile | Foreach-Object {
+       if ($_ -match "^(.*?)=(.*)$")
+       {
+           Set-Content "env:\$($matches[1])" $matches[2]
+       }
+   }
 
    Remove-Item $tempFile
 }
@@ -65,7 +65,7 @@ function Die
     exit 1
 }
 
-function Warn 
+function Warn
 {
     param(
         [Parameter(Position = 0, ValueFromPipeline = $true)]
@@ -77,16 +77,16 @@ function Warn
     Write-Host
 }
 
-function BuildSolution 
+function BuildSolution
 {
     param(
         [ValidateSet('v142','v143')]
         [Parameter(Position = 0, ValueFromPipeline = $true)]
-        [string] $Toolchain, 
+        [string] $Toolchain,
 
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         [ValidateSet('Debug', 'Release')]
-        [string] $Configuration, 
+        [string] $Configuration,
 
         [Parameter(Position = 2, ValueFromPipeline = $true)]
         [ValidateSet('x86', 'x64', 'arm64')]
@@ -104,8 +104,8 @@ function BuildSolution
         $Arch="win32";
     }
 
-	# Restore Nuget packages
-	&msbuild /nologo /verbosity:minimal /t:restore /p:Platform=$Arch /p:Configuration=Release $CefSln
+    # Restore Nuget packages
+    &msbuild /nologo /verbosity:minimal /t:restore /p:Platform=$Arch /p:Configuration=Release $CefSln
 
     $Arguments = @(
         "$CefSln",
@@ -167,9 +167,9 @@ function VSX
     $VS_PRE = ""
 
     switch -Exact ($Toolchain)
-	{
+    {
         'v142'
-		{
+        {
             $VS_VER = 16;
             $VS_OFFICIAL_VER = 2019;
         }
@@ -194,7 +194,7 @@ function VSX
         $ErrorActionPreference="SilentlyContinue"
         $VSInstallPath = & $VSwherePath -version $versionSearchStr -property installationPath $VS_PRE -products 'Microsoft.VisualStudio.Product.BuildTools'
         $ErrorActionPreference="Stop"
-		Write-Diagnostic "BuildTools $($VS_OFFICIAL_VER)InstallPath: $VSInstallPath"
+        Write-Diagnostic "BuildTools $($VS_OFFICIAL_VER)InstallPath: $VSInstallPath"
 
         if( -not $VSInstallPath -or -not (Test-Path $VSInstallPath))
         {
@@ -454,14 +454,14 @@ function WriteVersionToNugetTargets
     $Filename = Join-Path $WorkingDir NuGet\PackageReference\CefSharp.Common.NETCore.targets
     
     Write-Diagnostic  "Write Version ($RedistVersion) to $Filename"
-	
-	$RunTimeJsonData = Get-Content -Encoding UTF8 $Filename
+
+    $RunTimeJsonData = Get-Content -Encoding UTF8 $Filename
 
     $Regex1  = '" Version=".*"';
     $Replace = '" Version="' + $RedistVersion + '"';
     $NewString = $RunTimeJsonData -replace $Regex1, $Replace
-	
-	$Regex1  = '" VersionOverride=".*"';
+
+    $Regex1  = '" VersionOverride=".*"';
     $Replace = '" VersionOverride="' + $RedistVersion + '"';
     $NewString = $NewString -replace $Regex1, $Replace
     
@@ -584,15 +584,14 @@ switch -Exact ($Target)
     }
     "vs2022"
     {
-
         VSX v143
         Nupkg $NupkgFiles
     }
-	"update-build-version"
-	{
-		Write-Diagnostic "Updated Version to $Version"
-		Write-Diagnostic "Updated AssemblyVersion to $AssemblyVersion"
-	}
+    "update-build-version"
+    {
+        Write-Diagnostic "Updated Version to $Version"
+        Write-Diagnostic "Updated AssemblyVersion to $AssemblyVersion"
+    }
 }
 
 Pop-Location


### PR DESCRIPTION
**Summary:**
   - Update some leftover .net core 3.1 references to .net 6

**Changes:**
   - Changed references to .net core 3.1 with references to .net 6
      
**How Has This Been Tested?**  
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, operating system, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
