### PR TITLE
Allow JavaScript binding when browser wrapper cannot be found

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -62,7 +62,11 @@ namespace CefSharp
             _onBrowserCreated->Invoke(wrapper);
 
             //Multiple CefBrowserWrappers created when opening popups
-            _browserWrappers->TryAdd(browser->GetIdentifier(), wrapper);
+            auto browserId = browser->GetIdentifier();
+            _browserWrappers->TryAdd(browserId, wrapper);
+
+            auto javascriptBindingSettings = gcnew JavascriptBindingSettings();
+            _browserJavascriptBindingSettings->TryAdd(browserId, javascriptBindingSettings);
 
             if (!extraInfo.get())
             {
@@ -103,19 +107,19 @@ namespace CefSharp
 
             if (extraInfo->HasKey("JavascriptBindingApiEnabled"))
             {
-                wrapper->JavascriptBindingApiEnabled = extraInfo->GetBool("JavascriptBindingApiEnabled");
+                javascriptBindingSettings->JavascriptBindingApiEnabled = extraInfo->GetBool("JavascriptBindingApiEnabled");
             }
 
             if (extraInfo->HasKey("JavascriptBindingApiHasAllowOrigins"))
             {
-                wrapper->JavascriptBindingApiHasAllowOrigins = extraInfo->GetBool("JavascriptBindingApiHasAllowOrigins");
+                javascriptBindingSettings->JavascriptBindingApiHasAllowOrigins = extraInfo->GetBool("JavascriptBindingApiHasAllowOrigins");
 
-                if (wrapper->JavascriptBindingApiHasAllowOrigins)
+                if (javascriptBindingSettings->JavascriptBindingApiHasAllowOrigins)
                 {
                     auto allowOrigins = extraInfo->GetList("JavascriptBindingApiAllowOrigins");
                     if (allowOrigins.get() && allowOrigins->IsValid())
                     {
-                        wrapper->JavascriptBindingApiAllowOrigins = allowOrigins->Copy();
+                        javascriptBindingSettings->JavascriptBindingApiAllowOrigins = allowOrigins->Copy();
                     }
                 }
             }
@@ -136,6 +140,9 @@ namespace CefSharp
                 _onBrowserDestroyed->Invoke(wrapper);
                 delete wrapper;
             }
+
+            // Don't remove javascript settings because cef is unreliable in calling OnBrowserCreated/OnBrowserDestroyed consistently:
+            // https://github.com/cefsharp/CefSharp/issues/5228
         };
 
         void CefAppUnmanagedWrapper::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context)
@@ -165,9 +172,10 @@ namespace CefSharp
                 }
             }
 
-            auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier());
+            JavascriptBindingSettings^ javascriptBindingSettings = nullptr;
+            _browserJavascriptBindingSettings->TryGetValue(browser->GetIdentifier(), javascriptBindingSettings);
 
-            if (IsJavascriptBindingApiAllowed(browserWrapper, frame))
+            if (IsJavascriptBindingApiAllowed(javascriptBindingSettings, frame))
             {
                 //TODO: Look at adding some sort of javascript mapping layer to reduce the code duplication
                 auto global = context->GetGlobal();
@@ -347,24 +355,24 @@ namespace CefSharp
             return rootObject;
         }
 
-        bool CefAppUnmanagedWrapper::IsJavascriptBindingApiAllowed(CefBrowserWrapper^ browserWrapper, CefRefPtr<CefFrame> frame)
+        bool CefAppUnmanagedWrapper::IsJavascriptBindingApiAllowed(JavascriptBindingSettings^ javascriptBindingSettings, CefRefPtr<CefFrame> frame)
         {
-            if (browserWrapper == nullptr)
-            {
-                return true;
-            }
-
-            if (!browserWrapper->JavascriptBindingApiEnabled)
+            if (javascriptBindingSettings == nullptr)
             {
                 return false;
             }
 
-            if (!browserWrapper->JavascriptBindingApiHasAllowOrigins)
+            if (!javascriptBindingSettings->JavascriptBindingApiEnabled)
+            {
+                return false;
+            }
+
+            if (!javascriptBindingSettings->JavascriptBindingApiHasAllowOrigins)
             {
                 return true;
             }
 
-            auto allowOrigins = browserWrapper->JavascriptBindingApiAllowOrigins;
+            auto allowOrigins = javascriptBindingSettings->JavascriptBindingApiAllowOrigins;
             if (!allowOrigins.get())
             {
                 return false;

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.cpp
@@ -167,7 +167,7 @@ namespace CefSharp
 
             auto browserWrapper = FindBrowserWrapper(browser->GetIdentifier());
 
-            if (browserWrapper != nullptr && browserWrapper->JavascriptBindingApiEnabled && IsJavascriptBindingApiAllowed(browserWrapper, frame))
+            if (IsJavascriptBindingApiAllowed(browserWrapper, frame))
             {
                 //TODO: Look at adding some sort of javascript mapping layer to reduce the code duplication
                 auto global = context->GetGlobal();
@@ -349,7 +349,17 @@ namespace CefSharp
 
         bool CefAppUnmanagedWrapper::IsJavascriptBindingApiAllowed(CefBrowserWrapper^ browserWrapper, CefRefPtr<CefFrame> frame)
         {
-            if (browserWrapper == nullptr || !browserWrapper->JavascriptBindingApiHasAllowOrigins)
+            if (browserWrapper == nullptr)
+            {
+                return true;
+            }
+
+            if (!browserWrapper->JavascriptBindingApiEnabled)
+            {
+                return false;
+            }
+
+            if (!browserWrapper->JavascriptBindingApiHasAllowOrigins)
             {
                 return true;
             }

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -9,6 +9,7 @@
 
 #include "SubProcessApp.h"
 #include "CefBrowserWrapper.h"
+#include "JavascriptBindingSettings.h"
 #include "RegisterBoundObjectRegistry.h"
 
 using namespace System::Collections::Generic;
@@ -26,6 +27,7 @@ namespace CefSharp
             gcroot<Action<CefBrowserWrapper^>^> _onBrowserCreated;
             gcroot<Action<CefBrowserWrapper^>^> _onBrowserDestroyed;
             gcroot<ConcurrentDictionary<int, CefBrowserWrapper^>^> _browserWrappers;
+            gcroot<ConcurrentDictionary<int, JavascriptBindingSettings^>^> _browserJavascriptBindingSettings;
             gcroot<ConcurrentDictionary<String^, JavascriptRootObjectWrapper^>^> _jsRootObjectWrappersByFrameId;
             bool _focusedNodeChangedEnabled;
             bool _legacyBindingEnabled;
@@ -38,7 +40,7 @@ namespace CefSharp
             gcroot<Dictionary<String^, JavascriptObject^>^> _javascriptObjects;
 
             gcroot<RegisterBoundObjectRegistry^> _registerBoundObjectRegistry;
-            bool IsJavascriptBindingApiAllowed(CefBrowserWrapper^ browserWrapper, CefRefPtr<CefFrame> frame);
+            bool IsJavascriptBindingApiAllowed(JavascriptBindingSettings^ javascriptBindingSettings, CefRefPtr<CefFrame> frame);
 
         public:
             static const CefString kPromiseCreatorScript;
@@ -49,6 +51,7 @@ namespace CefSharp
                 _onBrowserCreated = onBrowserCreated;
                 _onBrowserDestroyed = onBrowserDestroyed;
                 _browserWrappers = gcnew ConcurrentDictionary<int, CefBrowserWrapper^>();
+                _browserJavascriptBindingSettings = gcnew ConcurrentDictionary<int, JavascriptBindingSettings^>();
                 _jsRootObjectWrappersByFrameId = gcnew ConcurrentDictionary<String^, JavascriptRootObjectWrapper^>();
                 _focusedNodeChangedEnabled = enableFocusedNodeChanged;
                 _javascriptObjects = gcnew Dictionary<String^, JavascriptObject^>();
@@ -68,6 +71,16 @@ namespace CefSharp
                     }
 
                     _browserWrappers = nullptr;
+                }
+
+                if (!Object::ReferenceEquals(_browserJavascriptBindingSettings, nullptr))
+                {
+                    for each (JavascriptBindingSettings ^ javascriptBindingSettings in Enumerable::OfType<JavascriptBindingSettings^>(_browserJavascriptBindingSettings))
+                    {
+                        delete javascriptBindingSettings;
+                    }
+
+                    _browserJavascriptBindingSettings = nullptr;
                 }
 
                 if (!Object::ReferenceEquals(_jsRootObjectWrappersByFrameId, nullptr))

--- a/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefAppUnmanagedWrapper.h
@@ -65,7 +65,7 @@ namespace CefSharp
             {
                 if (!Object::ReferenceEquals(_browserWrappers, nullptr))
                 {
-                    for each (CefBrowserWrapper ^ browser in Enumerable::OfType<CefBrowserWrapper^>(_browserWrappers))
+                    for each (CefBrowserWrapper ^ browser in _browserWrappers->Values)
                     {
                         delete browser;
                     }
@@ -75,7 +75,7 @@ namespace CefSharp
 
                 if (!Object::ReferenceEquals(_browserJavascriptBindingSettings, nullptr))
                 {
-                    for each (JavascriptBindingSettings ^ javascriptBindingSettings in Enumerable::OfType<JavascriptBindingSettings^>(_browserJavascriptBindingSettings))
+                    for each (JavascriptBindingSettings ^ javascriptBindingSettings in _browserJavascriptBindingSettings->Values)
                     {
                         delete javascriptBindingSettings;
                     }
@@ -85,7 +85,7 @@ namespace CefSharp
 
                 if (!Object::ReferenceEquals(_jsRootObjectWrappersByFrameId, nullptr))
                 {
-                    for each (JavascriptRootObjectWrapper^ rootObject in Enumerable::OfType<JavascriptRootObjectWrapper^>(_jsRootObjectWrappersByFrameId))
+                    for each (JavascriptRootObjectWrapper^ rootObject in _jsRootObjectWrappersByFrameId->Values)
                     {
                         delete rootObject;
                     }

--- a/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
+++ b/CefSharp.BrowserSubprocess.Core/CefBrowserWrapper.h
@@ -28,7 +28,6 @@ namespace CefSharp
         {
         private:
             MCefRefPtr<CefBrowser> _cefBrowser;
-            MCefRefPtr<CefListValue> _javascriptBindingApiAllowOrigins;
 
         public:
             CefBrowserWrapper(const CefRefPtr<CefBrowser> &cefBrowser)
@@ -36,17 +35,11 @@ namespace CefSharp
                 _cefBrowser = cefBrowser.get();
                 BrowserId = cefBrowser->GetIdentifier();
                 IsPopup = cefBrowser->IsPopup();
-
-                JavascriptBindingApiEnabled = true;
-                JavascriptBindingApiHasAllowOrigins = false;
-                JavascriptBindingApiAllowOrigins = nullptr;
             }
 
             !CefBrowserWrapper()
             {
                 _cefBrowser = nullptr;
-
-                _javascriptBindingApiAllowOrigins = nullptr;
             }
 
             ~CefBrowserWrapper()
@@ -56,13 +49,6 @@ namespace CefSharp
 
             property int BrowserId;
             property bool IsPopup;
-            property bool JavascriptBindingApiEnabled;
-            property bool JavascriptBindingApiHasAllowOrigins;
-            property CefRefPtr<CefListValue> JavascriptBindingApiAllowOrigins
-            {
-                CefRefPtr<CefListValue> get() { return _javascriptBindingApiAllowOrigins.get(); }
-                void set(CefRefPtr<CefListValue> value) { _javascriptBindingApiAllowOrigins = value.get(); }
-            }
 
 #ifndef NETCOREAPP
             // This allows us to create the WCF proxies back to our parent process.

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj
@@ -278,6 +278,7 @@
     <ClCompile Include="..\CefSharp.Core.Runtime\Internals\CefRefCountManaged.cpp" />
     <ClCompile Include="BrowserSubprocessExecutable.h" />
     <ClInclude Include="Cef.h" />
+    <ClInclude Include="JavascriptBindingSettings.h" />
     <ClInclude Include="JavascriptRootObjectWrapper.h" />
     <ClInclude Include="SubProcessApp.h" />
     <ClInclude Include="Async\JavascriptAsyncMethodCallback.h" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="..\CefSharp.Core.Runtime\Internals\CefRefCountManaged.cpp" />
     <ClCompile Include="BrowserSubprocessExecutable.h" />
     <ClInclude Include="Cef.h" />
+    <ClInclude Include="JavascriptBindingSettings.h" />
     <ClInclude Include="JavascriptPromiseHandler.h" />
     <ClInclude Include="JavascriptPromiseResolverCatch.h" />
     <ClInclude Include="JavascriptPromiseResolverThen.h" />

--- a/CefSharp.BrowserSubprocess.Core/JavascriptBindingSettings.h
+++ b/CefSharp.BrowserSubprocess.Core/JavascriptBindingSettings.h
@@ -1,0 +1,47 @@
+// Copyright © 2013 The CefSharp Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "include/cef_v8.h"
+
+#include "Stdafx.h"
+
+namespace CefSharp
+{
+    namespace BrowserSubprocess
+    {
+        private ref class JavascriptBindingSettings
+        {
+        private:
+            MCefRefPtr<CefListValue> _javascriptBindingApiAllowOrigins;
+
+        public:
+            JavascriptBindingSettings()
+            {
+                JavascriptBindingApiEnabled = true;
+                JavascriptBindingApiHasAllowOrigins = false;
+                JavascriptBindingApiAllowOrigins = nullptr;
+            }
+
+            !JavascriptBindingSettings()
+            {
+                _javascriptBindingApiAllowOrigins = nullptr;
+            }
+
+            ~JavascriptBindingSettings()
+            {
+                this->!JavascriptBindingSettings();
+            }
+
+            property bool JavascriptBindingApiEnabled;
+            property bool JavascriptBindingApiHasAllowOrigins;
+            property CefRefPtr<CefListValue> JavascriptBindingApiAllowOrigins
+            {
+                CefRefPtr<CefListValue> get() { return _javascriptBindingApiAllowOrigins.get(); }
+                void set(CefRefPtr<CefListValue> value) { _javascriptBindingApiAllowOrigins = value.get(); }
+            }
+        };
+    }
+}


### PR DESCRIPTION
**Fixes:** #5228

**Summary:** Fixes regression to allow JavaScript bindings when browser wrapper can not be found.

**Changes:**
- Moved all checks to IsJavascriptBindingApiAllowed to determine whether JavaScript bindings are enabled.
      
**How Has This Been Tested?**  
Manually.
My App works again with this build: https://ci.appveyor.com/project/campersau/cefsharp/builds/53796822/artifacts

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [X] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [X] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated per-browser JavaScript binding configuration and centralized authorization checks for the JavaScript binding API, improving reliability of origin/allowlist handling. This restructures internal storage and lookup of binding settings to reduce race conditions and make allowlist enforcement more consistent, without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->