### PR TITLE
Core - Update CefErrorCode and PermissionRequestType

### DIFF
--- a/CefSharp/Enums/CefErrorCode.cs
+++ b/CefSharp/Enums/CefErrorCode.cs
@@ -212,6 +212,21 @@ namespace CefSharp
         BlockedInIncognitoByAdministrator = -35,
 
         /// <summary>
+        /// The request was blocked because the local network permission is missing.
+        /// Note that this is different from BlockedByLocalNetworkAccessChecks
+        /// which is specifically for a CORS error code.
+        /// </summary>
+        LocalNetworkPermissionMissing = -36,
+
+        /// <summary>
+        /// The request was blocked because ECH is strictly required, but:
+        ///  - The client could not obtain a valid ECH configuration.
+        ///  - The server rejected the ECH, and the client failed to establish a new ECH
+        ///    connection after retrying with retry_configs.
+        /// </summary>
+        StrictEchRequired = -37,
+
+        /// <summary>
         /// A connection was closed (corresponding to a TCP FIN).
         /// </summary>
         ConnectionClosed = -100,
@@ -682,6 +697,12 @@ namespace CefSharp
 
         ProxyDelegateCanceledConnectResponse = -188,
 
+        /// <summary>
+        /// The control message was too large for the transport. (for example a UDP
+        /// message control data exceeds size threshold).
+        /// </summary>
+        ControlMsgTooBig = -189,
+
         // Certificate error codes
         //
         // The values of certificate error codes must be consecutive.
@@ -1126,10 +1147,9 @@ namespace CefSharp
         /// </summary>
         PacScriptTerminated = -367,
 
-        /// <summary>
-        /// Signals that the request requires the IPP proxy.
-        /// </summary>
-        ProxyRequired = -368,
+        // Obsolete. Support for CNAME record detection was never fully implemented and
+        // is no longer needed since the IP Protection feature didn't launch.
+        // NET_ERROR(PROXY_REQUIRED, -368)
 
         // Obsolete. Kept here to avoid reuse.
         // Request is throttled because of a Backoff header.
@@ -1319,6 +1339,11 @@ namespace CefSharp
         /// The disk cache is unable to open or create this entry.
         /// </summary>
         CacheOpenOrCreateFailure = -413,
+
+        /// <summary>
+        /// Zstd compression of a cache entry body failed.
+        /// </summary>
+        CacheCompressionFailure = -414,
 
         /// <summary>
         /// The server's response was insecure (e.g. there was a cert error).
@@ -1569,6 +1594,12 @@ namespace CefSharp
         /// - REFUSED
         /// </summary>
         DnsOtherFailure = -820,
+
+        /// <summary>
+        /// Declined to call DNS for a direct_only request of a hostname whose traffic
+        /// would be routed through a proxy.
+        /// </summary>
+        DnsDirectOnly = -821,
 
         // The following errors are for mapped from a subset of invalid
         // storage::BlobStatus.

--- a/CefSharp/Enums/PermissionRequestType.cs
+++ b/CefSharp/Enums/PermissionRequestType.cs
@@ -43,5 +43,6 @@ namespace CefSharp
         LocalNetworkAccess = 1 << 25,
         LocalNetwork = 1 << 26,
         LoopbackNetwork = 1 << 27,
+        Sensors = 1 << 28,
     }
 }


### PR DESCRIPTION
PermissionRequestType got a new flag in Chromium 151.0.7922.109

Updated `CefErrorCode` using https://raw.githubusercontent.com/chromium/chromium/151.0.7922.109/net/base/net_error_list.h
Updated `PermissionRequestType` using https://github.com/chromiumembedded/cef/blob/2384915b7b1f0fe5ad1107e48d80c34e86b698d7/include/internal/cef_types.h#L3888-L3932

**Changes:**

- ProxyRequired was removed (obsoleted upstream), which is a breaking change but consistent with the source

**How Has This Been Tested?**
Build works.

**Types of changes**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated documentation

**Checklist:**

- [ ] Tested the code(if applicable)
- [x] Commented my code
- [x] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [x] The formatting is consistent with the project (project supports .editorconfig)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reporting additional network, DNS, encryption, and cache-related error codes.
  * Added sensor access as a recognized permission request type.

* **Breaking Changes**
  * Removed the `ProxyRequired` error code from the public error code list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->