### PR TITLE
Update cef references from bitbucket to github

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ Please ask your questions under the Discussions section here on GitHub
 
 ---
 
-`CefSharp` is a wrapper around the [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef/overview) in a lot of cases a feature must be added to `CEF` first before it can be used in `CefSharp`. `CEF` has its own `Feature Request Forum` at https://magpcss.org/ceforum/viewforum.php?f=7
+`CefSharp` is a wrapper around the [Chromium Embedded Framework](https://github.com/chromiumembedded/cef) in a lot of cases a feature must be added to `CEF` first before it can be used in `CefSharp`. `CEF` has its own `Feature Request Forum` at https://magpcss.org/ceforum/viewforum.php?f=7
 
 --- 
 
@@ -28,4 +28,4 @@ Add any other context or screenshots about the feature request here.
 **Checklist:**
 - [ ] I have reviewed the [CEF API](https://magpcss.org/ceforum/apidocs3/index-all.html) and have confirmed the feature I'm requesting is possible.
 - [ ] The Feature I'm requesting is an improvement to Async Javascript Binding (No new feature are being added to the Sync Javascript binding)
-- [ ] An open `PR` exists on the [CEF Pull Requests](https://bitbucket.org/chromiumembedded/cef/pull-requests/) and I'd like to propose this feature is added to `CefSharp` when/if it's merged.
+- [ ] An open `PR` exists on the [CEF Pull Requests](https://github.com/chromiumembedded/cef/pulls) and I'd like to propose this feature is added to `CefSharp` when/if it's merged.

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -9,7 +9,7 @@ newIssueWelcomeComment: >
   <br/>
   <br/>
   It's also important to remember that `CefSharp` is just a wrapper around the `Chromium Embedded Framework(CEF)`, a lot of questions people
-  have aren't actually `CefSharp` specific, they're generic to `CEF` and for those `CEF` has it's own support forum at http://magpcss.org/ceforum/index.php and issue tracker at https://bitbucket.org/chromiumembedded/cef
+  have aren't actually `CefSharp` specific, they're generic to `CEF` and for those `CEF` has it's own support forum at http://magpcss.org/ceforum/index.php and issue tracker at https://github.com/chromiumembedded/cef/issues
   <br/>
   <br/>
   

--- a/CefSharp.Core.Runtime/Internals/RenderClientAdapter.h
+++ b/CefSharp.Core.Runtime/Internals/RenderClientAdapter.h
@@ -56,7 +56,7 @@ namespace CefSharp
 
                 //NOTE:  If ScreenInfo is returned as null,  the screen_info available and rect structs would remain default (0,0,0,0).  If so, the underlying CEF library would use 
                 // GetViewRect to populate values in the window.screen object (javascript).
-                //https://bitbucket.org/chromiumembedded/cef/src/47e6d4bf84444eb6cb4d4509231a8c9ee878a584/include/cef_render_handler.h?at=2357#cef_render_handler.h-90
+                //https://github.com/chromiumembedded/cef/blob/47e6d4bf84444eb6cb4d4509231a8c9ee878a584/include/cef_render_handler.h#L90
                 if (screenInfo.HasValue == false)
                 {
                     return false;

--- a/CefSharp.Example/CefExample.cs
+++ b/CefSharp.Example/CefExample.cs
@@ -61,7 +61,7 @@ namespace CefSharp.Example
             //http://peter.sh/experiments/chromium-command-line-switches/
             //NOTE: Not all relevant in relation to `CefSharp`, use for reference purposes only.
             //CEF specific command line args
-            //https://bitbucket.org/chromiumembedded/cef/src/master/libcef/common/cef_switches.cc?fileviewer=file-view-default
+            //https://github.com/chromiumembedded/cef/blob/master/libcef/common/cef_switches.cc
 
             //**IMPORTANT**: For enabled/disabled command line arguments like disable-gpu specifying a value of "0" like
             //settings.CefCommandLineArgs.Add("disable-gpu", "0"); will have no effect as the second argument is ignored.
@@ -104,7 +104,7 @@ namespace CefSharp.Example
             // `--disable-gpu --disable-gpu-compositing --enable-begin-frame-scheduling`
             // (you'll loose WebGL support but gain increased FPS and reduced CPU usage).
             // http://magpcss.org/ceforum/viewtopic.php?f=6&t=13271#p27075
-            //https://bitbucket.org/chromiumembedded/cef/commits/e3c1d8632eb43c1c2793d71639f3f5695696a5e8
+            //https://github.com/chromiumembedded/cef/commit/e3c1d8632eb43c1c2793d71639f3f5695696a5e8
 
             //NOTE: The following function will set all three params
             //settings.SetOffScreenRenderingBestPerformanceArgs();

--- a/CefSharp.Example/Resources/CdmSupportTest.html
+++ b/CefSharp.Example/Resources/CdmSupportTest.html
@@ -81,7 +81,7 @@
                 Use of proprietary codecs (such as H.264) requires a custom build of CEF to be used due to 
                 licensing requirements.<br />
                 Details on how to build the CEF project and other resources can be 
-                <a href="https://bitbucket.org/chromiumembedded/cef">found here</a>.</li>
+                <a href="https://github.com/chromiumembedded/cef">found here</a>.</li>
         </ul>
     </p>
 </body>

--- a/CefSharp.Example/Resources/Home.html
+++ b/CefSharp.Example/Resources/Home.html
@@ -98,7 +98,7 @@
                             </li>
                             <li>
                                 <strong>
-                                    Built on top of <a href="https://bitbucket.org/chromiumembedded/cef">CEF</a>,
+                                    Built on top of <a href="https://github.com/chromiumembedded/cef">CEF</a>,
                                 </strong> the Chromium Embedded Framework by Marshall A. Greenblatt.
                             </li>
                             <li>
@@ -196,7 +196,7 @@
                     <h3>State-of-the-art HTML5 and Javascript support</h3>
                     <p>
                         Perhaps very obvious, but still worth mentioning. Since CefSharp is based on
-                        <a href="https://bitbucket.org/chromiumembedded/cef">CEF</a>, which is in turn based on
+                        <a href="https://github.com/chromiumembedded/cef">CEF</a>, which is in turn based on
                         <a href="http://www.chromium.org/Home">Chromium</a> (version 43 for the time being), CefSharp provides
                         one of the best HTML5 rendering experiences available -
                         <a href="http://html5test.com/compare/browser/mybrowser/chrome-41/chrome-43/ie-11.html">

--- a/CefSharp.WinForms.Example/Handlers/ScheduleMessagePumpBrowserProcessHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/ScheduleMessagePumpBrowserProcessHandler.cs
@@ -17,7 +17,7 @@ namespace CefSharp.WinForms.Example.Handlers
     /// that it needs to perform work.
     /// See the following link for the CEF reference implementation that containes a more complex example that maybe
     /// required in some circumstances.
-    /// https://bitbucket.org/chromiumembedded/cef/commits/1ff26aa02a656b3bc9f0712591c92849c5909e04?at=2785
+    /// https://github.com/chromiumembedded/cef/commit/1ff26aa02a656b3bc9f0712591c92849c5909e04
     /// </summary>
     public class ScheduleMessagePumpBrowserProcessHandler : BrowserProcessHandler
     {

--- a/CefSharp.WinForms.Example/Handlers/WinFormsBrowserProcessHandler.cs
+++ b/CefSharp.WinForms.Example/Handlers/WinFormsBrowserProcessHandler.cs
@@ -14,7 +14,7 @@ namespace CefSharp.WinForms.Example.Handlers
     /// The timer fires roughly <see cref="BrowserProcessHandler.SixtyTimesPerSecond"/>
     /// times per second calling  Cef.DoMessageLoopWork on the WinForms UI Thread.
     /// See the following link for the CEF reference implementation.
-    /// https://bitbucket.org/chromiumembedded/cef/commits/1ff26aa02a656b3bc9f0712591c92849c5909e04?at=2785
+    /// https://github.com/chromiumembedded/cef/commit/1ff26aa02a656b3bc9f0712591c92849c5909e04
     /// </summary>
     public class WinFormsBrowserProcessHandler : BrowserProcessHandler
     {

--- a/CefSharp.Wpf.Example/Handlers/WpfBrowserProcessHandler.cs
+++ b/CefSharp.Wpf.Example/Handlers/WpfBrowserProcessHandler.cs
@@ -12,7 +12,7 @@ namespace CefSharp.Wpf.Example.Handlers
     /// <summary>
     /// EXPERIMENTAL - this implementation is very simplistic and not ready for production use
     /// See the following link for the CEF reference implementation.
-    /// https://bitbucket.org/chromiumembedded/cef/commits/1ff26aa02a656b3bc9f0712591c92849c5909e04?at=2785
+    /// https://github.com/chromiumembedded/cef/commit/1ff26aa02a656b3bc9f0712591c92849c5909e04
     /// </summary>
     public class WpfBrowserProcessHandler : BrowserProcessHandler
     {

--- a/CefSharp.Wpf.HwndHost.Example/crash_reporter.cfg
+++ b/CefSharp.Wpf.HwndHost.Example/crash_reporter.cfg
@@ -2,7 +2,7 @@
 # "crash_reporter.cfg".
 # This file **must** be placed next to the main application executable. 
 # Comments start with a hash character and must be on their own line.
-# See https://bitbucket.org/chromiumembedded/cef/wiki/CrashReporting.md
+# See https://chromiumembedded.github.io/cef/crash_reporting
 # for further details
 
 [Config]

--- a/CefSharp.Wpf/HwndHost/Handler/IntegratedMessageLoopBrowserProcessHandler.cs
+++ b/CefSharp.Wpf/HwndHost/Handler/IntegratedMessageLoopBrowserProcessHandler.cs
@@ -14,7 +14,7 @@ namespace CefSharp.Wpf.HwndHost.Handler
     /// integreate CEF into the WPF message loop (Dispatcher).
     /// Currently it's a very basic implementation.
     /// See the following link for the CEF reference implementation.
-    /// https://bitbucket.org/chromiumembedded/cef/commits/1ff26aa02a656b3bc9f0712591c92849c5909e04?at=2785
+    /// https://github.com/chromiumembedded/cef/commit/1ff26aa02a656b3bc9f0712591c92849c5909e04
     /// </summary>
     public class IntegratedMessageLoopBrowserProcessHandler
         : BrowserProcessHandler

--- a/CefSharp/Enums/CefRuntimeStyle.cs
+++ b/CefSharp/Enums/CefRuntimeStyle.cs
@@ -7,7 +7,7 @@ namespace CefSharp
     /// runtime provides less default browser functionality but adds additional
     /// client callbacks and support for windowless (off-screen) rendering. For
     /// additional comparative details on runtime types see
-    /// https://bitbucket.org/chromiumembedded/cef/wiki/Architecture.md#markdown-header-cef3
+    /// https://chromiumembedded.github.io/cef/architecture#cef3
     ///
     /// Each runtime is composed of a bootstrap component and a style component.
     /// The style component is individually

--- a/CefSharp/Handler/ILifeSpanHandler.cs
+++ b/CefSharp/Handler/ILifeSpanHandler.cs
@@ -42,7 +42,7 @@ namespace CefSharp
         /// WinForms - To host the popup (browser) in a TAB/Custom Window see https://github.com/cefsharp/CefSharp/wiki/General-Usage#winforms---hosting-popup-using-tab-control for an easy method.
         /// WPF - For an example of hosting the popup (browser) in a custom window see https://github.com/cefsharp/CefSharp/wiki/General-Usage#wpf---hosting-popup-in-new-window-experimental
         /// Same can be applied for hosting the popup in a TAB.
-        /// This method is still EXPERIMENTAL and will likely require upstream bug fixes in CEF (https://bitbucket.org/chromiumembedded/cef).
+        /// This method is still EXPERIMENTAL and will likely require upstream bug fixes in CEF (https://github.com/chromiumembedded/cef).
         /// </remarks>
         bool OnBeforePopup(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string targetUrl, string targetFrameName, WindowOpenDisposition targetDisposition, bool userGesture, IPopupFeatures popupFeatures, IWindowInfo windowInfo, IBrowserSettings browserSettings, ref bool noJavascriptAccess, out IWebBrowser newBrowser);
 

--- a/CefSharp/Handler/LifeSpanHandler.cs
+++ b/CefSharp/Handler/LifeSpanHandler.cs
@@ -167,7 +167,7 @@ namespace CefSharp.Handler
         /// WinForms - To host the popup (browser) in a TAB/Custom Window see https://github.com/cefsharp/CefSharp/wiki/General-Usage#winforms---hosting-popup-using-tab-control for an easy method.
         /// WPF - For an example of hosting the popup (browser) in a custom window see https://github.com/cefsharp/CefSharp/wiki/General-Usage#wpf---hosting-popup-in-new-window-experimental
         /// Same can be applied for hosting the popup in a TAB.
-        /// This method is still EXPERIMENTAL and will likely require upstream bug fixes in CEF (https://bitbucket.org/chromiumembedded/cef).
+        /// This method is still EXPERIMENTAL and will likely require upstream bug fixes in CEF (https://github.com/chromiumembedded/cef).
         /// </remarks>
         protected virtual bool OnBeforePopup(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string targetUrl, string targetFrameName, WindowOpenDisposition targetDisposition, bool userGesture, IPopupFeatures popupFeatures, IWindowInfo windowInfo, IBrowserSettings browserSettings, ref bool noJavascriptAccess, out IWebBrowser newBrowser)
         {

--- a/CefSharp/RequestContextExtensions.cs
+++ b/CefSharp/RequestContextExtensions.cs
@@ -219,7 +219,7 @@ namespace CefSharp
 
             if (!ProxySchemes.Contains(scheme.ToLower()))
             {
-                throw new ArgumentException("Invalid Scheme, see https://bitbucket.org/chromiumembedded/cef/wiki/GeneralUsage.md#markdown-header-proxy-resolution for a list of valid schemes.", "scheme");
+                throw new ArgumentException("Invalid Scheme, see https://chromiumembedded.github.io/cef/general_usage#proxy-resolution for a list of valid schemes.", "scheme");
             }
 
             if (string.IsNullOrWhiteSpace(host))

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -228,7 +228,7 @@ namespace CefSharp
 
         void IResourceHandler.Cancel()
         {
-            // Prior to Prior to https://github.com/chromiumembedded/cef/commit/90301bdb7fd0b32137c221f38e8785b3a8ad8aa4
+            // Prior to https://github.com/chromiumembedded/cef/commit/90301bdb7fd0b32137c221f38e8785b3a8ad8aa4
             // This method was unexpectedly being called during Read (from a different thread),
             // changes to the threading model were made and I haven't confirmed if this is still
             // the case.

--- a/CefSharp/ResourceHandler.cs
+++ b/CefSharp/ResourceHandler.cs
@@ -228,7 +228,7 @@ namespace CefSharp
 
         void IResourceHandler.Cancel()
         {
-            // Prior to Prior to https://bitbucket.org/chromiumembedded/cef/commits/90301bdb7fd0b32137c221f38e8785b3a8ad8aa4
+            // Prior to Prior to https://github.com/chromiumembedded/cef/commit/90301bdb7fd0b32137c221f38e8785b3a8ad8aa4
             // This method was unexpectedly being called during Read (from a different thread),
             // changes to the threading model were made and I haven't confirmed if this is still
             // the case.

--- a/NuGet/PackageReference/Readme.txt
+++ b/NuGet/PackageReference/Readme.txt
@@ -1,7 +1,7 @@
 CefSharp .Net 6.0+ Nuget Package
 
 Background:
-  CefSharp is a .Net wrapping library for CEF (Chromium Embedded Framework) https://bitbucket.org/chromiumembedded/cef
+  CefSharp is a .Net wrapping library for CEF (Chromium Embedded Framework) https://github.com/chromiumembedded/cef
   CEF is a C/C++ library that allows developers to embed the HTML content rendering strengths of Google's Chrome open source WebKit engine (Chromium).
 
 Post Installation:

--- a/NuGet/Readme.txt
+++ b/NuGet/Readme.txt
@@ -1,7 +1,7 @@
 CefSharp Nuget Package
 
 Background:
-  CefSharp is a .Net wrapping library for CEF (Chromium Embedded Framework) https://bitbucket.org/chromiumembedded/cef
+  CefSharp is a .Net wrapping library for CEF (Chromium Embedded Framework) https://github.com/chromiumembedded/cef
   CEF is a C/C++ library that allows developers to embed the HTML content rendering strengths of Google's Chrome open source WebKit engine (Chromium).
 
 Post Installation:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Got a quick question? [Discussions](https://github.com/cefsharp/CefSharp/discussions) here on `GitHub` is the preferred place to ask!
 
-[CefSharp](https://cefsharp.github.io/) lets you embed Chromium in .NET apps. It is a lightweight .NET wrapper around the [Chromium Embedded Framework (CEF)](https://bitbucket.org/chromiumembedded/cef) by Marshall A. Greenblatt. About 30% of the bindings are written in C++/CLI with the majority of code here is C#. It can be used from C# or VB, or any other CLR language. CefSharp provides both WPF and WinForms web browser control implementations.
+[CefSharp](https://cefsharp.github.io/) lets you embed Chromium in .NET apps. It is a lightweight .NET wrapper around the [Chromium Embedded Framework (CEF)](https://github.com/chromiumembedded/cef) by Marshall A. Greenblatt. About 30% of the bindings are written in C++/CLI with the majority of code here is C#. It can be used from C# or VB, or any other CLR language. CefSharp provides both WPF and WinForms web browser control implementations.
 
 CefSharp is [BSD](https://opensource.org/licenses/BSD-3-Clause "BSD License") licensed, so it can be used in both proprietary and free/open source applications. For the full details, see the [LICENSE](LICENSE) file. 
 


### PR DESCRIPTION
To me it looks like everything for cef is now on github (issues / PRs / docs).

**Summary:**
   - Updates all cef link references from bitbucket to github

**Changes:**
   - Direct PR / issue reference have not been update but everything else like
     - commits
     - docs
      
**How Has This Been Tested?**  
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, operating system, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CEF and CefSharp links throughout the project from Bitbucket to current GitHub or documentation destinations.
  * Refreshed links in issue templates, welcome messages, examples, package readmes, API documentation, and project guidance.
  * Updated an exception message to reference the current CEF documentation URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->