### PR TITLE
Upgrade to v144.0.27+g3fae261+chromium-144.0.7559.254

### DIFF
--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.netcore.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.27\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.27\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
+++ b/CefSharp.BrowserSubprocess.Core/CefSharp.BrowserSubprocess.Core.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.27\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.27\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.BrowserSubprocess.Core/Resource.rc
+++ b/CefSharp.BrowserSubprocess.Core/Resource.rc
@@ -1,8 +1,8 @@
 #pragma code_page(65001)
 
 1 VERSIONINFO
- FILEVERSION 144,0,260
- PRODUCTVERSION 144,0,260
+ FILEVERSION 144,0,270
+ PRODUCTVERSION 144,0,270
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -18,10 +18,10 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "CefSharp.BrowserSubprocess.Core"
-            VALUE "FileVersion", "144.0.260"
+            VALUE "FileVersion", "144.0.270"
             VALUE "LegalCopyright", "Copyright © 2026 The CefSharp Authors"
             VALUE "ProductName", "CefSharp"
-            VALUE "ProductVersion", "144.0.260"
+            VALUE "ProductVersion", "144.0.270"
         END
     END
     BLOCK "VarFileInfo"

--- a/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.26" targetFramework="native" />
+  <package id="cef.sdk" version="144.0.27" targetFramework="native" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.netcore.config
+++ b/CefSharp.BrowserSubprocess.Core/packages.CefSharp.BrowserSubprocess.Core.netcore.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.26" targetFramework="net6.0" />
+  <package id="cef.sdk" version="144.0.27" targetFramework="net6.0" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.BrowserSubprocess/app.manifest
+++ b/CefSharp.BrowserSubprocess/app.manifest
@@ -8,7 +8,7 @@
     xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.260.0" name="CefSharp.BrowserSubprocess.app" />
+  <assemblyIdentity version="144.0.270.0" name="CefSharp.BrowserSubprocess.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CefSharp.Core.Runtime/CefSharp.Core.Runtime.netcore.vcxproj
+++ b/CefSharp.Core.Runtime/CefSharp.Core.Runtime.netcore.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.27\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.27\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.Core.Runtime/CefSharp.Core.Runtime.vcxproj
+++ b/CefSharp.Core.Runtime/CefSharp.Core.Runtime.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\cef.sdk.144.0.26\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.26\build\cef.sdk.props')" />
+  <Import Project="..\packages\cef.sdk.144.0.27\build\cef.sdk.props" Condition="Exists('..\packages\cef.sdk.144.0.27\build\cef.sdk.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />

--- a/CefSharp.Core.Runtime/Resource.rc
+++ b/CefSharp.Core.Runtime/Resource.rc
@@ -1,8 +1,8 @@
 #pragma code_page(65001)
 
 1 VERSIONINFO
- FILEVERSION 144,0,260
- PRODUCTVERSION 144,0,260
+ FILEVERSION 144,0,270
+ PRODUCTVERSION 144,0,270
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -18,10 +18,10 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "CefSharp.Core"
-            VALUE "FileVersion", "144.0.260"
+            VALUE "FileVersion", "144.0.270"
             VALUE "LegalCopyright", "Copyright © 2026 The CefSharp Authors"
             VALUE "ProductName", "CefSharp"
-            VALUE "ProductVersion", "144.0.260"
+            VALUE "ProductVersion", "144.0.270"
         END
     END
     BLOCK "VarFileInfo"

--- a/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.config
+++ b/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.26" targetFramework="native" />
+  <package id="cef.sdk" version="144.0.27" targetFramework="native" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.netcore.config
+++ b/CefSharp.Core.Runtime/packages.CefSharp.Core.Runtime.netcore.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.sdk" version="144.0.26" targetFramework="net6.0" />
+  <package id="cef.sdk" version="144.0.27" targetFramework="net6.0" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.csproj
@@ -23,7 +23,7 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.netcore.csproj
+++ b/CefSharp.OffScreen.Example/CefSharp.OffScreen.Example.netcore.csproj
@@ -38,7 +38,7 @@
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.OffScreen\CefSharp.OffScreen.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.OffScreen.Example/app.manifest
+++ b/CefSharp.OffScreen.Example/app.manifest
@@ -7,7 +7,7 @@
   xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.260.0" name="CefSharp.OffScreen.Example.app" />
+  <assemblyIdentity version="144.0.270.0" name="CefSharp.OffScreen.Example.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CefSharp.Test/CefSharp.Test.csproj
+++ b/CefSharp.Test/CefSharp.Test.csproj
@@ -36,7 +36,7 @@
     <ItemGroup>
         <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
         <PackageReference Include="Bogus" Version="35.4.1" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.Test/CefSharp.Test.netcore.csproj
+++ b/CefSharp.Test/CefSharp.Test.netcore.csproj
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
     <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
     <PackageReference Include="Bogus" Version="35.4.1" />
-    <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+    <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.csproj
@@ -32,7 +32,7 @@
         <ProjectReference Include="..\CefSharp\CefSharp.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.WinForms.Example/CefSharp.WinForms.Example.netcore.csproj
+++ b/CefSharp.WinForms.Example/CefSharp.WinForms.Example.netcore.csproj
@@ -38,7 +38,7 @@
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.WinForms\CefSharp.WinForms.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.WinForms.Example/app.manifest
+++ b/CefSharp.WinForms.Example/app.manifest
@@ -8,7 +8,7 @@
     xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.260.0" name="CefSharp.WinForms.Example.app" />
+  <assemblyIdentity version="144.0.270.0" name="CefSharp.WinForms.Example.app" />
 
   <dependency>
     <dependentAssembly>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.csproj
@@ -31,7 +31,7 @@
         <Folder Include="Assets\Images\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>

--- a/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
+++ b/CefSharp.Wpf.Example/CefSharp.Wpf.Example.netcore.csproj
@@ -39,7 +39,7 @@
         <ProjectReference Include="..\CefSharp.Example\CefSharp.Example.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.Wpf.Example/app.manifest
+++ b/CefSharp.Wpf.Example/app.manifest
@@ -7,7 +7,7 @@
   xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <assemblyIdentity version="144.0.260.0" name="CefSharp.Wpf.Example.app" />
+  <assemblyIdentity version="144.0.270.0" name="CefSharp.Wpf.Example.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.csproj
+++ b/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.csproj
@@ -28,7 +28,7 @@
         <ProjectReference Include="..\CefSharp\CefSharp.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="MaterialDesignThemes" Version="4.8.0" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">

--- a/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.netcore.csproj
+++ b/CefSharp.Wpf.HwndHost.Example/CefSharp.Wpf.HwndHost.Example.netcore.csproj
@@ -40,7 +40,7 @@
         <ProjectReference Include="..\CefSharp.Core\CefSharp.Core.netcore.csproj" />
         <ProjectReference Include="..\CefSharp.Wpf\CefSharp.Wpf.netcore.csproj" />
         <ProjectReference Include="..\CefSharp\CefSharp.netcore.csproj" />
-        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.26" />
+        <PackageReference Include="chromiumembeddedframework.runtime" Version="144.0.27" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CefSharp.shfbproj
+++ b/CefSharp.shfbproj
@@ -31,7 +31,7 @@
       <DocumentationSource sourceFile="CefSharp.WinForms\CefSharp.WinForms.csproj" />
       <DocumentationSource sourceFile="CefSharp.Wpf\CefSharp.Wpf.csproj" />
     </DocumentationSources>
-    <HelpFileVersion>144.0.260</HelpFileVersion>
+    <HelpFileVersion>144.0.270</HelpFileVersion>
     <MaximumGroupParts>2</MaximumGroupParts>
     <NamespaceGrouping>False</NamespaceGrouping>
     <SyntaxFilters>C#, Managed C++</SyntaxFilters>
@@ -59,7 +59,7 @@
       <Filter entryType="Namespace" fullName="CefSharp.Wpf.Internals" isExposed="False" xmlns="" />
     </ApiFilter>
     <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, EditorBrowsableNever, NonBrowsable</VisibleItems>
-    <HeaderText>Version 144.0.260</HeaderText>
+    <HeaderText>Version 144.0.270</HeaderText>
     <CopyrightHref>https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE</CopyrightHref>
     <NamespaceSummaries>
       <NamespaceSummaryItem name="CefSharp" isDocumented="True">Interfaces, enums, structs and classes that make up the core API interface</NamespaceSummaryItem>

--- a/CefSharp/Properties/AssemblyInfo.cs
+++ b/CefSharp/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ namespace CefSharp
         public const bool ComVisible = false;
         public const string AssemblyCompany = "The CefSharp Authors";
         public const string AssemblyProduct = "CefSharp";
-        public const string AssemblyVersion = "144.0.260";
-        public const string AssemblyFileVersion = "144.0.260.0";
+        public const string AssemblyVersion = "144.0.270";
+        public const string AssemblyFileVersion = "144.0.270.0";
         public const string AssemblyCopyright = "Copyright © 2026 The CefSharp Authors";
         public const string CefSharpCoreProject = "CefSharp.Core, PublicKey=" + PublicKey;
         public const string CefSharpBrowserSubprocessProject = "CefSharp.BrowserSubprocess, PublicKey=" + PublicKey;

--- a/NuGet/CefSharp.Common.app.config.x64.transform
+++ b/NuGet/CefSharp.Common.app.config.x64.transform
@@ -20,7 +20,7 @@
                 <!-- Add the codebase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->
-                <codeBase version="144.0.260.0" href="x64/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
+                <codeBase version="144.0.270.0" href="x64/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/CefSharp.Common.app.config.x86.transform
+++ b/NuGet/CefSharp.Common.app.config.x86.transform
@@ -20,7 +20,7 @@
                 <!-- Add the codebase section if missing. -->
                 <codeBase xdt:Transform="InsertIfMissing"/>
                 <!-- Ensure the codeBase version and href are set to the correct values. -->
-                <codeBase version="144.0.260.0" href="x86/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
+                <codeBase version="144.0.270.0" href="x86/CefSharp.Core.Runtime.dll" xdt:Transform="Replace"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/NuGet/PackageReference/CefSharp.Common.NETCore.targets
+++ b/NuGet/PackageReference/CefSharp.Common.NETCore.targets
@@ -143,16 +143,16 @@
       <Choose>
         <When Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
           <ItemGroup>
-			<PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="144.0.26" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="144.0.26" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="144.0.26" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-x64" VersionOverride="144.0.27" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" VersionOverride="144.0.27" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" VersionOverride="144.0.27" />
           </ItemGroup>
         </When>
         <Otherwise>
           <ItemGroup>
-            <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="144.0.26" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="144.0.26" />
-			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="144.0.26" />
+            <PackageReference Include="chromiumembeddedframework.runtime.win-x64" Version="144.0.27" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-x86" Version="144.0.27" />
+			<PackageReference Include="chromiumembeddedframework.runtime.win-arm64" Version="144.0.27" />
           </ItemGroup>
         </Otherwise>
       </Choose>

--- a/UpdateNugetPackages.ps1
+++ b/UpdateNugetPackages.ps1
@@ -3,7 +3,7 @@
 
 param(
 	[Parameter(Position = 1)]
-	[string] $CefVersion = "144.0.26",
+	[string] $CefVersion = "144.0.27",
 	[Parameter(Position = 2)]
 	[string] $CefSharpVersion = ""
 	)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 144.0.260-RCI{build}
+version: 144.0.270-RCI{build}
 
 clone_depth: 10
 

--- a/build.ps1
+++ b/build.ps1
@@ -5,9 +5,9 @@ param(
     [Parameter(Position = 0)] 
     [string] $Target = "vs2022",
     [Parameter(Position = 1)]
-    [string] $Version = "144.0.260",
+    [string] $Version = "144.0.270",
     [Parameter(Position = 2)]
-    [string] $AssemblyVersion = "144.0.260",
+    [string] $AssemblyVersion = "144.0.270",
     [Parameter(Position = 3)]
     [ValidateSet("NetFramework", "NetCore")]
     [string] $TargetFramework = "NetFramework",


### PR DESCRIPTION
**Fixes:** #5256

**Summary:** Upgrade to v144.0.27+g3fae261+chromium-144.0.7559.254

This is a security update to Chromium 144.0.7559.254. Chromium v144 is a Long Term Support (LTS) branch.

**Changes:**
- Use https://github.com/cefsharp/cef-binary/releases/tag/v144.0.27%2Bg3fae261%2Bchromium-144.0.7559.254 binaries

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue) — security update to Chromium 144.0.7559.254
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code (if applicable)
- [x] Commented my code
- [ ] Changed the documentation (if applicable)
- [x] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)

---

## Security Fixes

This release includes selected security fixes including:

- 501576946 High [CVE-2026-9934](https://nvd.nist.gov/vuln/detail/CVE-2026-9934): Use after free in Aura.
- 491685406 High [CVE-2026-9895](https://nvd.nist.gov/vuln/detail/CVE-2026-9895): Out of bounds read in GPU.
- 511776372 High [CVE-2026-9980](https://nvd.nist.gov/vuln/detail/CVE-2026-9980): Insufficient validation of untrusted input in Printing.
- 513730012 High [CVE-2026-10004](https://nvd.nist.gov/vuln/detail/CVE-2026-10004): Insufficient validation of untrusted input in Passwords.
- 514715455 High [CVE-2026-10013](https://nvd.nist.gov/vuln/detail/CVE-2026-10013): Use after free in WebCodecs.
- 507707838 High [CVE-2026-9894](https://nvd.nist.gov/vuln/detail/CVE-2026-9894): Use after free in GPU.
- 513177826 High [CVE-2026-9992](https://nvd.nist.gov/vuln/detail/CVE-2026-9992): Use after free in Network.
- 498205735 High [CVE-2026-9902](https://nvd.nist.gov/vuln/detail/CVE-2026-9902): Use after free in Accessibility.
- 478560268 High [CVE-2026-2314](https://nvd.nist.gov/vuln/detail/CVE-2026-2314): Heap buffer overflow in Codecs.
- 499119490 High [CVE-2026-7351](https://nvd.nist.gov/vuln/detail/CVE-2026-7351): Race in MHTML.
- 511249104 Critical [CVE-2026-9887](https://nvd.nist.gov/vuln/detail/CVE-2026-9887): Use after free in Proxy.
- 507365348 Critical [CVE-2026-9873](https://nvd.nist.gov/vuln/detail/CVE-2026-9873): Use after free in Network.
- 491080830 Medium [CVE-2026-4462](https://nvd.nist.gov/vuln/detail/CVE-2026-4462): Out of bounds read in Blink.
- 513505927 High [CVE-2026-10001](https://nvd.nist.gov/vuln/detail/CVE-2026-10001): Use after free in PerformanceManager.
- 513508128 Critical [CVE-2026-9891](https://nvd.nist.gov/vuln/detail/CVE-2026-9891): Use after free in Extensions.


**References:**
- [Chrome Releases — Long-term support channel update](https://chromereleases.googleblog.com/2026/06/long-term-support-channel-update-for.html)
- CEF Build: chromiumembedded/cef#4179
