### PR TITLE
Core - Support building with VS 2026

### DIFF
--- a/CefSharp.props
+++ b/CefSharp.props
@@ -2,16 +2,13 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <VisualStudioProductVersion>2019</VisualStudioProductVersion>
-    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='17.0' AND Exists('$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration)\VS2022\libcef_dll_wrapper.lib')">2022</VisualStudioProductVersion>
+    <VisualStudioProductVersion>2022</VisualStudioProductVersion>
+    <VisualStudioProductVersion Condition="'$(VisualStudioVersion)'=='18.0' AND Exists('$(SolutionDir)packages\$(CefSdkVer)\CEF\$(Platform)\$(Configuration)\VS2026\libcef_dll_wrapper.lib')">2026</VisualStudioProductVersion>
 
-    <PlatformToolset>v142</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='18.0'">v145</PlatformToolset>
   
-    <!-- TODO: We might need to do something here when VS2019 and VS2022 are installed -->
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <!-- <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'=='16.0'">10.0</WindowsTargetPlatformVersion> -->
-    <!-- <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'=='17.0'">10.0</WindowsTargetPlatformVersion> -->
   </PropertyGroup>
 
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 #requires -Version 5
 
 param(
-    [ValidateSet("vs2022","vs2019", "nupkg-only", "update-build-version")]
+    [ValidateSet("vs2022","vs2026", "nupkg-only", "update-build-version")]
     [Parameter(Position = 0)] 
     [string] $Target = "vs2022",
     [Parameter(Position = 1)]
@@ -80,7 +80,7 @@ function Warn
 function BuildSolution
 {
     param(
-        [ValidateSet('v142','v143')]
+        [ValidateSet('v145','v143')]
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         [string] $Toolchain,
 
@@ -153,7 +153,7 @@ function BuildSolution
 function VSX 
 {
     param(
-        [ValidateSet('v142','v143')]
+        [ValidateSet('v143','v145')]
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         [string] $Toolchain
     )
@@ -168,10 +168,11 @@ function VSX
 
     switch -Exact ($Toolchain)
     {
-        'v142'
+        'v145'
         {
-            $VS_VER = 16;
-            $VS_OFFICIAL_VER = 2019;
+            $VS_VER = 18;
+            $VS_OFFICIAL_VER = 2026;
+			$VS_PRE = "-prerelease";
         }
         'v143'
         {
@@ -537,7 +538,7 @@ if(-not (Test-Path $VSWherePath))
     $VSWherePath = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
 }
 
-#Check if we already have vswhere which is included in newer versions of VS2017/VS2019
+#Check if we already have vswhere which is included in newer versions of VS2022
 if(-not (Test-Path $VSWherePath))
 {
     Write-Diagnostic "Downloading VSWhere as no install found at $VSWherePath"
@@ -577,9 +578,9 @@ switch -Exact ($Target)
     {
         Nupkg $NupkgFiles
     }
-    "vs2019"
+    "vs2026"
     {
-        VSX v142
+        VSX v145
         Nupkg $NupkgFiles
     }
     "vs2022"

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 #requires -Version 5
 
 param(
-    [ValidateSet("vs2022","vs2019", "nupkg-only", "update-build-version")]
+    [ValidateSet("vs2022","vs2026", "nupkg-only", "update-build-version")]
     [Parameter(Position = 0)] 
     [string] $Target = "vs2022",
     [Parameter(Position = 1)]
@@ -80,7 +80,7 @@ function Warn
 function BuildSolution
 {
     param(
-        [ValidateSet('v142','v143')]
+        [ValidateSet('v145','v143')]
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         [string] $Toolchain,
 
@@ -153,7 +153,7 @@ function BuildSolution
 function VSX 
 {
     param(
-        [ValidateSet('v142','v143')]
+        [ValidateSet('v143','v145')]
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         [string] $Toolchain
     )
@@ -168,10 +168,11 @@ function VSX
 
     switch -Exact ($Toolchain)
     {
-        'v142'
+        'v145'
         {
-            $VS_VER = 16;
-            $VS_OFFICIAL_VER = 2019;
+            $VS_VER = 18;
+            $VS_OFFICIAL_VER = 2026;
+			$VS_PRE = "-prerelease";
         }
         'v143'
         {
@@ -536,7 +537,7 @@ if(-not (Test-Path $VSWherePath))
     $VSWherePath = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
 }
 
-#Check if we already have vswhere which is included in newer versions of VS2017/VS2019
+#Check if we already have vswhere which is included in newer versions of VS2022
 if(-not (Test-Path $VSWherePath))
 {
     Write-Diagnostic "Downloading VSWhere as no install found at $VSWherePath"
@@ -576,9 +577,9 @@ switch -Exact ($Target)
     {
         Nupkg $NupkgFiles
     }
-    "vs2019"
+    "vs2026"
     {
-        VSX v142
+        VSX v145
         Nupkg $NupkgFiles
     }
     "vs2022"


### PR DESCRIPTION
Allow building with VS 2026, currently lib cef wrapper isn't compiled with VS2026, so VS2026 will still use the older VS2022 compiled `.lib` file.

Part of #5243



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration defaults to target Visual Studio 2022, with support for Visual Studio 2026.
  * Updated platform toolset mappings for newer Visual Studio releases.
  * Added Visual Studio 2026 build and packaging support.
  * Retained ARM64 support in non-.NET Core builds.
  * Updated default version information to 152.0.60.
  * Removed obsolete guidance for older Visual Studio versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->