### PR TITLE
Copy arm64 files for AnyCpu builds

### DIFF
--- a/NuGet/CefSharp.Common.targets
+++ b/NuGet/CefSharp.Common.targets
@@ -118,6 +118,7 @@
     <CefSharpTargetDir Condition="'$(CefSharpTargetDir)' != '' AND !HasTrailingSlash('$(CefSharpTargetDir)')">$(CefSharpTargetDir)\</CefSharpTargetDir>
     <CefSharpTargetDirAnyCpu32>$(CefSharpTargetDir)x86\</CefSharpTargetDirAnyCpu32>
     <CefSharpTargetDirAnyCpu64>$(CefSharpTargetDir)x64\</CefSharpTargetDirAnyCpu64>
+    <CefSharpTargetDirAnyCpuArm64>$(CefSharpTargetDir)arm64\</CefSharpTargetDirAnyCpuArm64>
     <!--
     For Sdk Projects the PlatformTarget is unreliable (https://github.com/dotnet/sdk/issues/1560)
     When our targets file is imported $(PlatformTarget) will be x86 when the Platform is infact AnyCPU.
@@ -232,6 +233,12 @@
               <PublishState>Included</PublishState>
               <Visible>false</Visible>
             </None>
+            <None Include="@(CefRedistArm64)">
+              <Link>$(CefSharpTargetDirAnyCpuArm64)%(RecursiveDir)%(FileName)%(Extension)</Link>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+              <PublishState>Included</PublishState>
+              <Visible>false</Visible>
+            </None>
             <None Include="@(CefSharpCommonBinaries32)">
               <Link>$(CefSharpTargetDirAnyCpu32)%(RecursiveDir)%(FileName)%(Extension)</Link>
               <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -240,6 +247,12 @@
             </None>
             <None Include="@(CefSharpCommonBinaries64)">
               <Link>$(CefSharpTargetDirAnyCpu64)%(RecursiveDir)%(FileName)%(Extension)</Link>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+              <PublishState>Included</PublishState>
+              <Visible>false</Visible>
+            </None>
+            <None Include="@(CefSharpCommonBinariesArm64)">
+              <Link>$(CefSharpTargetDirAnyCpuArm64)%(RecursiveDir)%(FileName)%(Extension)</Link>
               <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
               <PublishState>Included</PublishState>
               <Visible>false</Visible>
@@ -260,6 +273,12 @@
               <PublishState>Included</PublishState>
               <Visible>false</Visible>
             </None>     
+            <None Include="@(CefSharpCommonManagedDll)">
+              <Link>$(CefSharpTargetDirAnyCpuArm64)%(RecursiveDir)%(FileName)%(Extension)</Link>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+              <PublishState>Included</PublishState>
+              <Visible>false</Visible>
+            </None>
           </ItemGroup>
         </When>
         <!-- x86 and Win32-->
@@ -335,6 +354,13 @@
               <Visible>false</Visible>
 			  <IncludeInVsix>true</IncludeInVsix>
             </Content>
+            <Content Include="@(CefRedistArm64)">
+              <Link>$(CefSharpTargetDirAnyCpuArm64)%(RecursiveDir)%(FileName)%(Extension)</Link>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+              <PublishState>Included</PublishState>
+              <Visible>false</Visible>
+			  <IncludeInVsix>true</IncludeInVsix>
+            </Content>
             <Content Include="@(CefSharpCommonBinaries32)">
               <Link>$(CefSharpTargetDirAnyCpu32)%(RecursiveDir)%(FileName)%(Extension)</Link>
               <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -344,6 +370,13 @@
             </Content>
             <Content Include="@(CefSharpCommonBinaries64)">
               <Link>$(CefSharpTargetDirAnyCpu64)%(RecursiveDir)%(FileName)%(Extension)</Link>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+              <PublishState>Included</PublishState>
+              <Visible>false</Visible>
+			  <IncludeInVsix>true</IncludeInVsix>
+            </Content>
+            <Content Include="@(CefSharpCommonBinariesArm64)">
+              <Link>$(CefSharpTargetDirAnyCpuArm64)%(RecursiveDir)%(FileName)%(Extension)</Link>
               <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
               <PublishState>Included</PublishState>
               <Visible>false</Visible>
@@ -367,6 +400,13 @@
               <Visible>false</Visible>
 			  <IncludeInVsix>true</IncludeInVsix>
             </Content>     
+            <Content Include="@(CefSharpCommonManagedDll)">
+              <Link>$(CefSharpTargetDirAnyCpuArm64)%(RecursiveDir)%(FileName)%(Extension)</Link>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+              <PublishState>Included</PublishState>
+              <Visible>false</Visible>
+			  <IncludeInVsix>true</IncludeInVsix>
+            </Content>
           </ItemGroup>
         </When>
         <!-- x86 and Win32-->


### PR DESCRIPTION
**Addition to PR:** #5267
**Fixes:** #4155
<!-- e.g Fixes: #2345 -->

**Summary:**
   - Adds arm64 AnyCPU build targets to the NuGet/CefSharp.Common.targets‎ using same layout as for x86 & x64 builds.

**Changes:**
- Adds `CefSharpTargetDirAnyCpuArm64`, resolving to `arm64\`.
- In the `CefSharpBuildAction=None` AnyCPU path, adds ARM64 copies for:
  - `@(CefRedistArm64)` — CEF redistribution/native resources
  - `@(CefSharpCommonBinariesArm64)` — `CefSharp.Core.Runtime.dll`, browser subprocess files, etc.
  - `@(CefSharpCommonManagedDll)` — `CefSharp.dll`, required by the architecture-specific browser subprocess folder
- Adds the same three ARM64 copy rules to the `CefSharpBuildAction=Content` AnyCPU path.
      
**How Has This Been Tested?**  
 1. Built the CefSharp NuGet packages locally from the `netarm64` branch including my changes
 2. Configured a .NET Framework 4.8.1 WPF test application to restore CefSharp.Wpf 150.0.110 from that local package feed.
 3. Built the test application as AnyCPU, project file included the following.
 `<CefSharpAnyCpuSupport>true</CefSharpAnyCpuSupport>
<CefSharpPlatformTargetOverride>AnyCPU</CefSharpPlatformTargetOverride>
<PreferNativeArm64>true</PreferNativeArm64`
4. Verified the AnyCPU build output contains all three runtime folders
5. Deployed the AnyCPU output to a native Windows ARM64 VM. The application startup log reported:
`Process architecture: Arm64
Expected runtime: ...\arm64\CefSharp.Core.Runtime.dll
Expected CEF runtime: ...\arm64\libcef.dll`

I also validated these changes the same way in our product’s cefsharp-browser application: it builds as AnyCPU with the ARM64 CefSharp runtime included and prefers native ARM64 execution on supported Windows devices.

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [x] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 support to AnyCPU build outputs.
  * ARM64 native files and managed assemblies are now copied into the appropriate architecture-specific folder during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->