### PR TITLE
Upgrade to v144.0.26+g8b05ce5+chromium-144.0.7559.252

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.25\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.25\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.25\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.25\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.BrowserSubprocess.Core/Resource.rc
+++ b/CefSharp.BrowserSubprocess.Core/Resource.rc
@@ -1,8 +1,8 @@
 #pragma code_page(65001)
 
 1 VERSIONINFO
- FILEVERSION 144,0,250
- PRODUCTVERSION 144,0,250
+ FILEVERSION 144,0,260
+ PRODUCTVERSION 144,0,260
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -18,10 +18,10 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "CefSharp.BrowserSubprocess.Core"
-            VALUE "FileVersion", "144.0.250"
+            VALUE "FileVersion", "144.0.260"
             VALUE "LegalCopyright", "Copyright © 2026 The CefSharp Authors"
             VALUE "ProductName", "CefSharp"
-            VALUE "ProductVersion", "144.0.250"
+            VALUE "ProductVersion", "144.0.260"
         END
     END
     BLOCK "VarFileInfo"

--- a/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.25" targetFramework="native" />
+  <package id="cef.sdk" version="144.0.26" targetFramework="native" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.netcore.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.netcore.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.25" targetFramework="net6.0" />
+  <package id="cef.sdk" version="144.0.26" targetFramework="net6.0" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.BrowserSubprocess/app.manifest
+++ b/CefSharp.BrowserSubprocess/app.manifest
@@ -8,7 +8,7 @@
     xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.250.0" name="CefSharp.BrowserSubprocess.app" />
+  <assemblyIdentity version="144.0.260.0" name="CefSharp.BrowserSubprocess.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
+++ b/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
@@ -269,6 +269,7 @@ namespace CefSharp.Core
         public virtual bool IsGlobal { get { throw null; } }
         public virtual bool CanSetPreference(string name) { throw null; }
         public virtual void ClearCertificateExceptions(CefSharp.ICompletionCallback callback) { }
+        public virtual void ClearHttpCache(CefSharp.ICompletionCallback callback) { }
         public virtual void ClearHttpAuthCredentials(CefSharp.ICompletionCallback callback) { }
         public virtual bool ClearSchemeHandlerFactories() { throw null; }
         public virtual void CloseAllConnections(CefSharp.ICompletionCallback callback) { }

--- a/CefSharp.Core.Runtime/CefSharp.Core.Runtime.netcore.vcxproj
+++ b/CefSharp.Core.Runtime/CefSharp.Core.Runtime.netcore.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.25\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.25\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.Core.Runtime/CefSharp.Core.Runtime.vcxproj
+++ b/CefSharp.Core.Runtime/CefSharp.Core.Runtime.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.25\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.25\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.Core.Runtime/Internals/TypeConversion.h
+++ b/CefSharp.Core.Runtime/Internals/TypeConversion.h
@@ -58,6 +58,7 @@ namespace CefSharp
                     item->IsInProgress = downloadItem->IsInProgress();
                     item->IsComplete = downloadItem->IsComplete();
                     item->IsCancelled = downloadItem->IsCanceled();
+                    item->IsPaused = downloadItem->IsPaused();
                     item->CurrentSpeed = downloadItem->GetCurrentSpeed();
                     item->PercentComplete = downloadItem->GetPercentComplete();
                     item->TotalBytes = downloadItem->GetTotalBytes();

--- a/CefSharp.Core.Runtime/RequestContext.cpp
+++ b/CefSharp.Core.Runtime/RequestContext.cpp
@@ -126,6 +126,15 @@ namespace CefSharp
             _requestContext->ClearCertificateExceptions(wrapper);
         }
 
+        void RequestContext::ClearHttpCache(ICompletionCallback^ callback)
+        {
+            ThrowIfDisposed();
+
+            CefRefPtr<CefCompletionCallback> wrapper = callback == nullptr ? nullptr : new CefCompletionCallbackAdapter(callback);
+
+            _requestContext->ClearHttpCache(wrapper);
+        }
+
         void RequestContext::ClearHttpAuthCredentials(ICompletionCallback^ callback)
         {
             ThrowIfDisposed();

--- a/CefSharp.Core.Runtime/RequestContext.h
+++ b/CefSharp.Core.Runtime/RequestContext.h
@@ -283,6 +283,13 @@ namespace CefSharp
             virtual void ClearCertificateExceptions(ICompletionCallback^ callback);
 
             /// <summary>
+            /// Clears the HTTP cache.
+            /// </summary>
+            /// <param name="callback">If is non-NULL it will be executed on the CEF UI thread after
+            /// completion. This param is optional</param>
+            virtual void ClearHttpCache(ICompletionCallback^ callback);
+
+            /// <summary>
             /// Clears all HTTP authentication credentials that were added as part of handling
             /// <see cref="IRequestHandler::GetAuthCredentials"/>.
             /// </summary>

--- a/CefSharp.Core.Runtime/Resource.rc
+++ b/CefSharp.Core.Runtime/Resource.rc
@@ -1,8 +1,8 @@
 #pragma code_page(65001)
 
 1 VERSIONINFO
- FILEVERSION 144,0,250
- PRODUCTVERSION 144,0,250
+ FILEVERSION 144,0,260
+ PRODUCTVERSION 144,0,260
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -18,10 +18,10 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "CefSharp.Core"
-            VALUE "FileVersion", "144.0.250"
+            VALUE "FileVersion", "144.0.260"
             VALUE "LegalCopyright", "Copyright © 2026 The CefSharp Authors"
             VALUE "ProductName", "CefSharp"
-            VALUE "ProductVersion", "144.0.250"
+            VALUE "ProductVersion", "144.0.260"
         END
     END
     BLOCK "VarFileInfo"

--- a/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.config
+++ b/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.25" targetFramework="native" />
+  <package id="cef.sdk" version="144.0.26" targetFramework="native" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.netcore.config
+++ b/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.netcore.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.25" targetFramework="net6.0" />
+  <package id="cef.sdk" version="144.0.26" targetFramework="net6.0" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.Core/RequestContext.cs
+++ b/CefSharp.Core/RequestContext.cs
@@ -181,6 +181,12 @@ namespace CefSharp
         }
 
         /// <inheritdoc/>
+        public void ClearHttpCache(ICompletionCallback callback = null)
+        {
+            requestContext.ClearHttpCache(callback);
+        }
+
+        /// <inheritdoc/>
         public void ClearHttpAuthCredentials(ICompletionCallback callback = null)
         {
             requestContext.ClearHttpAuthCredentials(callback);

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
@@ -23,7 +23,7 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.netcore.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.netcore.csproj
@@ -38,7 +38,7 @@
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.OffScreen\CefSharp.OffScreen.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.OffScreen.Example/app.manifest
+++ b/CefSharp.OffScreen.Example/app.manifest
@@ -7,7 +7,7 @@
   xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.250.0" name="CefSharp.OffScreen.Example.app" />
+  <assemblyIdentity version="144.0.260.0" name="CefSharp.OffScreen.Example.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -36,7 +36,7 @@
     <ItemGroup>
         <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
         <PackageReference Include="Bogus" Version="35.4.1" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.Test/CefSharp.Test.netcore.csproj
+++ b/CefSharp.Test/CefSharp.Test.netcore.csproj
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
     <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
     <PackageReference Include="Bogus" Version="35.4.1" />
-    <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+    <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -32,7 +32,7 @@
         <ProjectReference Include="..\CefSharp\CefSharp.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.netcore.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.netcore.csproj
@@ -38,7 +38,7 @@
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.WinForms\CefSharp.WinForms.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.WinForms.Example/app.manifest
+++ b/CefSharp.WinForms.Example/app.manifest
@@ -8,7 +8,7 @@
     xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.250.0" name="CefSharp.WinForms.Example.app" />
+  <assemblyIdentity version="144.0.260.0" name="CefSharp.WinForms.Example.app" />
 
   <dependency>
     <dependentAssembly>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -31,7 +31,7 @@
         <Folder Include="Assets\Images\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
@@ -39,7 +39,7 @@
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.Wpf.Example/app.manifest
+++ b/CefSharp.Wpf.Example/app.manifest
@@ -7,7 +7,7 @@
   xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.250.0" name="CefSharp.Wpf.Example.app" />
+  <assemblyIdentity version="144.0.260.0" name="CefSharp.Wpf.Example.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.csproj
+++ b/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.csproj
@@ -28,7 +28,7 @@
         <ProjectReference Include="..\CefSharp\CefSharp.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">

--- a/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.netcore.csproj
+++ b/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.netcore.csproj
@@ -40,7 +40,7 @@
         <ProjectReference Include="..\CefSharp.Core\CefSharp.Core.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.25" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.shfbproj
+++ b/CefSharp.shfbproj
@@ -31,7 +31,7 @@
       <DocumentationSource sourceFile="CefSharp.WinForms\CefSharp.WinForms.csproj" />
       <DocumentationSource sourceFile="CefSharp.Wpf\CefSharp.Wpf.csproj" />
     </DocumentationSources>
-    <HelpFileVersion>144.0.250</HelpFileVersion>
+    <HelpFileVersion>144.0.260</HelpFileVersion>
     <MaximumGroupParts>2</MaximumGroupParts>
     <NamespaceGrouping>False</NamespaceGrouping>
     <SyntaxFilters>C#, Managed C++</SyntaxFilters>
@@ -59,7 +59,7 @@
       <Filter entryType="Namespace" fullName="CefSharp.Wpf.Internals" isExposed="False" xmlns="" />
     </ApiFilter>
     <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
-    <HeaderText>Version 144.0.250</HeaderText>
+    <HeaderText>Version 144.0.260</HeaderText>
     <CopyrightHref>https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE</CopyrightHref>
     <NamespaceSummaries>
       <NamespaceSummaryItem name="CefSharp" isDocumented="True">Interfaces, enums, structs and classes that make up the core API interface</NamespaceSummaryItem>

--- a/CefSharp/DownloadItem.cs
+++ b/CefSharp/DownloadItem.cs
@@ -32,6 +32,11 @@ namespace CefSharp
         public bool IsCancelled { get; set; }
 
         /// <summary>
+        /// Returns true if the download has been paused.
+        /// </summary>
+        public bool IsPaused { get; set; }
+
+        /// <summary>
         /// Returns a simple speed estimate in bytes/s.
         /// </summary>
         public Int64 CurrentSpeed { get; set; }

--- a/CefSharp/IRequestContext.cs
+++ b/CefSharp/IRequestContext.cs
@@ -169,6 +169,13 @@ namespace CefSharp
         void ClearCertificateExceptions(ICompletionCallback callback);
 
         /// <summary>
+        /// Clears the HTTP cache.
+        /// </summary>
+        /// <param name="callback">If is non-NULL it will be executed on the CEF UI thread after
+        /// completion. This param is optional</param>
+        void ClearHttpCache(ICompletionCallback callback = null);
+
+        /// <summary>
         /// Clears all HTTP authentication credentials that were added as part of handling
         /// <see cref="IRequestHandler.GetAuthCredentials"/>.
         /// </summary>

--- a/CefSharp/Properties/AssemblyInfo.cs
+++ b/CefSharp/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ namespace CefSharp
         public const bool ComVisible = false;
         public const string AssemblyCompany = "The CefSharp Authors";
         public const string AssemblyProduct = "CefSharp";
-        public const string AssemblyVersion = "144.0.250";
-        public const string AssemblyFileVersion = "144.0.250.0";
+        public const string AssemblyVersion = "144.0.260";
+        public const string AssemblyFileVersion = "144.0.260.0";
         public const string AssemblyCopyright = "Copyright © 2026 The CefSharp Authors";
         public const string CefSharpCoreProject = "CefSharp.Core, PublicKey=" + PublicKey;
         public const string CefSharpBrowserSubprocessProject = "CefSharp.BrowserSubprocess, PublicKey=" + PublicKey;

--- a/NuGet/CefSharp.Common.app.config.x64.transform
+++ b/NuGet/CefSharp.Common.app.config.x64.transform
@@ -20,7 +20,7 @@
                 <!-- Add the codebase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->
-                <codeBase version="144.0.250.0" href="x64/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
+                <codeBase version="144.0.260.0" href="x64/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.Common.app.config.x86.transform
+++ b/NuGet/CefSharp.Common.app.config.x86.transform
@@ -20,7 +20,7 @@
                 <!-- Add the codebase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->
-                <codeBase version="144.0.250.0" href="x86/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
+                <codeBase version="144.0.260.0" href="x86/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/PackageReference/CefSharp.Common.NETCore.targets
+++ b/NuGet/PackageReference/CefSharp.Common.NETCore.targets
@@ -143,16 +143,16 @@
       <Choose>
         <When Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
           <ItemGroup>
-			<PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="144.0.25" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="144.0.25" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="144.0.25" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="144.0.26" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="144.0.26" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="144.0.26" />
           </ItemGroup>
         </When>
         <Otherwise>
           <ItemGroup>
-            <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="144.0.25" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="144.0.25" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="144.0.25" />
+            <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="144.0.26" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="144.0.26" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="144.0.26" />
           </ItemGroup>
         </Otherwise>
       </Choose>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ If you're new to `CefSharp` and are downloading the source to check it out, plea
 | Branch                                                                | CEF Version  | VC++ Version | .Net Version | Status |
 |-----------------------------------------------------------------------|------|-------|---------|-----------------|
 | [master](https://github.com/cefsharp/CefSharp/)                       | 7499 | 2022* | 4.6.2** | Development     |
-| [cefsharp/143](https://github.com/cefsharp/CefSharp/tree/cefsharp/143)| 7499 | 2022* | 4.6.2** | **Release**     |
+| [cefsharp/144](https://github.com/cefsharp/CefSharp/tree/cefsharp/144)| 7599 | 2022* | 4.6.2** | **Release**     |
+| [cefsharp/143](https://github.com/cefsharp/CefSharp/tree/cefsharp/143)| 7499 | 2022* | 4.6.2** | Unsupported     |
 | [cefsharp/141](https://github.com/cefsharp/CefSharp/tree/cefsharp/141)| 7390 | 2022* | 4.6.2** | Unsupported     |
 | [cefsharp/140](https://github.com/cefsharp/CefSharp/tree/cefsharp/140)| 7339 | 2022* | 4.6.2** | Unsupported     |
 | [cefsharp/139](https://github.com/cefsharp/CefSharp/tree/cefsharp/139)| 7258 | 2022* | 4.6.2** | Unsupported     |

--- a/UpdateNugetPackages.ps1
+++ b/UpdateNugetPackages.ps1
@@ -1,9 +1,9 @@
-#requires -Version 5
+﻿#requires -Version 5
 [CmdletBinding()]
 
 param(
 	[Parameter(Position = 1)]
-	[string] $CefVersion = "144.0.25",
+	[string] $CefVersion = "144.0.26",
 	[Parameter(Position = 2)]
 	[string] $CefSharpVersion = ""
 	)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 144.0.120-RCI{build}
+version: 144.0.260-RCI{build}
 
 clone_depth: 10
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,13 +1,13 @@
-#requires -Version 5
+﻿#requires -Version 5
 
 param(
     [ValidateSet("vs2022","vs2019", "nupkg-only", "update-build-version")]
     [Parameter(Position = 0)] 
     [string] $Target = "vs2022",
     [Parameter(Position = 1)]
-    [string] $Version = "144.0.250",
+    [string] $Version = "144.0.260",
     [Parameter(Position = 2)]
-    [string] $AssemblyVersion = "144.0.250",
+    [string] $AssemblyVersion = "144.0.260",
     [Parameter(Position = 3)]
     [ValidateSet("NetFramework", "NetCore")]
     [string] $TargetFramework = "NetFramework",


### PR DESCRIPTION
Fixes #5256 

**Summary:** Upgrade to v144.0.25+g27ce504+chromium-144.0.7559.250

**Changes:**
- Add the `DownloadItem.IsPause` property
- Add the `RequestContext.ClearHttpCache(callback)` method
- Use https://github.com/cefsharp/cef-binary/releases/tag/v144.0.26%2Bg8b05ce5%2Bchromium-144.0.7559.252 binaries
      
**How Has This Been Tested?**  

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - security update to Chromium 144.0.7559.252
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code (if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)
