### PR TITLE
Add `RequestContext.ClearHttpCache()` and `DownloadItem.IsPaused` from CEF SDK 144

### DIFF
--- a/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
+++ b/CefSharp.Core.Runtime.RefAssembly/CefSharp.Core.Runtime.netcore.cs
@@ -270,6 +270,7 @@ namespace CefSharp.Core
         public virtual bool IsGlobal { get { throw null; } }
         public virtual bool CanSetPreference(string name) { throw null; }
         public virtual void ClearCertificateExceptions(CefSharp.ICompletionCallback callback) { }
+        public virtual void ClearHttpCache(CefSharp.ICompletionCallback callback) { }
         public virtual void ClearHttpAuthCredentials(CefSharp.ICompletionCallback callback) { }
         public virtual bool ClearSchemeHandlerFactories() { throw null; }
         public virtual void CloseAllConnections(CefSharp.ICompletionCallback callback) { }

--- a/CefSharp.Core.Runtime/Internals/TypeConversion.h
+++ b/CefSharp.Core.Runtime/Internals/TypeConversion.h
@@ -58,6 +58,7 @@ namespace CefSharp
                     item->IsInProgress = downloadItem->IsInProgress();
                     item->IsComplete = downloadItem->IsComplete();
                     item->IsCancelled = downloadItem->IsCanceled();
+                    item->IsPaused = downloadItem->IsPaused();
                     item->CurrentSpeed = downloadItem->GetCurrentSpeed();
                     item->PercentComplete = downloadItem->GetPercentComplete();
                     item->TotalBytes = downloadItem->GetTotalBytes();

--- a/CefSharp.Core.Runtime/RequestContext.cpp
+++ b/CefSharp.Core.Runtime/RequestContext.cpp
@@ -126,6 +126,15 @@ namespace CefSharp
             _requestContext->ClearCertificateExceptions(wrapper);
         }
 
+        void RequestContext::ClearHttpCache(ICompletionCallback^ callback)
+        {
+            ThrowIfDisposed();
+
+            CefRefPtr<CefCompletionCallback> wrapper = callback == nullptr ? nullptr : new CefCompletionCallbackAdapter(callback);
+
+            _requestContext->ClearHttpCache(wrapper);
+        }
+
         void RequestContext::ClearHttpAuthCredentials(ICompletionCallback^ callback)
         {
             ThrowIfDisposed();

--- a/CefSharp.Core.Runtime/RequestContext.h
+++ b/CefSharp.Core.Runtime/RequestContext.h
@@ -283,6 +283,13 @@ namespace CefSharp
             virtual void ClearCertificateExceptions(ICompletionCallback^ callback);
 
             /// <summary>
+            /// Clears the HTTP cache.
+            /// </summary>
+            /// <param name="callback">If is non-NULL it will be executed on the CEF UI thread after
+            /// completion. This param is optional</param>
+            virtual void ClearHttpCache(ICompletionCallback^ callback);
+
+            /// <summary>
             /// Clears all HTTP authentication credentials that were added as part of handling
             /// <see cref="IRequestHandler::GetAuthCredentials"/>.
             /// </summary>

--- a/CefSharp.Core/RequestContext.cs
+++ b/CefSharp.Core/RequestContext.cs
@@ -181,6 +181,12 @@ namespace CefSharp
         }
 
         /// <inheritdoc/>
+        public void ClearHttpCache(ICompletionCallback callback = null)
+        {
+            requestContext.ClearHttpCache(callback);
+        }
+
+        /// <inheritdoc/>
         public void ClearHttpAuthCredentials(ICompletionCallback callback = null)
         {
             requestContext.ClearHttpAuthCredentials(callback);

--- a/CefSharp/DownloadItem.cs
+++ b/CefSharp/DownloadItem.cs
@@ -32,6 +32,11 @@ namespace CefSharp
         public bool IsCancelled { get; set; }
 
         /// <summary>
+        /// Returns true if the download has been paused.
+        /// </summary>
+        public bool IsPaused { get; set; }
+
+        /// <summary>
         /// Returns a simple speed estimate in bytes/s.
         /// </summary>
         public Int64 CurrentSpeed { get; set; }

--- a/CefSharp/IRequestContext.cs
+++ b/CefSharp/IRequestContext.cs
@@ -169,6 +169,13 @@ namespace CefSharp
         void ClearCertificateExceptions(ICompletionCallback callback);
 
         /// <summary>
+        /// Clears the HTTP cache.
+        /// </summary>
+        /// <param name="callback">If is non-NULL it will be executed on the CEF UI thread after
+        /// completion. This param is optional</param>
+        void ClearHttpCache(ICompletionCallback callback = null);
+
+        /// <summary>
         /// Clears all HTTP authentication credentials that were added as part of handling
         /// <see cref="IRequestHandler.GetAuthCredentials"/>.
         /// </summary>


### PR DESCRIPTION
**Summary:** 
- `IRequestContext.ClearHttpCache()` wraps the `CefRequestContext::ClearHttpCache()` method, allowing callers to clear the HTTP cache for a given request context.
- `DownloadItem.IsPaused` exposes the pause state of the downloaded item via `CefDownloadItem::IsPaused()`

**Changes:** 
- Add the `DownloadItem.IsPause` property
- Add the `RequestContext.ClearHttpCache(callback)` method
      
**How Has This Been Tested?**  

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP cache clearing capability to RequestContext with optional completion callback support for asynchronous operations.
  * Added pause state indicator property to DownloadItem to check download status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->