### PR TITLE
Core - OnSelectClientCertificate own the copied certificate vector

### DIFF
--- a/CefSharp.Core.Runtime/Internals/CefCertificateCallbackWrapper.h
+++ b/CefSharp.Core.Runtime/Internals/CefCertificateCallbackWrapper.h
@@ -19,11 +19,19 @@ namespace CefSharp
         {
         private:
             MCefRefPtr<CefSelectClientCertificateCallback> _callback;
-            const CefRequestHandler::X509CertificateList& _certificateList;
+            // Owned copy of the certificates Chromium offered, not a reference to the caller's.
+            // ClientAdapter::OnSelectClientCertificate builds that list as a stack local, so a
+            // reference to it dangles the moment the handler returns. CEF permits calling Select
+            // "either in this method or at a later time", so a wrapper that outlives the handler
+            // has to own the list it selects from, or a deferred Select reads freed memory.
+            // A ref class cannot hold a std::vector by value, hence the pointer. Copying the
+            // vector copies the reference-counted CefX509Certificate pointers, and those
+            // references are what keep the certificates themselves alive.
+            CefRequestHandler::X509CertificateList* _certificateList;
 
         public:
             CefCertificateCallbackWrapper(CefRefPtr<CefSelectClientCertificateCallback>& callback, const CefRequestHandler::X509CertificateList& certificates)
-                : _callback(callback), _certificateList(certificates)
+                : _callback(callback), _certificateList(new CefRequestHandler::X509CertificateList(certificates))
             {
 
             }
@@ -31,6 +39,9 @@ namespace CefSharp
             !CefCertificateCallbackWrapper()
             {
                 _callback = nullptr;
+
+                delete _certificateList;
+                _certificateList = nullptr;
             }
 
             ~CefCertificateCallbackWrapper()
@@ -53,8 +64,8 @@ namespace CefSharp
                     auto certThumbprint = cert->Thumbprint;
 
                     std::vector<CefRefPtr<CefX509Certificate>>::const_iterator it =
-                        _certificateList.begin();
-                    for (; it != _certificateList.end(); ++it)
+                        _certificateList->begin();
+                    for (; it != _certificateList->end(); ++it)
                     {
                         auto bytes((*it)->GetDEREncoded());
                         auto byteSize = bytes->GetSize();

--- a/CefSharp.Core.Runtime/Internals/CefCertificateCallbackWrapper.h
+++ b/CefSharp.Core.Runtime/Internals/CefCertificateCallbackWrapper.h
@@ -19,14 +19,14 @@ namespace CefSharp
         {
         private:
             MCefRefPtr<CefSelectClientCertificateCallback> _callback;
-            // Owned copy of the certificates Chromium offered, not a reference to the caller's.
-            // ClientAdapter::OnSelectClientCertificate builds that list as a stack local, so a
-            // reference to it dangles the moment the handler returns. CEF permits calling Select
-            // "either in this method or at a later time", so a wrapper that outlives the handler
-            // has to own the list it selects from, or a deferred Select reads freed memory.
-            // A ref class cannot hold a std::vector by value, hence the pointer. Copying the
-            // vector copies the reference-counted CefX509Certificate pointers, and those
-            // references are what keep the certificates themselves alive.
+            // Owned copy of the certificates Chromium offered, not a reference to the caller's list.
+            // That list belongs to CEF for the duration of ClientAdapter::OnSelectClientCertificate,
+            // and this wrapper deliberately outlives that call - CEF allows Select to be called
+            // "either in this method or at a later time" - so a reference would dangle the moment
+            // the handler returns and a deferred Select would read freed memory.
+            // A ref class cannot hold a std::vector by value, hence the pointer. Copying the vector
+            // copies the reference-counted CefX509Certificate pointers, and those references are
+            // what keep the certificates themselves alive.
             CefRequestHandler::X509CertificateList* _certificateList;
 
         public:

--- a/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
+++ b/CefSharp.Core.Runtime/Internals/ClientAdapter.cpp
@@ -764,8 +764,6 @@ namespace CefSharp
             auto browserWrapper = GetBrowserWrapper(browser->GetIdentifier(), browser->IsPopup());
 
             auto list = gcnew X509Certificate2Collection();
-            // Create a copy of the vector in an attempt to fix #2948
-            CefRequestHandler::X509CertificateList certs;
 
             std::vector<CefRefPtr<CefX509Certificate> >::const_iterator it =
                 certificates.begin();
@@ -780,11 +778,11 @@ namespace CefSharp
                 bytes->GetData(static_cast<void*>(src), byteSize, 0);
                 auto cert = gcnew X509Certificate2(bufferByte);
                 list->Add(cert);
-
-                certs.push_back(*it);
             }
 
-            auto callbackWrapper = gcnew CefCertificateCallbackWrapper(callback, certs);
+            // Passed straight through. The wrapper takes its own reference to each certificate, so
+            // there is no need to copy the vector here.
+            auto callbackWrapper = gcnew CefCertificateCallbackWrapper(callback, certificates);
 
             return handler->OnSelectClientCertificate(
                 _browserControl, browserWrapper, isProxy,


### PR DESCRIPTION
**Fixes:** #2948

**Summary:**
   - `ISelectClientCertificateCallback.Select` still throws when called after `OnSelectClientCertificate` has returned, so the deferred form documented by CEF ("Return true and call `CefSelectClientCertificateCallback::Select` either in this method or at a later time") cannot be used
   - #2948 was closed on the basis that [there had been no reports since a51cdd37](https://github.com/cefsharp/CefSharp/issues/2948#issuecomment-1848819486), with an invitation to reopen if it still reproduced. It does, on v144.0.270, and `CefCertificateCallbackWrapper.h` is unchanged on master
   - The [2021 diagnosis on that issue](https://github.com/cefsharp/CefSharp/issues/2948#issuecomment-757356471) — *"It sounds like the vector is being freed. We can possibly copy the vector to resolve this (assuming the CefRefPtr instances are valid)"* — was correct. a51cdd37 makes the copy, but `CefCertificateCallbackWrapper` stores it as `const X509CertificateList&` and the copy is a local in `ClientAdapter::OnSelectClientCertificate`, so it is destroyed when the handler returns, exactly as the original was
   - Answering inside the handler works, which is likely why no further reports followed. [@thracx's workaround on that issue](https://github.com/cefsharp/CefSharp/issues/2948#issuecomment-759496971), removing `InvokeOnUiThreadIfRequired` so the certificate is selected on the handler's own thread, is the same observation from the other direction

**Changes:** [specify the structures changed]
   - I have modified `CefCertificateCallbackWrapper`
      - Owns a heap copy of the certificate list instead of holding `const CefRequestHandler::X509CertificateList&`
      - Allocated in the constructor initializer and deleted in the finalizer, following the ownership pattern already used by `BrowserSettings`, `CefSettingsBase`, `RequestContextSettings` and `WindowInfo`
      - `Select` iterates via the pointer
   - Copying the vector copies the reference-counted `CefX509Certificate` pointers, which is what keeps the certificates alive. A ref class cannot hold a `std::vector` (or a smart pointer) by value, which is why the field was a reference to begin with
   - No signature change, and no behaviour change for callers that answer inside the handler

**How Has This Been Tested?**
Built the NETCore packages for x86 and x64 from the v144.0.270 tag with this change, on VS2022 / Windows 10, and loaded servers that require a client certificate and servers that merely request one.

Deferred path, the failing case: held the callback, returned `true` from `OnSelectClientCertificate`, then called `Select` afterwards from another thread.
   - Before: the process died inside the thumbprint comparison loop.
   - After: the chosen certificate is presented on the still-suspended request and the server accepts it.

Also re-checked the two paths that already worked, both unchanged: calling `Select` inside the handler, and calling `Select(nullptr)` to continue without a certificate.

**Screenshots (if appropriate):**

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
- [x] Tested the code(if applicable)
- [x] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)

One point worth a maintainer's opinion: with deferral working, `Select` becomes reachable from a thread other than the CEF UI thread. The header's "or at a later time" wording reads as intended, and it works in practice, but if `Select` is meant to be UI-thread-only then that is worth documenting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate selection reliability by preserving the available certificate list throughout the selection process.
  * Prevented potential issues caused by accessing certificate data after its original source was released.
  * Ensured certificate options remain available while the selection callback completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->