### PR TITLE
docs: fix typo avaliable -> available

### DIFF
--- a/CefSharp.Example/Filters/PassThruResponseFilter.cs
+++ b/CefSharp.Example/Filters/PassThruResponseFilter.cs
@@ -41,7 +41,7 @@ namespace CefSharp.Example.Filters
             dataIn.Read(readBytes, 0, readBytes.Length);
             dataOut.Write(readBytes, 0, readBytes.Length);
 
-            //If we read less than the total amount avaliable then we need
+            //If we read less than the total amount available then we need
             //return FilterStatus.NeedMoreData so we can then write the rest
             if (dataInRead < dataIn.Length)
             {


### PR DESCRIPTION
Corrects the misspelling `avaliable` -> `available` in `CefSharp.Example/Filters/PassThruResponseFilter.cs`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in an internal code comment.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->