### PR TITLE
Determine selected client certificate via thumbprint

### DIFF
--- a/CefSharp.Core.Runtime/Internals/CefCertificateCallbackWrapper.h
+++ b/CefSharp.Core.Runtime/Internals/CefCertificateCallbackWrapper.h
@@ -56,23 +56,6 @@ namespace CefSharp
                         _certificateList.begin();
                     for (; it != _certificateList.end(); ++it)
                     {
-
-                        // TODO: Need to make this logic of comparing serial number of the certificate (*it)
-                        // with the selected certificate returned by the user selection (cert).
-                        // Better and more performant way would be to read the serial number from
-                        // (*it) and convert it into System::String, so that it can directly compared
-                        // with certSerial. This is how I tried it but the Encoding class garbled up
-                        // the string when converting it from CefRefPtr<CefBinaryValue> to System::String
-                        // Try to find a better way to do this
-                        //
-                        //auto serialNum((*it)->GetSerialNumber());
-                        //auto byteSize = serialNum->GetSize();
-                        //auto bufferByte = gcnew cli::array<Byte>(byteSize);
-                        //pin_ptr<Byte> src = &bufferByte[0]; // pin pointer to first element in arr
-                        //serialNum->GetData(static_cast<void*>(src), byteSize, 0);
-                        //UTF8Encoding^ encoding = gcnew UTF8Encoding;
-                        //auto serialStr(encoding->GetString(bufferByte));
-
                         auto bytes((*it)->GetDEREncoded());
                         auto byteSize = bytes->GetSize();
 


### PR DESCRIPTION
**Fixes:** #5185 

**Summary:** 
   - Certificate thumbprints get compared instead of the serial number

**Changes:** [specify the structures changed] 
   - Compare certificate thumbprints
   - Removed obsolete TODO comment regarding previous serial number comparison
      
**How Has This Been Tested?**  
Used the WinForms.Example project to load a website that requires a client certificate and verified that the selected one was sent to the server.


**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved certificate matching by switching to thumbprint-based comparison.
  * Matching is now case-insensitive for thumbprints, reducing false mismatches.
  * Removed legacy comparison logic, resulting in more reliable certificate selection behavior for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->